### PR TITLE
Update guide with the move to github.

### DIFF
--- a/html/guide.html
+++ b/html/guide.html
@@ -12,26 +12,22 @@
 
 <h2>ScoreBoard Wiki</h2>
 <p>Documentation for the scoreboard has moved to a wiki.	Please
-<a href="https://sourceforge.net/p/derbyscoreboard/wiki/">
+<a href="https://github.com/rollerderby/scoreboard/wiki">
 visit the wiki</a> for all docs.
 </p>
 
-<h2>ScoreBoard Roadmap</h2>
-<p>The development roadmap, including bug/feature changelogs for each release, are at
-<a href="https://sourceforge.net/p/derbyscoreboard/wiki/Roadmap/">
-the wiki Roadmap page</a>.
-</p>
-
 <h2>Contacts</h2>
+<p>For general usage questions there's the <a href="https://www.facebook.com/groups/derbyscoreboard/">Facebook group</a>.
+</p>
 <p>To contact the developers and/or get news about development, 
 <a href="http://lists.sourceforge.net/lists/listinfo/derbyscoreboard-devel">join the mailing list</a>.
 You also can read the 
 <a href="http://sourceforge.net/mailarchive/forum.php?forum_name=derbyscoreboard-devel">mailing list archive</a>.
 </p>
 <p>If you find any bugs, please report them on the mailing list and/or 
-<a href="https://sourceforge.net/p/derbyscoreboard/bugs/">open a bug</a>.
+<a href="https://github.com/rollerderby/scoreboard/issues">open a bug</a>.
 If you would like to see any new features added, please send an email to the mailing list and/or 
-<a href="https://sourceforge.net/p/derbyscoreboard/feature-requests/">open a feature request</a>.
+<a href="https://github.com/rollerderby/scoreboard/issues">open a feature request</a>.
 </p>
 
 <h2>Image Sizes</h2>


### PR DESCRIPTION
As far as I can tell there is no current roadmap, so remove it.