### PR TITLE
Fix issues when Jam Clock is counting Up

### DIFF
--- a/src/com/carolinarollergirls/scoreboard/defaults/DefaultClockModel.java
+++ b/src/com/carolinarollergirls/scoreboard/defaults/DefaultClockModel.java
@@ -48,7 +48,7 @@ public class DefaultClockModel extends DefaultScoreBoardEventProvider implements
 	}
 
 	public String getProviderName() { return "Clock"; }
-	public Class getProviderClass() { return Clock.class; }
+	public Class<Clock> getProviderClass() { return Clock.class; }
 	public String getProviderId() { return getId(); }
 
 	public ScoreBoard getScoreBoard() { return scoreBoardModel.getScoreBoard(); }
@@ -371,7 +371,6 @@ public class DefaultClockModel extends DefaultScoreBoardEventProvider implements
 				if (c.isMasterClock()) {
 					masterClock = c;
 				}
-				long delayStartTime = 0;
 				if (c.isSyncTime() && !quickAdd) {
 					// This syncs all the clocks to change second at the same time
 					// with respect to the master clock

--- a/src/com/carolinarollergirls/scoreboard/defaults/DefaultScoreBoardModel.java
+++ b/src/com/carolinarollergirls/scoreboard/defaults/DefaultScoreBoardModel.java
@@ -116,6 +116,7 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 	protected void addInPeriodListeners() {
 		addScoreBoardListener(new ConditionalScoreBoardListener(Clock.class, Clock.ID_PERIOD, "Running", Boolean.TRUE, periodStartListener));
 		addScoreBoardListener(new ConditionalScoreBoardListener(Clock.class, Clock.ID_PERIOD, "Running", Boolean.FALSE, periodEndListener));
+		addScoreBoardListener(new ConditionalScoreBoardListener(Clock.class, Clock.ID_JAM, "Running", false, jamEndListener));
 		addScoreBoardListener(new ConditionalScoreBoardListener(Clock.class, Clock.ID_JAM, "Running", Boolean.FALSE, periodEndListener));
 		addScoreBoardListener(new ConditionalScoreBoardListener(Clock.class, Clock.ID_JAM, "Running", Boolean.TRUE, jamStartListener));
 		addScoreBoardListener(new ConditionalScoreBoardListener(Clock.class, Clock.ID_TIMEOUT, "Running", Boolean.FALSE, periodEndListener));
@@ -192,7 +193,7 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 					ic.setTime(ic.isCountDirectionDown() ? ic.getMinimumTime() : ic.getMaximumTime());
 				}
 				// If Period Clock is at end, start a new period
-				if (pc.getTime() == (pc.isCountDirectionDown() ? pc.getMinimumTime() : pc.getMaximumTime())) {
+				if (pc.isTimeAtEnd()) {
 					pc.changeNumber(1);
 					pc.resetTime();
 					jc.setNumber(jc.getMinimumNumber());
@@ -206,7 +207,7 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 				pc.start();
 
 				// If Jam Clock is not at start (2:00), increment number and reset time
-				if (jc.getTime() != (jc.isCountDirectionDown() ? jc.getMaximumTime() : jc.getMinimumTime()))
+				if (!jc.isTimeAtStart())
 					jc.changeNumber(1);
 				jc.resetTime();
 				jc.start();
@@ -588,10 +589,8 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 				Clock p = getClock(Clock.ID_PERIOD);
 				Clock j = getClock(Clock.ID_JAM);
 				Clock t = getClock(Clock.ID_TIMEOUT);
-				if (event.getProvider() == j && !j.isRunning() && j.getTime() == j.getMinimumTime()) {
-					_stopJam();
-				}
-				if (isInPeriod() && !p.isRunning() && (p.getTime() == p.getMinimumTime()) && !j.isRunning() && !t.isRunning())
+
+				if (isInPeriod() && !p.isRunning() && p.isTimeAtEnd() && !j.isRunning() && !t.isRunning())
 					setInPeriod(false);
 			}
 		};
@@ -602,6 +601,16 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 					lc.stop();
 			}
 		};
