### PR TITLE
fix month in game filename

### DIFF
--- a/html/controls/operator.js
+++ b/html/controls/operator.js
@@ -301,7 +301,7 @@ function createGameControlDialog() {
 		if (t1.val() != "" && t2.val() != "") {
 			var now = new Date();
 			var d = now.getFullYear() + '-' +
-				_timeConversions.twoDigit(now.getMonth()) + '-' +
+				_timeConversions.twoDigit(now.getMonth()+1) + '-' +
 				_timeConversions.twoDigit(now.getDate()) + ' ' +
 				_timeConversions.twoDigit(now.getHours()) + ':' +
 				_timeConversions.twoDigit(now.getMinutes());


### PR DESCRIPTION
months in js are set/get in c-style (eg 0-11), so previous filenames have an off-by-one error when saving.  Having the correct month in filenames will likely be important when resuming existing games.