### PR TITLE
Add a 30s heartbeat to WS client code

### DIFF
--- a/html/json/WS.js
+++ b/html/json/WS.js
@@ -6,6 +6,7 @@ var WS = {
 	callbacks: new Array(),
 	Connected: false,
 	state: { },
+	heartbeat: null,
 	debug: false,
 
 	Connect: function(callback) {
@@ -42,6 +43,8 @@ var WS = {
 				}
 				if (WS.connectCallback != null)
 					WS.connectCallback();
+				// Hearbeat every 30s so the connection is kept alive.
+				WS.heartbeat = setInterval(WS.Command, 30000, "Ping");
 			};
 			WS.socket.onmessage = function(e) {
 				json = JSON.parse(e.data);
@@ -57,12 +60,14 @@ var WS = {
 				$(".ConnectionError").removeClass("Connected");
 				if (WS.connectTimeout == null)
 					WS.connectTimeout = setTimeout(WS._connect, 1000);
+				clearInterval(WS.heartbeat);
 			};
 			WS.socket.onerror = function(e) {
 				console.log("WS", "Websocket: Error", e);
 				$(".ConnectionError").removeClass("Connected");
 				if (WS.connectTimeout == null)
 					WS.connectTimeout = setTimeout(WS._connect, 1000);
+				clearInterval(WS.heartbeat);
 			}
 		} else {
 			// better run the callback on post connect if we didn't need to connect

--- a/src/com/carolinarollergirls/scoreboard/jetty/WS.java
+++ b/src/com/carolinarollergirls/scoreboard/jetty/WS.java
@@ -185,6 +185,8 @@ public class WS extends WebSocketServlet {
 					if (key.startsWith("Custom.")) {
 						WS.updateState(key, value);
 					}
+				} else if (action.equals("Ping")) {
+					send(new JSONObject().put("Pong", ""));
 				} else if (action.equals("Short")) {
 					sendShort = true;
 				} else if (action.equals("Long")) {


### PR DESCRIPTION
Part of the lag fix was no longer sending
updates which clients hadn't requested. Due
to this it is now possible that a client would have
no communication for some time, such as if there was
a long official timeout or during the intermission.

The WS code on the server side will kill such connections
after 5m of no activity. The client code should autoreconnect,
however under some circumstances which remain unclear this
does not happen. To mitigate this, add a heartbeat.
This also adds protection against falling out of NAT connection
tables etc. if someone is using it on a network where that matters.