### PR TITLE
auto-size PT grid to screen

### DIFF
--- a/html/controls/pt/index.css
+++ b/html/controls/pt/index.css
@@ -36,11 +36,6 @@ tr:nth-child(odd) {
 .PenaltyEditor .Codes>div .Description { font-size: 0.75em; }
 
 /* responsive vertical layout on phones and tablet portrait */
-@media only screen and (min-width: 960px) {
-	.Team {
-		height: 100vh;
-	}
-}
 @media only screen and (max-width: 960px) { 
    .Team{
 	position: relative;

--- a/html/controls/pt/index.css
+++ b/html/controls/pt/index.css
@@ -36,6 +36,11 @@ tr:nth-child(odd) {
 .PenaltyEditor .Codes>div .Description { font-size: 0.75em; }
 
 /* responsive vertical layout on phones and tablet portrait */
+@media only screen and (min-width: 960px) {
+	.Team {
+		height: 100vh;
+	}
+}
 @media only screen and (max-width: 960px) { 
    .Team{
 	position: relative;

--- a/html/controls/pt/ptcolor.css
+++ b/html/controls/pt/ptcolor.css
@@ -37,7 +37,7 @@ tr:nth-child(odd) {
 
 /* responsive vertical layout on phones and tablet portrait */
 @media only screen and (min-width: 960px) {
-	.Team {
+	.Team.auto-fit {
 		height: 100vh;
 	}
 }

--- a/html/controls/pt/ptcolor.css
+++ b/html/controls/pt/ptcolor.css
@@ -36,6 +36,11 @@ tr:nth-child(odd) {
 .PenaltyEditor .Codes>div .Description { font-size: 0.75em; }
 
 /* responsive vertical layout on phones and tablet portrait */
+@media only screen and (min-width: 960px) {
+	.Team {
+		height: 100vh;
+	}
+}
 @media only screen and (max-width: 960px) { 
    .Team{
 	position: relative;

--- a/html/controls/pt/ptcolor.js
+++ b/html/controls/pt/ptcolor.js
@@ -28,7 +28,13 @@ function initialize() {
 	WS.Register( [ 'ScoreBoard.PenaltyCode' ], function(k, v) { penaltyCode(k, v); } );
 	WS.Register( [ 'ScoreBoard.Clock(Period).MinimumNumber', 'ScoreBoard.Clock(Period).MaximumNumber' ], function(k, v) { setupSelect('Period'); } );
 	WS.Register( [ 'ScoreBoard.Clock(Jam).MinimumNumber', 'ScoreBoard.Clock(Jam).MaximumNumber' ], function(k, v) { setupSelect('Jam'); } );
+	
+	
 
+	if(_windowFunctions.checkParam("autoFit", "true")) {
+		$('.Team').addClass('auto-fit');
+	}
+	
 	penaltyEditor = $('div.PenaltyEditor').dialog({
 		modal: true,
 		closeOnEscape: false,


### PR DESCRIPTION
This is very easy thanks to "vh" units in css.  Only apply them in the non-mobile view so that more penalties can be seen at once in that view (based on understanding of how that view is supposed to work).  I can change this if desired though.

Closes #67 