### PR TITLE
Fix DDTV overlay to get team data from the right place. Cleanup.

### DIFF
--- a/html/views/overlays/ddtv/admin.html
+++ b/html/views/overlays/ddtv/admin.html
@@ -7,55 +7,6 @@
 	</head>
 
 	<body>
-<!--
-	<div class="controls">
-
-	<p id="Panel">
-			<h2>Panels</h2>
-			<select class="SelectUpdator" id="PanelOverlay" data-subforms=".ExtraForm" data-target="#OverlayType" data-setting="Custom.Overlay.Panel" data-field="data-next">
-				<option data-key="X" value="">--- No Panel --- [X]</option>
-				<option data-key="0" value="PPJBox">Points per Jam  [0]</option>
-				<option data-key="1" value="RosterTeam1">Roster (T1)  [1]</option>
-				<option data-key="2" value="RosterTeam2">Roster (T2)  [2]</option>
-				<option data-key="3" value="PenaltyTeam1">Penalty (T1) [3]</option>
-				<option data-key="4" value="PenaltyTeam2">Penalty (T2) [4]</option>
-				<option data-key="9" value="LowerThird" data-form=".ExtraFormLower">Lower Third [9]</option>
-				<option data-key="N" value="Upcoming">Upcoming [n]</option>
-			</select>
-
-
-			<button data-key=" " data-setting="Custom.Overlay.Panel" id="OverlayType" class="ToggleSwitch Reverse NoAuto" data-source="#PanelOverlay"> </button>
-			<input type="hidden" data-setting="Custom.Overlay.LowerThird.Style" id="LowerStyle" data-source="#LowerThirdStyle"> </input>
-
-			<div class="ExtraForm ExtraFormLower" style="display: none;">
-				<h2>Lower Third</h2>
-				<div class="in">
-					<label>Line 1/Line 2/Style</label>
-					<input data-setting="Custom.Overlay.LowerThird.Line1" type="text"/><br/>
-					<input data-setting="Custom.Overlay.LowerThird.Line2" type="text"/><br/>
-					<select class="SelectUpdator" id="LowerThirdStyle" data-setting="Custom.Overlay.LowerThird.Style" data-target="#LowerStyle">
-						<option value="ColourDefault">--- Default --- </option>
-						<option value="ColourTeam1">Team 1</option>
-						<option value="ColourTeam2">Team 2</option>
-					</select>
-
-	
-					<label>Auto Skater Generator</label>
-					<select id="Skaters">
-					</select>
-
-					<select id="Keepers" style="width: 80%; float: left;">
-						<option data-line1="" data-line2="" data-style="ColourDefault">--- Clear ---</option>
-					</select>
-					<button id="KeeperAdd" style="width: 15%; ">+</button>
-
-				</div>
-			</div>
-
-		</p>
-
-	</div>
--->
 
 	<div class="container containerPreview">
 		<h1>OVERLAY CONTROLS</h1>

--- a/html/views/overlays/ddtv/index.css
+++ b/html/views/overlays/ddtv/index.css
@@ -283,16 +283,6 @@ body .TopBar > div.Team2 { float: right; }
 */
 
 
