### PR TITLE
Enable warnings from javac.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The scoreboard should be unzipped into a folder on the local machine. The user r
 
 ### Java
 
-Java is required for providing a Java Runtime Environment (JRE) version 1.5.0 or newer. Installing the latest version of Oracle's Java is recommended.
+Java is required for providing a Java Runtime Environment (JRE) version 1.7.0 or newer. Installing the latest version of Oracle's Java is recommended.
 
 * Windows users can install the standard Java for Windows package that is available when clicking on Free Java Download from [Oracle’s Java site](https://java.com/).
 

--- a/build.xml
+++ b/build.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 
 <project name="Carolina Rollergirls Scoreboard" default="compile">
-	<property name="ant.build.javac.source" value="1.5"/>
-	<property name="ant.build.javac.target" value="1.5"/>
+	<property name="ant.build.javac.source" value="1.7"/>
+	<property name="ant.build.javac.target" value="1.7"/>
 
 	<property name="src.dir" value="src"/>
 	<property name="dest.dir" value="bin"/>
@@ -17,7 +17,7 @@
 
 	<property name="compile.deprecation" value="true"/>
 	<property name="compile.debug" value="true"/>
-	<property name="compile.nowarn" value="true"/>
+	<property name="compile.nowarn" value="false"/>
 	<property name="compile.verbose" value="false"/>
 
 	<property name="jar.dir" value="lib"/>
@@ -101,6 +101,7 @@
 
 			<compilerarg value="-Xlint:all"/>
 			<compilerarg value="-Xlint:-serial"/>
+			<compilerarg value="-Xlint:-options"/>
 			<classpath>
 				<fileset dir="${jar.dir}" includes="deps/*.jar" />
 			</classpath>

--- a/json/JSONObject.java
+++ b/json/JSONObject.java
@@ -298,7 +298,7 @@ public class JSONObject {
      */
     public JSONObject(Object object, String names[]) {
         this();
-        Class c = object.getClass();
+        Class<?> c = object.getClass();
         for (int i = 0; i < names.length; i += 1) {
             String name = names[i];
             try {
@@ -631,7 +631,7 @@ public class JSONObject {
         if (object == null) {
             return null;
         }
-        Class klass = object.getClass();
+        Class<?> klass = object.getClass();
         Field[] fields = klass.getFields();
         int length = fields.length;
         if (length == 0) {
@@ -981,7 +981,7 @@ public class JSONObject {
     }
 
     private void populateMap(Object bean) {
-        Class klass = bean.getClass();
+        Class<?> klass = bean.getClass();
 
 // If klass is a System class then set includeSuperClass to false.
 

--- a/json/Property.java
+++ b/json/Property.java
@@ -43,7 +43,7 @@ public class Property {
     public static JSONObject toJSONObject(java.util.Properties properties) throws JSONException {
         JSONObject jo = new JSONObject();
         if (properties != null && !properties.isEmpty()) {
-            Enumeration enumProperties = properties.propertyNames();
+            Enumeration<?> enumProperties = properties.propertyNames();
             while(enumProperties.hasMoreElements()) {
                 String name = (String)enumProperties.nextElement();
                 jo.put(name, properties.getProperty(name));

--- a/src/com/carolinarollergirls/scoreboard/defaults/DefaultPolicyModel.java
+++ b/src/com/carolinarollergirls/scoreboard/defaults/DefaultPolicyModel.java
@@ -105,7 +105,7 @@ public class DefaultPolicyModel extends DefaultScoreBoardEventProvider implement
 			defaultValue = v;
 
 			try {
-				constructor = Class.forName("java.lang."+type).getConstructor(new Class[]{ String.class });
+				constructor = Class.forName("java.lang."+type).getConstructor(new Class<?>[]{ String.class });
 			} catch ( Exception e ) {
 				constructor = null;
 			}


### PR DESCRIPTION
Bump to Java 1.6 to remove warning about 1.5 being deprecated. It's
been 12 years, we're probably safe.
Supress a warning about bootstrap class path not set in conjunction with
-source 1.6.



This keeps a standard build clean of warnings.