### PR TITLE
Replaced old information with text from guide.html.

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -161,20 +161,9 @@ function showOverlays() {
       <p>Version: <a id="version"></a></p>
     </center>
 
-      <p style="margin: 0 15%;">
-          <b>Important notice:</b><br/>
-          The scoreboard no longer includes any team logos or sponsor (ad) images.
-          The team logo images are now packaged separately.
-          To get the latest team logo images, go to the
-          <a href="http://sourceforge.net/projects/derbyscoreboard/files/crg-scoreboard/media/">sourceforge download area for media zip files</a>
-          and download the latest crg-scoreboard-images-teamlogo zip file.	Then go to the
-          <a href="controls/media_management.html">Media Management page</a>
-          and on the <i>Image</i> tab click the <i>Upload</i> button on the right side of the
-          <i>Type: teamlogo</i> section, and upload the entire zip file of teamlogos.
-          Alternately, you can just upload whatever individual team logo images you have.
-          You can also add or remove team logo (or sponsor/ad) images by simply adding or
-          removing files from the html/images/teamlogo (or sponsor_banner) directory.
-        </p>
+<p><b>Scoreboard Wiki:</b></p>
+<p>Documentation for the getting the scoreboard installed and started quickly is available in the included README file. To check for the latest release of this software, please visit the <a href="https://github.com/rollerderby/scoreboard">project home on GitHub</a> and visit the <a href="https://github.com/rollerderby/scoreboard/wiki">project wiki</a> for all docs. The Derby Scoreboard <a href="https://www.facebook.com/groups/derbyscoreboard/">Facebook group</a> is very active and currently the best way to reach other users and developers.</p>
+
   </div>
 
   <div id="OverlayDialog">


### PR DESCRIPTION
There was old information directing the user to SourceForge, replaced with link to wiki, identical to guide.html now. Addresses #27 