### PR TITLE
Make it possible to upload images if directory is empty

### DIFF
--- a/src/com/carolinarollergirls/scoreboard/xml/MediaXmlDocumentManager.java
+++ b/src/com/carolinarollergirls/scoreboard/xml/MediaXmlDocumentManager.java
@@ -96,8 +96,13 @@ public class MediaXmlDocumentManager extends PartialOpenXmlDocumentManager imple
 
 	protected void initializeType(File typeDir) {
 		Iterator<File> files = Arrays.asList(typeDir.listFiles((FileFilter)mediaFileFilter)).iterator();
-		while (files.hasNext())
+		while (files.hasNext()) {
 			addMediaElement(typeDir.getName(), files.next());
+    }
+		// Ensure we have an entry, even if dir is empty.
+		synchronized (updateLock) {
+			update(createTypeElement(typeDir.getName()));
+		}
 	}
 
 	protected void monitorType(File typeDir) {

--- a/src/com/carolinarollergirls/scoreboard/xml/MediaXmlDocumentManager.java
+++ b/src/com/carolinarollergirls/scoreboard/xml/MediaXmlDocumentManager.java
@@ -98,7 +98,7 @@ public class MediaXmlDocumentManager extends PartialOpenXmlDocumentManager imple
 		Iterator<File> files = Arrays.asList(typeDir.listFiles((FileFilter)mediaFileFilter)).iterator();
 		while (files.hasNext()) {
 			addMediaElement(typeDir.getName(), files.next());
-    }
+		}
 		// Ensure we have an entry, even if dir is empty.
 		synchronized (updateLock) {
 			update(createTypeElement(typeDir.getName()));


### PR DESCRIPTION
The default release has no sponsor/team images, so you have
to place them on the filesystem by hand. With this change
you can do this entirely from the UI now.

Another small quality of life improvement.