### PR TITLE
Create Black and White teams by default

### DIFF
--- a/config/default/15-teams.xml
+++ b/config/default/15-teams.xml
@@ -68,5 +68,15 @@
       </Position>
     </Team>
   </ScoreBoard>
+  <Teams>
+    <Team Id="Black">
+      <Name><![CDATA[Black]]></Name>
+      <Logo />
+    </Team>
+    <Team Id="White">
+      <Name><![CDATA[White]]></Name>
+      <Logo />
+    </Team>
+  </Teams>
 </document>
 


### PR DESCRIPTION
If there's no autosave directory, start out with a
black and white team to make it easier to get
a game going from a fresh install.

Fixes #61 