### PR TITLE
Add "OR" Button to Mobile Jam Control, Add Timeout Editor Page to Mobile Controls

### DIFF
--- a/html/controls/mobile.html
+++ b/html/controls/mobile.html
@@ -33,9 +33,6 @@
 			<li><a href="#JamControlPage">Jam Control</a></li>
 			<li><a href="#PeriodTimePage">Period Time</a></li>
 			<li><a href="#TeamScorePage">Team Score</a></li>
-<!-- hide link for next release, then work on using on-server clocks
-			<li><a href="#PenaltyPage">Penalty Timing</a></li>
--->
 		</ul>
 	</div>
 </div>
@@ -130,7 +127,7 @@
 				<span class="Team1 AlternateName"></span>
 				
 			</button></div>
-			<div class="ui-block-b"><button class="Official">Official</button></div>
+			<div class="ui-block-b"><button class="Official">TO Official</button></div>
 			<div class="ui-block-c"><button class="Team2">
 			TO 
 				<span class="Team2 Name">Team 2</span>

--- a/html/controls/mobile.html
+++ b/html/controls/mobile.html
@@ -171,14 +171,58 @@
 
 	<div data-role="content">
 		<p class="Time"><a class="Time"></a></p>
-		<p><hr/></p>
+		<hr/>
 		<p>
 			<button class="TimeDown" data-inline="true" value="-1000">-1 sec</button>
 			<button class="TimeUp" data-inline="true" value="1000">+1 sec</button>
 		</p>
-		<p><hr/></p>
+		<hr/>
 		<p><input type="text" class="SetTime"/></p>
 		<p><button class="SetTime" data-inline="true">Set Time</button></p>
+	</div>
+</div>
+
+<div data-role="page" id="TeamTimeoutPage">
+	<div data-role="header">
+		<a href="#Main" data-direction="reverse" data-icon="arrow-l">Main</a>
+		<h1>Timeouts</h1>
+	</div>
+
+	<div data-role="content">
+
+			<h3>
+				<a class="Team1 Name">Team 1</a>
+				<a class="Team1 AlternateName"></a>
+			</h3>
+			<div class="ui-grid-a">
+				<div class="ui-block-a">
+					<h4>Timeouts</h4>
+				</div>
+				<div class="ui-block-b">
+					<div class="ui-block-b Team1 Timeout"></div>
+				</div>
+
+				<div class="ui-block-a">
+					<h4>Official Review</h4>
+				</div>
+				<div class="ui-block-b Team1 OfficialReview"></div>
+			</div>
+
+		<h3>
+				<a class="Team2 Name">Team 2</a>
+				<a class="Team2 AlternateName"></a>
+			</h3>
+			<div class="ui-grid-a">
+				<div class="ui-block-a">
+					<h4>Timeouts</h4>
+				</div>
+				<div class="ui-block-b Team2 Timeout"></div>
+
+				<div class="ui-block-a">
+					<h4>Official Review</h4>
+				</div>
+				<div class="ui-block-b Team2 OfficialReview"></div>
+			</div>
 	</div>
 </div>
 

--- a/html/controls/mobile.html
+++ b/html/controls/mobile.html
@@ -125,20 +125,41 @@
 		<button class="Timeout" data-role="button">Timeout</button>
 		<div class="ui-grid-b Timeout">
 			<div class="ui-block-a"><button class="Team1">
+				TO 
 				<span class="Team1 Name">Team 1</span>
 				<span class="Team1 AlternateName"></span>
+				
 			</button></div>
 			<div class="ui-block-b"><button class="Official">Official</button></div>
 			<div class="ui-block-c"><button class="Team2">
+			TO 
 				<span class="Team2 Name">Team 2</span>
 				<span class="Team2 AlternateName"></span>
+				
 			</button></div>
 		</div>
-		<p class="Clocks">
+		<div class="ui-grid-b OfficialReview">
+			<div class="ui-block-a"><button class="Team1">
+			OR
+				<span class="Team1 Name">Team 1</span>
+				<span class="Team1 AlternateName"></span>
+				 
+			</button></div>
+			<div class="ui-block-b">
+			</div>
+			<div class="ui-block-c"><button class="Team2">
+			 OR
+				<span class="Team2 Name">Team 2</span>
+				<span class="Team1 AlternateName"></span>
+				
+			</button></div>
+		</div>
+			<p class="Clocks">
 			<span class="ClockBubble Period">Period</span>
 			<span class="ClockBubble Jam">Jam</span>
 			<span class="ClockBubble Timeout">Timeout</span>
 		</p>
+		
 </div>
 </div>
 

