### PR TITLE
Restrict key controls to the Team/Time tab

### DIFF
--- a/html/javascript/keycontrols.js
+++ b/html/javascript/keycontrols.js
@@ -107,7 +107,9 @@ _crgKeyControls = {
 	addCondition: function(condition) {
 		_crgKeyControls._conditions.push(condition);
 	},
-	_conditions: [ function() { return !$("div.MultipleKeyAssignDialog").length; } ],
+	_conditions: [ function() { return !$("div.MultipleKeyAssignDialog").length; },
+		function() { return !$("#TeamTimeTab.ui-tabs-hide").length;} //disable keys when TeamTimeTab is hidden.
+	],
 
 	_start: function() {
 		if (!_crgKeyControls._keyControlStarted) {


### PR DESCRIPTION
The commit that made hidden key controls work, unintentionally also enabled them when a different tab is selected (e.g. entering teams). This fixes the unwanted behaviour and restricts the key controls to the Team/Time tab again.