+		
+		protected ScoreBoardListener jamEndListener = new ScoreBoardListener() {
+			public void scoreBoardChange(ScoreBoardEvent event) {
+				Clock j = getClock(Clock.ID_JAM);
+				if (event.getProvider() == j && !j.isRunning() && j.isTimeAtEnd()) {
+					_stopJam();
+				}
+			}
+		};
+		
 	protected ScoreBoardListener timeoutStartListener = new ScoreBoardListener() {
 			public void scoreBoardChange(ScoreBoardEvent event) {
 				ClockModel ic = getClockModel(Clock.ID_INTERMISSION);

--- a/src/com/carolinarollergirls/scoreboard/defaults/DefaultScoreBoardModel.java
+++ b/src/com/carolinarollergirls/scoreboard/defaults/DefaultScoreBoardModel.java
@@ -10,8 +10,6 @@ package com.carolinarollergirls.scoreboard.defaults;
 
 import java.util.*;
 
-import java.io.*;
-
 import com.carolinarollergirls.scoreboard.*;
 import com.carolinarollergirls.scoreboard.xml.*;
 import com.carolinarollergirls.scoreboard.event.*;
@@ -55,13 +53,13 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 	}
 
 	public String getProviderName() { return "ScoreBoard"; }
-	public Class getProviderClass() { return ScoreBoard.class; }
+	public Class<ScoreBoard> getProviderClass() { return ScoreBoard.class; }
 	public String getProviderId() { return ""; }
 
 	public XmlScoreBoard getXmlScoreBoard() { return xmlScoreBoard; }
 
 	protected void loadPolicies() {
-		Enumeration keys = ScoreBoardManager.getProperties().propertyNames();
+		Enumeration<?> keys = ScoreBoardManager.getProperties().propertyNames();
 
 		while (keys.hasMoreElements()) {
 			String key = keys.nextElement().toString();

--- a/src/com/carolinarollergirls/scoreboard/defaults/DefaultScoreBoardModel.java
+++ b/src/com/carolinarollergirls/scoreboard/defaults/DefaultScoreBoardModel.java
@@ -116,7 +116,7 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 	protected void addInPeriodListeners() {
 		addScoreBoardListener(new ConditionalScoreBoardListener(Clock.class, Clock.ID_PERIOD, "Running", Boolean.TRUE, periodStartListener));
 		addScoreBoardListener(new ConditionalScoreBoardListener(Clock.class, Clock.ID_PERIOD, "Running", Boolean.FALSE, periodEndListener));
-		addScoreBoardListener(new ConditionalScoreBoardListener(Clock.class, Clock.ID_JAM, "Running", false, jamEndListener));
+		addScoreBoardListener(new ConditionalScoreBoardListener(Clock.class, Clock.ID_JAM, "Running", Boolean.FALSE, jamEndListener));
 		addScoreBoardListener(new ConditionalScoreBoardListener(Clock.class, Clock.ID_JAM, "Running", Boolean.FALSE, periodEndListener));
 		addScoreBoardListener(new ConditionalScoreBoardListener(Clock.class, Clock.ID_JAM, "Running", Boolean.TRUE, jamStartListener));
 		addScoreBoardListener(new ConditionalScoreBoardListener(Clock.class, Clock.ID_TIMEOUT, "Running", Boolean.FALSE, periodEndListener));

--- a/tests/com/carolinarollergirls/scoreboard/defaults/DefaultClockModelTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/defaults/DefaultClockModelTests.java
@@ -1,0 +1,456 @@
+package com.carolinarollergirls.scoreboard.defaults;
+
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import com.carolinarollergirls.scoreboard.Clock;
+import com.carolinarollergirls.scoreboard.Policy;
+import com.carolinarollergirls.scoreboard.Ruleset;
+import com.carolinarollergirls.scoreboard.model.ScoreBoardModel;
+import com.carolinarollergirls.scoreboard.policy.ClockSyncPolicy;
+
+public class DefaultClockModelTests {
+
+	private ScoreBoardModel sbModelMock;
+	private Ruleset ruleMock;
+	private Policy policyMock;
+	
+	
+	private DefaultClockModel clock;
+	private static String ID = "TEST";
+	
+	private boolean syncStatus = false;
+	
+	@Before
+	public void setUp() throws Exception {
+		syncStatus = false;
+		sbModelMock = Mockito.mock(DefaultScoreBoardModel.class);
+		
+		ruleMock = Mockito.mock(Ruleset.class);
+		policyMock = Mockito.mock(Policy.class);
+		
+		Mockito
+			.when(sbModelMock.getScoreBoard())
+			.thenReturn(sbModelMock);
+		
+		Mockito
+			.when(sbModelMock._getRuleset())
+			.thenReturn(ruleMock);
+		
+		Mockito
+			.when(sbModelMock.getPolicy(ClockSyncPolicy.ID))
+			.thenReturn(policyMock);
+		
+		// makes it easier to test both sync and non-sync paths through clock model
+		Mockito
+			.when(policyMock.isEnabled())
+			.thenAnswer(new Answer<Boolean>() {
+				public Boolean answer(InvocationOnMock invocation) throws Throwable {
+					return syncStatus;
+				}
+			});
+		
+		clock = new DefaultClockModel(sbModelMock, ID);
+	}
+	
+	@Test
+	public void test_defaults() {
+		assertEquals(0, clock.getMinimumNumber());
+		assertEquals(0, clock.getMaximumNumber());
+		assertEquals(0, clock.getNumber());
+		
+		assertEquals(ID, clock.getId());
+		assertEquals(null, clock.getName());
+		assertFalse(clock.isMasterClock());
+		assertFalse(clock.isCountDirectionDown());
+		assertFalse(clock.isRunning());
+
+		assertEquals(clock, clock.getClock());
+		assertEquals(sbModelMock, clock.getScoreBoard());
+		assertEquals(sbModelMock, clock.getScoreBoardModel());
+		
+		assertEquals("Clock", clock.getProviderName());
+		assertEquals(ID, clock.getProviderId());
+		assertEquals(Clock.class, clock.getProviderClass());
+	}
+	
+	@Test
+	public void syncTimeTest() {
+		
+	}
+
+	
+	@Test
+	public void test_name() {
+		clock.setName("Test Clock");
+		
+		assertEquals("Test Clock", clock.getName());
+		//TODO: Test Event system
+	}
+	
+	@Test
+	public void test_min_number_setter() {
+		clock.setMinimumNumber(1);
+		
+		// validate constraint: max > min
+		assertEquals(1, clock.getMinimumNumber());
+		assertEquals(1, clock.getMaximumNumber());
+		assertEquals(1, clock.getNumber());
+
+	}
+	
+	@Test
+	public void test_min_number_setter2() {
+		clock.setMinimumNumber(10);
+		clock.setMinimumNumber(5);
+		
+		// validate constraint: number is automatically set to max
+		assertEquals(5, clock.getMinimumNumber());
+		assertEquals(10, clock.getMaximumNumber());
+		assertEquals(10, clock.getNumber());
+
+	}
+	
+	@Test
+	public void test_max_number_setter() {
+		clock.setMaximumNumber(5);
+		
+		
+		assertEquals(0, clock.getMinimumNumber());
+		assertEquals(5, clock.getMaximumNumber());
+		assertEquals(0, clock.getNumber());
+	}
+	
+	@Test
+	public void test_max_number_setter2() {
+		clock.setMinimumNumber(10);
+		clock.setMaximumNumber(5);
+		
+		// validate constraint: cannot set a max that is < min
+		assertEquals(10, clock.getMinimumNumber());
+		assertEquals(10, clock.getMaximumNumber());
+		assertEquals(10, clock.getNumber());
+	}
+	
+	@Test
+	public void test_max_number_change() {
+		clock.setMaximumNumber(5);
+		clock.changeMaximumNumber(2);
+		
+		assertEquals(0, clock.getMinimumNumber());
+		assertEquals(7, clock.getMaximumNumber());
+		assertEquals(0, clock.getNumber());
+	}
+	
+	@Test
+	public void test_min_number_change() {
+		clock.setMinimumNumber(5);
+		clock.changeMinimumNumber(2);
+		
+		assertEquals(7, clock.getMinimumNumber());
+		assertEquals(7, clock.getMaximumNumber());
+		assertEquals(7, clock.getNumber());
+	}
+	
+	@Test
+	public void test_number_changing() {
+		clock.setMaximumNumber(12);
+		clock.setMinimumNumber(3);
+		
+		clock.setNumber(5);
+		assertEquals(5, clock.getNumber());
+		
+		clock.changeNumber(3);
+		assertEquals(8, clock.getNumber());
+		
+		// validate constraint: cannot set number above maximum
+		clock.setNumber(23);
+		assertEquals(12, clock.getNumber());
+		
+		// validate constraint: cannot set number below minimum
+		clock.setNumber(-2);
+		assertEquals(3, clock.getNumber());
+		
+		// ...and check that constraint is not a >0 type constraint
+		clock.setNumber(1);
+		assertEquals(3, clock.getNumber());
+		
+		clock.changeNumber(6);
+		assertEquals(9, clock.getNumber());
+		
+		// validate constraint: cannot changeNumber above maximum
+		clock.changeNumber(6);
+		assertEquals(12, clock.getNumber());
+		
+		
+		clock.setNumber(5);
+		clock.changeNumber(-1);
+		assertEquals(4, clock.getNumber());
+		
+		// validate constraint: cannot changeNumber below minimum
+		clock.changeNumber(-4);
+		assertEquals(3, clock.getNumber());
+	}
+	
+	@Test
+	public void test_min_time_setter() {
+		clock.setMinimumTime(1000);
+		
+		// validate constraint: max > min
+		assertEquals(1000, clock.getMinimumTime());
+		assertEquals(1000, clock.getMaximumTime());
+		assertEquals(1000, clock.getTime());
+		
+		clock.setMinimumTime(500);
+		
+
+	}
+	
+	@Test
+	public void test_min_time_setter2() {
+		clock.setMinimumTime(2000);
+		clock.setMinimumTime(1000);
+		
+		// validate constraint: reducing min time doesn't reset max or current time
+		assertEquals(1000, clock.getMinimumTime());
+		assertEquals(2000, clock.getMaximumTime());
+		assertEquals(2000, clock.getTime());
+
+	}
+	
+	@Test
+	public void test_min_time_setter3() {
+		clock.setMaximumTime(2000);
+		clock.setMinimumTime(1000);
+		
+		// validate constraint: time cannot be less than min time
+		assertEquals(1000, clock.getMinimumTime());
+		assertEquals(2000, clock.getMaximumTime());
+		assertEquals(1000, clock.getTime());
+
+	}
+	
+	@Test
+	public void test_max_time_setter() {
+		clock.setMaximumTime(5000);
+		
+		// validate constraint: increase max time doesn't reset min or current time
+		assertEquals(0, clock.getMinimumTime());
+		assertEquals(5000, clock.getMaximumTime());
+		assertEquals(0, clock.getTime());
+	}
+	
+	@Test
+	public void test_max_time_setter2() {
+		clock.setMinimumTime(2000);
+		clock.setMaximumTime(1000);
+		
+		// validate constraint: cannot set a max that is < min
+		assertEquals(2000, clock.getMinimumTime());
+		assertEquals(2000, clock.getMaximumTime());
+		assertEquals(2000, clock.getTime());
+	} 
+	
+	@Test
+	public void test_max_time_change() {
+		clock.setMaximumTime(1000);
+		clock.changeMaximumTime(2000);
+		
+		assertEquals(0, clock.getMinimumTime());
+		assertEquals(3000, clock.getMaximumTime());
+		assertEquals(0, clock.getTime());
+	}
+	
+	@Test
+	public void test_min_time_change() {
+		clock.setMinimumTime(5000);
+		clock.changeMinimumTime(2000);
+		
+		assertEquals(7000, clock.getMinimumTime());
+		assertEquals(7000, clock.getMaximumTime());
+		assertEquals(7000, clock.getTime());
+	}
+	
+	@Test
+	public void test_time_changing() {
+		clock.setMaximumTime(5000);
+		clock.setMinimumTime(1000);
+		
+		clock.setTime(2000);
+		assertEquals(2000, clock.getTime());
+		assertEquals(3000, clock.getInvertedTime());
+		
+		clock.setTime(6000);
+		assertEquals(5000, clock.getTime());
+		assertEquals(0, clock.getInvertedTime());
+		
+		clock.setTime(400);
+		assertEquals(1000, clock.getTime());
+		assertEquals(4000, clock.getInvertedTime());
+		
+		clock.setTime(600);
+		assertEquals(600, clock.getTime());
+		assertEquals(4400, clock.getInvertedTime());
+		//TODO: validate that event DOES NOT fire in this case
+		
+		clock.setTime(2000);
+		clock.changeTime(1200);
+		assertEquals(3200, clock.getTime());
+		assertEquals(1800, clock.getInvertedTime());
+		//TODO: validate that events fire in this case
+		
+		clock.changeTime(-5000);
+		assertEquals(1000, clock.getTime());
+		assertEquals(4000, clock.getInvertedTime());
+		
+		clock.changeTime(4100);
+		assertEquals(5100, clock.getTime());
+		assertEquals(-100, clock.getInvertedTime());
+	}
+	
+	
+	@Test
+	public void test_time_at_start_count_up()
+	{
+		clock.setMaximumTime(5000);
+		
+		assertTrue(clock.isTimeAtStart());
+		assertFalse(clock.isTimeAtEnd());
+		
+		clock.setTime(2000);
+		
+		assertFalse(clock.isTimeAtStart());
+		assertFalse(clock.isTimeAtEnd());
+		
+		clock.setTime(5000);
+		
+		assertFalse(clock.isTimeAtStart());
+		assertTrue(clock.isTimeAtEnd());
+	}
+	
+	@Test
+	public void test_time_at_start_count_down()
+	{
+		clock.setCountDirectionDown(true);
+		clock.setMaximumTime(5000);
+		clock.setTime(5000);
+		
+		assertTrue(clock.isTimeAtStart());
+		assertFalse(clock.isTimeAtEnd());
+		
+		clock.setTime(2000);
+		
+		assertFalse(clock.isTimeAtStart());
+		assertFalse(clock.isTimeAtEnd());
+		
+		clock.setTime(0);
+		
+		assertFalse(clock.isTimeAtStart());
+		assertTrue(clock.isTimeAtEnd());
+	}
+	
+	@Test
+	public void test_reset_time()
+	{
+		clock.setMaximumTime(5000);
+		clock.setMinimumTime(1000);
+		
+		clock.setTime(3000);
+		
+		clock.resetTime();
+		
+		assertEquals(1000, clock.getTime());
+		
+		clock.setTime(3000);
+		clock.setCountDirectionDown(true);
+		
+		clock.resetTime();
+		
+		assertEquals(5000, clock.getTime());
+	}
+	
+	@Test
+	public void test_apply_rules_name()
+	{
+		clock.applyRule("Clock.TEST.Name", "New Name");
+		assertEquals("New Name", clock.getName());
+		
+		clock.applyRule("Clock.OTHER.Name", "Shouldn't Change");
+		assertEquals("New Name", clock.getName());
+	}
+	
+	@Test
+	public void test_apply_rules_direction()
+	{
+		clock.applyRule("Clock." + ID + ".Direction", true);
+		assertTrue(clock.isCountDirectionDown());
+		
+		clock.applyRule("Clock.OTHER.Direction", false);
+		assertTrue(clock.isCountDirectionDown());
+	}
+	
+	@Test
+	public void test_apply_rules_min_number()
+	{
+		clock.applyRule("Clock." + ID + ".MinimumNumber", 10);
+		assertEquals(10, clock.getMinimumNumber());
+		assertEquals(10, clock.getMaximumNumber());
+		assertEquals(10, clock.getNumber());
+
+		
+		clock.applyRule("Clock.OTHER.MaximumNumber", 20);
+		assertEquals(10, clock.getMinimumNumber());
+		assertEquals(10, clock.getMaximumNumber());
+		assertEquals(10, clock.getNumber());
+	}
+	
+	@Test
+	public void test_apply_rules_max_number()
+	{
+		clock.applyRule("Clock." + ID + ".MaximumNumber", 10);
+		assertEquals(0, clock.getMinimumNumber());
+		assertEquals(10, clock.getMaximumNumber());
+		assertEquals(0, clock.getNumber());
+
+		
+		clock.applyRule("Clock.OTHER.MaximumNumber", 20);
+		assertEquals(0, clock.getMinimumNumber());
+		assertEquals(10, clock.getMaximumNumber());
+		assertEquals(0, clock.getNumber());
+	}
+	
+	@Test
+	public void test_apply_rules_min_time()
+	{
+		clock.applyRule("Clock." + ID + ".MinimumTime", (long)10000);
+		assertEquals(10000, clock.getMinimumTime());
+		assertEquals(10000, clock.getMaximumTime());
+		assertEquals(10000, clock.getTime());
+
+		
+		clock.applyRule("Clock.OTHER.MaximumTime", (long)20000);
+		assertEquals(10000, clock.getMinimumTime());
+		assertEquals(10000, clock.getMaximumTime());
+		assertEquals(10000, clock.getTime());
+	}
+	
+	@Test
+	public void test_apply_rules_max_time()
+	{
+		clock.applyRule("Clock." + ID + ".MaximumTime", (long)10000);
+		assertEquals(0, clock.getMinimumTime());
+		assertEquals(10000, clock.getMaximumTime());
+		assertEquals(0, clock.getTime());
+
+		
+		clock.applyRule("Clock.OTHER.MaximumTime", (long)20000);
+		assertEquals(0, clock.getMinimumTime());
+		assertEquals(10000, clock.getMaximumTime());
+		assertEquals(0, clock.getTime());
+	}
+}


### PR DESCRIPTION
There are a few bugs in ScoreBoardModel related to checking if a clock is at the minimum time, which causes problems when the clock is instead set to count up.  I've updated these instances (and the other instances that are correct, to simplify & avoid errors in the future) to use the isTimeAtStart/isTimeAtEnd functions instead.

Additional changes:

1. Add a bunch of unit tests around the logic in the DefaultClockModel.  The actual nitty-gritty of start/stop and ticking on the Runnable still needs to be tested, but that will probably need some refactoring to be unit testable correctly.

2. Clean up the warnings in DefaultScoreBoardModel and DefaultClockModel.  These are cosmetic changes, mostly.

3. split the "period End" logic and "jam End" logic into two separate event handlers.  I think this split makes things a bit clearer.

Next steps:
1. A bunch of logic exists in Policies around clocks.  It's all correct, but I didn't touch it because those Policies will change into Rules (hopefully) in the near future.

2. More Unit Tests, both around DefaultClockModel and the actual "business rules" in the ScoreBoardModel related to clocks.

3. Expose a getElapsedTime()/getRemainingTime() method on the Clock object.  This will make it easier to simplify a lot of other instances that we are looking at times, which seems very error prone.

4. Clean up the apis related to Rulesets slightly to reduce the reliance on statics and improve testability.

Closes #89