### PR TITLE
Add metrics for scoreboard state: clocks and scores

### DIFF
--- a/src/com/carolinarollergirls/scoreboard/ScoreBoardManager.java
+++ b/src/com/carolinarollergirls/scoreboard/ScoreBoardManager.java
@@ -29,6 +29,9 @@ public class ScoreBoardManager {
 
 		//FIXME - not the best way to load autosave doc.
 		scoreBoardModel.getXmlScoreBoard().load();
+
+		// Register Prometheus metrics about scoreboard state.
+		new ScoreBoardMetricsCollector(scoreBoardModel).register();
 	}
 
 	public static void stop() {

--- a/src/com/carolinarollergirls/scoreboard/ScoreBoardMetricsCollector.java
+++ b/src/com/carolinarollergirls/scoreboard/ScoreBoardMetricsCollector.java
@@ -1,0 +1,56 @@
+package com.carolinarollergirls.scoreboard;
+/**
+ * Copyright (C) 2008-2012 Mr Temper <MrTemper@CarolinaRollergirls.com>
+ *
+ * This file is part of the Carolina Rollergirls (CRG) ScoreBoard.
+ * The CRG ScoreBoard is licensed under either the GNU General Public
+ * License version 3 (or later), or the Apache License 2.0, at your option.
+ * See the file COPYING for details.
+ */
+
+import java.util.*;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.GaugeMetricFamily;
+import com.carolinarollergirls.scoreboard.*;
+import com.carolinarollergirls.scoreboard.model.*;
+
+
+public class ScoreBoardMetricsCollector extends Collector {
+  private ScoreBoardModel sbm;
+  ScoreBoardMetricsCollector(ScoreBoardModel sbm) {
+    this.sbm = sbm;
+  }
+  public List<MetricFamilySamples> collect() {
+    List<MetricFamilySamples> mfs = new ArrayList<MetricFamilySamples>();
+
+    GaugeMetricFamily clockTime = new GaugeMetricFamily("crg_scoreboard_clock_time_seconds", 
+        "Time on scoreboard clock.", Arrays.asList("clock"));
+    mfs.add(clockTime);
+    GaugeMetricFamily clockInvertedTime = new GaugeMetricFamily("crg_scoreboard_clock_inverted_time_seconds", 
+        "Time on scoreboard clock, inverted.", Arrays.asList("clock"));
+    mfs.add(clockInvertedTime);
+    GaugeMetricFamily clockRunning = new GaugeMetricFamily("crg_scoreboard_clock_running", 
+        "Is scoreboard clock running.", Arrays.asList("clock"));
+    mfs.add(clockRunning);
+    GaugeMetricFamily clockNumber = new GaugeMetricFamily("crg_scoreboard_clock_number", 
+        "Number on scoreboard clock.", Arrays.asList("clock"));
+    mfs.add(clockNumber);
+    for (Clock c : sbm.getClocks()) {
+        clockTime.addMetric(Arrays.asList(c.getName()), (float)c.getTime() / 1000);
+        clockInvertedTime.addMetric(Arrays.asList(c.getName()), (float)c.getInvertedTime() / 1000);
+        clockRunning.addMetric(Arrays.asList(c.getName()), c.isRunning() ? 1 : 0);
+        clockNumber.addMetric(Arrays.asList(c.getName()), c.getNumber());
+    }
+
+    GaugeMetricFamily score = new GaugeMetricFamily("crg_scoreboard_team_score", 
+        "Score on scoreboard.", Arrays.asList("team", "name"));
+    mfs.add(score);
+    for (Team t : sbm.getTeams()) {
+        score.addMetric(Arrays.asList(t.getId(), t.getName()), t.getScore());
+    }
+
+    return mfs;
+  }
+}
+


### PR DESCRIPTION
These allow tying performance metrics back to jam
times/numbers as people are more likely to know those
than NTP-synced unixtime that a monitoring system
like Prometheus usually deals with.