-.PPJBox h4				{ text-transform: uppercase; text-align: center; font-size: 1.4em; }
-
-.PPJContainer	{ background: #ccc; padding: 10px; }
-.PPJBox .Team1  { border-bottom: 1px solid #777; }
-.PPJBox .Team2  { border-top: 1px solid #777; }
-
-.PPJBox .Team   { height: 23vh; }
-.PPJBox .Period	{ height: 23vh;  position: relative; display: block; float: left; }
-.PPJBox .Period2 { border-left: 2px solid #777; }
-
 .JammerStar { text-align: center;  color: #ddd; position: absolute; font-size: 1.6em; font-weight: normal; }
 .Points	    { width: 100%; text-align: center;  color: #333; position: absolute; font-size: 1.6em; font-weight: normal; height: 2em; }
  
@@ -315,7 +305,6 @@ body .TopBar > div.Team2 { float: right; }
 
 
 .GraphBlock 	{ display: block; float: left; width: 10px; background: #888; margin: 0 2px; font-size: 60%; text-align: center; }
-.PPJBox .Period2 .GraphBlock { background: #999; }
 
 .Team1 .GraphBlock { margin-top: 1px; }
 .Team2 .GraphBlock { margin-bottom: 1px; }

--- a/html/views/overlays/ddtv/index.html
+++ b/html/views/overlays/ddtv/index.html
@@ -111,27 +111,6 @@
 			</div>	
 
       <div class="PanelWrapperCenter">
-<!--
-				<div class="ClockBox Wrapper OverlayPanel PanelHideBottom MediumPanel AnimatedPanel">
-						<div class="Wrapper Clock SlideDown ShowInIntermission ShowInLineUp ShowInTimeout">
-							<div class="Box BigName ShowInIntermission Clock" sbDisplay="Setting(ScoreBoard.Intermission.PreGame), Setting(Intermission.Intermission), Setting(Intermission.Unofficial), Setting(Intermission.Official), OfficialScore, Clock(Intermission).Number, Clock(Intermission).MaximumNumber" sbModify="intermissionDisplay"></div>
-							<div class="Box BoxLarge TextCenter Time Clock ShowInIntermission" sbDisplay="Clock(Intermission).Time" sbModify="toTime"></div>
-						</div>
-				</div>
-
-				<div class="PPJBox Wrapper PanelHideLeft OverlayPanel LargePanel AnimatedPanel">
-					<h1 class="NoLogo">Points Per Jam</h1>
-					<h4 class="htop ColourTeam1" sbDisplay="AlternateName(overlay),Name" sbContext="Team(1)"></h4>	
-					<div class="PPJContainer Wrapper">
-						<div class="Wrapper Team Team1">
-							<div class="Period Period1"></div><div class="Period Period2"></div>
-						</div>
-						<div class="Wrapper Team Team2">
-							<div class="Period Period1"></div><div class="Period Period2"></div>
-						</div> </div>
-					<h4 class="hbottom ColourTeam2" sbDisplay="AlternateName(overlay),Name" sbContext="Team(2)"></h4>	
-				</div>
--->
         <!-- TEAM ROSTERS -->
         <div class="RosterTeam1 TeamList PanelHideLeft Wrapper OverlayPanel LargePanel AnimatedPanel AnimationDelay" sbContext="Team(1)" >
           <div class="Skew TeamHeading ColourTeam1"><h1 class="LongName DeSkew" sbDisplay="AlternateName(overlay),Name"></h1></div>

--- a/html/views/overlays/ddtv/index.js
+++ b/html/views/overlays/ddtv/index.js
@@ -68,14 +68,8 @@ function initialize() {
 			'ScoreBoard.Team(1).RetainedOfficialReview',
 			'ScoreBoard.Team(2).RetainedOfficialReview' ], function(k,v) { smallDescriptionUpdate(k,v); } );
 
-	WS.Register( 'Game.Period', function(k,v) { jamData(k,v); } );
-
 	WS.Register( 'ScoreBoard.Team(1)', function(k,v) { teamData(1, k,v); } );
 	WS.Register( 'ScoreBoard.Team(2)', function(k,v) { teamData(2, k,v); } );
-
-	WS.Register( 'ScoreBoard.Clock(Period).Number', function(k,v) {
-		if(v == 2) { $('.PPJBox .Team .Period2').show(); } else { $('.PPJBox .Team .Period2').hide(); }
-	});
 
 	WS.Register([ 'Custom.Overlay.Score', 'Custom.Overlay.Top' ], function(k,v) {  
 		$('div[data-setting="'+k+'"]').each(function() {
@@ -107,7 +101,7 @@ function initialize() {
 		console.log('changed panel', k, v);
 		$('.OverlayPanel').removeClass('Show'); 
 		// sort divs in the panel before we show, just in case it's changed
-		if(v == 'PenaltyTeam1' || v == 'PenaltyTeam2' || v == 'PT1') {
+		if(v == 'PenaltyTeam1' || v == 'PenaltyTeam2') {
 			c = $('.PenaltyTeam [data-flag="BC"]');
 			c.empty().remove();
 		}
@@ -132,7 +126,6 @@ function initialize() {
 		if(e.which == 50) { WS.Set('Custom.Overlay.Panel', WS.state['Custom.Overlay.Panel'] == 'RosterTeam2' ? '' : 'RosterTeam2'); }
 		if(e.which == 51) { WS.Set('Custom.Overlay.Panel', WS.state['Custom.Overlay.Panel'] == 'PenaltyTeam1' ? '' : 'PenaltyTeam1'); }
 		if(e.which == 52) { WS.Set('Custom.Overlay.Panel', WS.state['Custom.Overlay.Panel'] == 'PenaltyTeam2' ? '' : 'PenaltyTeam2'); }
-		if(e.which == 87) { WS.Set('Custom.Overlay.Panel', WS.state['Custom.Overlay.Panel'] == 'PPJBox' ? '' : 'PPJBox'); }
 		if(e.which == 84) { WS.Set('Custom.Overlay.Top',   WS.state['Custom.Overlay.Top'] == 'Off' ? 'On': 'Off'); }
 		if(e.which == 32) { WS.Set('Custom.Overlay.Panel', ''); }
 	});
@@ -146,17 +139,17 @@ function teamData(team, k,v) {
 	var key;
 	var setting; 
 
-	var skaterRegEx = /^Game\.Team\((.+)\)\.Skater\((.+)\)\.(.+)$/;
+	var skaterRegEx = /^ScoreBoard\.Team\((.+)\)\.Skater\((.+)\)\.(.+)$/;
 	var match = k.match(skaterRegEx);
 	if(match) { 
 		skaterId = match[2]; key = match[3]; penalty = null; 
 	}
 
-	var penaltyRegEx = /^Game\.Team\((.+)\)\.Skater\((.+)\)\.Penalty\((.+)\).(.+)$/;
+	var penaltyRegEx = /^ScoreBoard\.Team\((.+)\)\.Skater\((.+)\)\.Penalty\((.+)\).(.+)$/;
 	var match = k.match(penaltyRegEx);
 	if(match) { skaterId = match[2]; key = match[4]; penalty = match[3]; }
 
-	var teamInfoRegEx = /^Game\.Team\((.+)\)\.(.+)$/;
+	var teamInfoRegEx = /^ScoreBoard\.Team\((.+)\)\.(.+)$/;
 	var match = k.match(teamInfoRegEx);
 	if(match) { 
 		var subkey = match[2];
@@ -172,7 +165,7 @@ function teamData(team, k,v) {
 		}
 	}
 
-	var colourRegEx = /^Game\.Team\((.+)\)\.Color\((.+)\)$/;
+	var colourRegEx = /^ScoreBoard\.Team\((.+)\)\.Color\((.+)\)$/;
 	var match = k.match(colourRegEx);
 	if(match) { 
 		var setting = match[2];
@@ -297,69 +290,6 @@ function createPenalty(mb, pnum, v) {
 	penalty.attr('data-sort', pnum);
 	$(mb).append(penalty);
 	$(mb).sortDivs();
-}
-
-var jamScoreRegEx = /^Game.Period\((.+)\)\.Jam\((.+)\)\.Team\((.+)\)\.(.+)$/;
-
-function jamData(k,v) {
-        match = k.match(jamScoreRegEx);
-        if (match == null) return;
-
-        var period = match[1];
-        var jam = match[2];
-        var team = match[3];
-	var key = match[4];
-
-	if (key != 'JamScore' && key != 'LeadJammer') return;
-
-	pa = '.PPJBox .Team'+ team + ' .Period'+period;
-	me = pa + ' .Jam'+jam;
-	$pId = $(pa); $mId = $(me)
-
-	if(v == null) {
-		$(me).remove();
-		$mId.sortDivs();
-		return;
-	}
-
-	if($(me).length == 0) {
-		pointsPerJamColumnWidths();
-		xv = $('<div data-sort="' + jam + '" class="ColumnWidth GraphBlock Jam' + jam + '"></div>');
-		$('<div class="JammerStar ColumnWidth"></div>').appendTo(xv);
-		$('<div class="Points ColumnWidth"></div>').appendTo(xv);
-		$pId.append(xv);
-		$pId.sortDivs();
-	}
-
-	if(key == 'LeadJammer') {
-		$(me).attr('lead', v);
-	}
-
-	if(key == 'JamScore') {
-		setHeight = v*4 + 'px';
-		$(me).css('height', setHeight);
-
-		if(team == 1) {
-			hid = $('.PPJBox .Team1 .Period').innerHeight();
-			marg = parseInt(hid)-parseInt(setHeight);
-			$(me).css('marginTop', marg);
-		}
-		if(v != 0) { $('.Points', me).text(v); }
-	}
-	pointsPerJamColumnWidths();
-
-}
-
-function pointsPerJamColumnWidths() {
-	ne1 = $('.PPJBox .Team1 .GraphBlock').length;
-	ne2 = $('.PPJBox .Team2 .GraphBlock').length;
-	if(ne2 > ne1)  ne1=ne2;
-	nel = ne1 + 3;
-	wid = parseInt( $('.PPJBox').innerWidth() );
-	newwidth = parseInt(wid / nel) - 3;
-	$('.ColumnWidth').innerWidth(newwidth);
-	$('.PPJBox .Team1 .GraphBlock').css('backgroundColor', WS.state['ScoreBoard.Team(1).Color(overlay_bg)']);
-	$('.PPJBox .Team2 .GraphBlock').css('backgroundColor', WS.state['ScoreBoard.Team(2).Color(overlay_bg)']);
 }
 
 function clockType(k,v) {

--- a/html/views/overlays/wb/tcdg2016wb.js
+++ b/html/views/overlays/wb/tcdg2016wb.js
@@ -54,7 +54,7 @@ function skaterUpdate(t, k, v) { //arguments: team number, skater id, jam number
 	if (match == null || match.length == 0)
 		return;
 	var id = match[1]; // id = skater id
-	var prefix = 'ScoreBoard.Team(' + t + ').Skater(' + id + ')';  //Example: prefix = Game.Team('1').Skater('id')
+	var prefix = 'ScoreBoard.Team(' + t + ').Skater(' + id + ')';  //Example: prefix = ScoreBoard.Team('1').Skater('id')
 	if (k == prefix + '.Number') { //Example if skater id == ScoreBoard.Team('team').Skater('id').Number
 		var rowd = $('.Teamd' + t + ' .Skater.Penalty[id=' + id + ']');
 		if (v == null) { // if jam number is null

--- a/html/views/overlays/wb/tcdg2016wb_underlay.js
+++ b/html/views/overlays/wb/tcdg2016wb_underlay.js
@@ -54,7 +54,7 @@ function skaterUpdate(t, k, v) { //arguments: team number, skater id, jam number
 	if (match == null || match.length == 0)
 		return;
 	var id = match[1]; // id = skater id
-	var prefix = 'ScoreBoard.Team(' + t + ').Skater(' + id + ')';  //Example: prefix = Game.Team('1').Skater('id')
+	var prefix = 'ScoreBoard.Team(' + t + ').Skater(' + id + ')';  //Example: prefix = ScoreBoard.Team('1').Skater('id')
 	if (k == prefix + '.Number') { //Example if skater id == ScoreBoard.Team('team').Skater('id').Number
 		var rowd = $('.Teamd' + t + ' .Skater.Penalty[id=' + id + ']');
 		if (v == null) { // if jam number is null


### PR DESCRIPTION
Some Game->Scoreboard were missed in
https://github.com/rollerderby/scoreboard/commit/0de1a43e6026ae4bde750e52d057ebd3e8fe6d9d

Also remove dead code around "PPJ", as that's one less place Game. is
mentioned.


This brings us down to one overlay that `Game.` WS updates are used in. Once those are gone `WS` can be made non-static, and we can start writing unittests around it.