### PR TITLE
Frontend: Penalty Tracking Screens improved

### DIFF
--- a/html/controls/pt/index.css
+++ b/html/controls/pt/index.css
@@ -1,11 +1,21 @@
-body { font-size: 10pt; }
-
+body {	
+	font-size: 11pt;
+	font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;"; 
+}
+table,tr,td{
+	border-collapse: collapse;
+	border-color:#777;
+	}
+/*increase readability by making penalty codes bold */
+tr:nth-child(odd) {
+    font-weight:bold;
+}
 .Team {
 	position: absolute;
 	width: 49%;
 	top: 0%;
 }
-.Team thead td { font-size: 1.1em; font-weight: bold; background-color: #000; color: #FFF; }
+.Team thead td { font-size: 1em; font-weight: bold; background-color: #222; color: #FFF; }
 .Team td { text-align: center; vertical-align: center; }
 .Team1 { left: 0.5%; }
 .Team2 { right: 0.5%; }
@@ -24,3 +34,19 @@ body { font-size: 10pt; }
 .PenaltyEditor .Codes>div div { text-align: center; }
 .PenaltyEditor .Codes>div .Code { font-size: 1.2em; background-color: #FAA; color: #000; }
 .PenaltyEditor .Codes>div .Description { font-size: 0.75em; }
+
+/* responsive vertical layout on phones and tablet portrait */
+@media only screen and (max-width: 960px) { 
+   .Team{
+	position: relative;
+	float:left;
+	width: 99%;
+	margin-bottom:1em;
+	}
+	.Team1, .Team2 { 
+	position: relative; 
+	margin:2px;
+	left:auto;
+	right:auto;
+	}
+}

--- a/html/controls/pt/ptcolor.css
+++ b/html/controls/pt/ptcolor.css
@@ -1,11 +1,21 @@
-body { font-size: 10pt; }
-
+body {	
+	font-size: 11pt;
+	font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;"; 
+}
+table,tr,td{
+	border-collapse: collapse;
+	border-color:#777;
+	}
+/*increase readability by making penalty codes bold */
+tr:nth-child(odd) {
+    font-weight:bold;
+}
 .Team {
 	position: absolute;
 	width: 49%;
 	top: 0%;
 }
-.Team thead td { font-size: 1.1em; font-weight: bold; background-color: #000; color: #FFF; }
+.Team thead td { font-size: 1em; font-weight: bold; background-color: #222; color: #FFF; }
 .Team td { text-align: center; vertical-align: center; }
 .Team1 { left: 0.5%; }
 .Team2 { right: 0.5%; }
@@ -24,3 +34,19 @@ body { font-size: 10pt; }
 .PenaltyEditor .Codes>div div { text-align: center; }
 .PenaltyEditor .Codes>div .Code { font-size: 1.2em; background-color: #FAA; color: #000; }
 .PenaltyEditor .Codes>div .Description { font-size: 0.75em; }
+
+/* responsive vertical layout on phones and tablet portrait */
+@media only screen and (max-width: 960px) { 
+   .Team{
+	position: relative;
+	float:left;
+	width: 99%;
+	margin-bottom:1em;
+	}
+	.Team1, .Team2 { 
+	position: relative; 
+	margin:2px;
+	left:auto;
+	right:auto;
+	}
+}

--- a/html/views/wb/tcdg2016wb.css
+++ b/html/views/wb/tcdg2016wb.css
@@ -272,7 +272,7 @@ a {
 }
 .Team thead td { font-size: 100%; position: relative; font-family: 'roboto'; font-weight: bold; background-color: #000; color: #FFF; }
 .Teamd { top: 0%; font-size: 100%; font-family: 'roboto'; font-weight: bold; color: #FFF; }
-.tdivr { font-size: 58%; position: relative; font-family: 'roboto'; font-weight: bold; color: #FFF; height: 7%; }
+.tdivr { font-size: 58%; position: relative; font-family: 'roboto'; font-weight: bold; color: #FFF; height: 6.5%; }
 .Team td { text-align: center; vertical-align: center; font-size: 52%; color: #FFF; }
 .Team1  { right: 0.5%; font-family: 'roboto'; font-weight: bold; top: 12%; left: 1%; width: 47%; text-align: center; overflow: hidden;color: white; }
 .Teamd1 { left: 0.2%; height: 100%; width: 48%; text-align: center; overflow: hidden;color: white; }

--- a/html/views/wb/whiteboard.css
+++ b/html/views/wb/whiteboard.css
@@ -18,14 +18,14 @@ table,tr,td{
 .Team1 { left: 0.5%; }
 .Team2 { right: 0.5%; }
 .Team .Number, .Team .Box, .Team .FO_EXP, .Team .Total { width: 8.33%; }
-.Team tr:nth-child(4n+0), .Team tr:nth-child(4n-1) { background-color: #CCC; }
+.Team tr:nth-child(4n-2), .Team tr:nth-child(4n-0) { background-color: #CCC; }
 
 .Team .Warn1 { background-color: #fffd38; }
-.Team .Warn1:nth-child(4n+0), .Team .Warn1:nth-child(4n-1) { background-color: #ccca2d; }
+.Team .Warn1:nth-child(4n-2), .Team .Warn1:nth-child(4n-0) { background-color: #ccca2d; }
 .Team .Warn2 { background-color: #ff8f2b; }
-.Team .Warn2:nth-child(4n+0), .Team .Warn2:nth-child(4n-1) { background-color: #cc7222; }
+.Team .Warn2:nth-child(4n-2), .Team .Warn2:nth-child(4n-0) { background-color: #cc7222; }
 .Team .Warn3 { background-color: #ff8080; }
-.Team .Warn3:nth-child(4n+0), .Team .Warn3:nth-child(4n-1) { background-color: #cc2d2d; }
+.Team .Warn3:nth-child(4n-2), .Team .Warn3:nth-child(4n-0) { background-color: #cc2d2d; }
 
 /* responsive vertical layout on phones and tablet portrait */
 @media only screen and (max-width: 960px) { 

--- a/html/views/wb/whiteboard.css
+++ b/html/views/wb/whiteboard.css
@@ -1,29 +1,43 @@
-body { font-size: 10pt; }
-/* Same css as the pt screen */
+body {	
+	font-size: 11pt;
+	font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;"; 
+}
+table,tr,td{
+	border-collapse: collapse;
+	border-color:#777;
+	}
+
 .Team {
 	position: absolute;
 	width: 49%;
 	top: 0%;
 }
-.Team thead td { font-size: 1.5em; font-weight: bold; background-color: #000; color: #FFF; }
-.Team td { text-align: center; vertical-align: center; font-size: 2em; }
+.Team thead td { font-size: 1em; font-weight: bold; background-color: #222; color: #FFF; }
+.Team td { text-align: center; vertical-align: center; }
 .Team1 { left: 0.5%; }
 .Team2 { right: 0.5%; }
 .Team .Number, .Team .Box, .Team .FO_EXP, .Team .Total { width: 8.33%; }
-.Team tr:nth-child(4n-2), .Team tr:nth-child(4n-0) { background-color: #CCC; }
+.Team tr:nth-child(4n+0), .Team tr:nth-child(4n-1) { background-color: #CCC; }
 
 .Team .Warn1 { background-color: #fffd38; }
-.Team .Warn1:nth-child(4n-2), .Team .Warn1:nth-child(4n-0) { background-color: #ccca2d; }
+.Team .Warn1:nth-child(4n+0), .Team .Warn1:nth-child(4n-1) { background-color: #ccca2d; }
 .Team .Warn2 { background-color: #ff8f2b; }
-.Team .Warn2:nth-child(4n-2), .Team .Warn2:nth-child(4n-0) { background-color: #cc7222; }
+.Team .Warn2:nth-child(4n+0), .Team .Warn2:nth-child(4n-1) { background-color: #cc7222; }
 .Team .Warn3 { background-color: #ff8080; }
-.Team .Warn3:nth-child(4n-2), .Team .Warn3:nth-child(4n-0) { background-color: #cc2d2d; }
+.Team .Warn3:nth-child(4n+0), .Team .Warn3:nth-child(4n-1) { background-color: #cc2d2d; }
 
-.PenaltyEditor .Codes>div { float: left; width: 150px; height: 80px; margin: 10px; border: 1px solid black; font-weight: bold; }
-.PenaltyEditor .Codes>div.Active { background-color: #F00; color: #FFF; }
-.PenaltyEditor .Codes>div div { text-align: center; }
-.PenaltyEditor .Codes>div .Code { font-size: 1.2em; background-color: #FAA; color: #000; }
-.PenaltyEditor .Codes>div .Description { font-size: 0.75em; }
-
-.Team1custColor { background-color: #000000; }
-.Team2custColor { background-color: #000000; }
+/* responsive vertical layout on phones and tablet portrait */
+@media only screen and (max-width: 960px) { 
+   .Team{
+	position: relative;
+	float:left;
+	width: 99%;
+	margin-bottom:1em;
+	}
+	.Team1, .Team2 { 
+	position: relative; 
+	margin:2px;
+	left:auto;
+	right:auto;
+	}
+}

--- a/html/views/wb/whiteboard.css
+++ b/html/views/wb/whiteboard.css
@@ -1,6 +1,7 @@
 body {	
 	font-size: 11pt;
-	font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;"; 
+	font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;
+	font-weight:bold;
 }
 table,tr,td{
 	border-collapse: collapse;


### PR DESCRIPTION
#1 Improved readability and responsive design for PT Tracking screen and WB
#2 tcdg Penalty board changed to be able to display 15 Skaters

only CSS changes

Screenshot Penalty Tracker/Whiteboard
![capture](https://user-images.githubusercontent.com/26040981/40928699-2e9862e2-681a-11e8-88e6-848673f76917.PNG)

Screenshot tcdg2016wb.html
![capture2](https://user-images.githubusercontent.com/26040981/40928760-5ceb0140-681a-11e8-8fc0-9c577c97b2bc.PNG)

