### PR TITLE
Write collected game data to a file only once per jam (at jam end).

### DIFF
--- a/src/com/carolinarollergirls/scoreboard/Game.java
+++ b/src/com/carolinarollergirls/scoreboard/Game.java
@@ -73,7 +73,9 @@ public class Game {
 				JamStats js = findJamStats(period, jam, true);
 				js.snapshot(jamEnd);
 
-				saveLock.notifyAll();
+				if (jamEnd) { // only write the data to file once per jam to combat lag from writing it multiple times over at the end of each jam
+					saveLock.notifyAll();
+				}
 			} catch (Exception e) {
 				ScoreBoardManager.printMessage("Error catching snapshot: " + e.getMessage());
 				e.printStackTrace();


### PR DESCRIPTION
Previous code wrote up to 7 times at the end of a jam, causing
significant lag on older machines.
Since the data is currently not recoverd on a crash anyways, writing
less often will not affect functionality.