--- a/html/controls/mobile.js
+++ b/html/controls/mobile.js
@@ -15,7 +15,6 @@ $sb(function() {
 	setupJamControlPage();
 	setupPeriodTimePage();
 	setupTeamScorePage();
-	//setupPenaltyTimePage();
 	setupTeamTimeoutPage();
 
 	$.each( [ "1", "2" ], function(i, t) {

--- a/html/controls/mobile.js
+++ b/html/controls/mobile.js
@@ -33,12 +33,18 @@ function setupJamControlPage() {
 	$sb("ScoreBoard.StopJam").$sbControl("#JamControlPage button.StopJam").val(true);
 	$sb("ScoreBoard.Timeout").$sbControl("#JamControlPage button.Timeout").val(true);
 	$sb("ScoreBoard.Team(1).Timeout").$sbControl("#JamControlPage div.Timeout button.Team1").val(true);
+	$sb("ScoreBoard.Team(1).OfficialReview").$sbControl("#JamControlPage div.OfficialReview button.Team1").val(true);
 	$sb("ScoreBoard.Team(1).Name").$sbElement("#JamControlPage div.Timeout button.Team1>span.Name");
 	$sb("ScoreBoard.Team(1).AlternateName(mobile).Name").$sbElement("#JamControlPage div.Timeout button.Team1>span.AlternateName");
+	$sb("ScoreBoard.Team(1).Name").$sbElement("#JamControlPage div.OfficialReview button.Team1>span.Name");
+	$sb("ScoreBoard.Team(1).AlternateName(mobile).Name").$sbElement("#JamControlPage div.OfficialReview button.Team1>span.AlternateName");
 	$sb("ScoreBoard.Timeout").$sbControl("#JamControlPage div.Timeout button.Official").val(true);
 	$sb("ScoreBoard.Team(2).Timeout").$sbControl("#JamControlPage div.Timeout button.Team2").val(true);
+	$sb("ScoreBoard.Team(2).OfficialReview").$sbControl("#JamControlPage div.OfficialReview button.Team2").val(true);
 	$sb("ScoreBoard.Team(2).Name").$sbElement("#JamControlPage div.Timeout button.Team2>span.Name");
 	$sb("ScoreBoard.Team(2).AlternateName(mobile).Name").$sbElement("#JamControlPage div.Timeout button.Team2>span.AlternateName");
+	$sb("ScoreBoard.Team(2).Name").$sbElement("#JamControlPage div.OfficialReview button.Team2>span.Name");
+	$sb("ScoreBoard.Team(2).AlternateName(mobile).Name").$sbElement("#JamControlPage div.OfficialReview button.Team2>span.AlternateName");
 
 	$.each( [ "Period", "Jam", "Timeout" ], function(i, clock) {
 		$sb("ScoreBoard.Clock("+clock+").Running").$sbBindAndRun("sbchange", function(event, value) {

--- a/html/controls/mobile.js
+++ b/html/controls/mobile.js
@@ -15,7 +15,8 @@ $sb(function() {
 	setupJamControlPage();
 	setupPeriodTimePage();
 	setupTeamScorePage();
-	setupPenaltyTimePage();
+	//setupPenaltyTimePage();
+	setupTeamTimeoutPage();
 
 	$.each( [ "1", "2" ], function(i, t) {
 		$sb("ScoreBoard.Team("+t+")").$sbBindAddRemoveEach("AlternateName", function(event, node) {
@@ -77,6 +78,18 @@ function setupJamControlPage() {
 				showJamControlClock(clock);
 		});
 	});
+}
+
+function setupTeamTimeoutPage() {
+	$sb("ScoreBoard.Team(1).Name").$sbElement("#TeamTimeoutPage a.Team1.Name");
+	$sb("ScoreBoard.Team(1).AlternateName(mobile).Name").$sbElement("#TeamTimeoutPage a.Team1.AlternateName");
+	$sb("ScoreBoard.Team(1).Timeouts").$sbControl("<a/><input type='text' />", { sbcontrol: { editOnClick: true }}).appendTo("#TeamTimeoutPage div.Team1.Timeout");
+	$sb("ScoreBoard.Team(1).OfficialReviews").$sbControl("<a/><input type='text' />", { sbcontrol: { editOnClick: true }}).appendTo("#TeamTimeoutPage div.Team1.OfficialReview");
+	
+	$sb("ScoreBoard.Team(2).Name").$sbElement("#TeamTimeoutPage a.Team2.Name");
+	$sb("ScoreBoard.Team(2).AlternateName(mobile).Name").$sbElement("#TeamTimeoutPage a.Team2.AlternateName");
+	$sb("ScoreBoard.Team(2).Timeouts").$sbControl("<a/><input type='text' />", { sbcontrol: { editOnClick: true }}).appendTo("#TeamTimeoutPage div.Team2.Timeout");
+	$sb("ScoreBoard.Team(2).OfficialReviews").$sbControl("<a/><input type='text' />", { sbcontrol: { editOnClick: true }}).appendTo("#TeamTimeoutPage div.Team2.OfficialReview");
 }
 
 function setupPeriodTimePage() {


### PR DESCRIPTION
Added OR Buttons to the Mobile Jam Control.  Also added a new view to the Mobile Controls that allows the mobile user to edit the number of timeouts and official reviews each team has, without having to open the operator screen.  

This view is very rudimentary, mostly because jquery-ui grid layouts remain a profound mystery to me.  Someone more layout-oriented could probably make this look a bit better.  But for now i think it will work.

Closes #41