### PR TITLE
Fix broken test on DefaultSettingsModel

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<project name="Carolina Rollergirls Scoreboard" default="compile">
+<project name="Carolina Rollergirls Scoreboard" default="test">
 	<property name="ant.build.javac.source" value="1.7"/>
 	<property name="ant.build.javac.target" value="1.7"/>
 

--- a/tests/com/carolinarollergirls/scoreboard/DefaultSettingsModelTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/DefaultSettingsModelTests.java
@@ -1,5 +1,6 @@
 package com.carolinarollergirls.scoreboard;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 
@@ -56,8 +57,8 @@ public class DefaultSettingsModelTests {
 		
 		settingsModel.reset();
 		
-		assertNull(settingsModel.get("Example.Team1"));
-		assertNull(settingsModel.get("Example"));
+		assertEquals("",settingsModel.get("Example.Team1"));
+		assertEquals(null,settingsModel.get("Example"));
 	}
 
 }

--- a/tests/com/carolinarollergirls/scoreboard/defaults/DefaultPositionModelTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/defaults/DefaultPositionModelTests.java
@@ -1,4 +1,4 @@
-package com.carolinarollergirls.scoreboard;
+package com.carolinarollergirls.scoreboard.defaults;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -9,9 +9,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import com.carolinarollergirls.scoreboard.defaults.DefaultScoreBoardModel;
-import com.carolinarollergirls.scoreboard.defaults.DefaultSkaterModel;
-import com.carolinarollergirls.scoreboard.defaults.DefaultTeamModel;
+import com.carolinarollergirls.scoreboard.Clock;
+import com.carolinarollergirls.scoreboard.Ruleset;
+import com.carolinarollergirls.scoreboard.Position;
+import com.carolinarollergirls.scoreboard.SkaterNotFoundException;
 import com.carolinarollergirls.scoreboard.model.PositionModel;
 import com.carolinarollergirls.scoreboard.model.ScoreBoardModel;
 import com.carolinarollergirls.scoreboard.model.SkaterModel;

--- a/tests/com/carolinarollergirls/scoreboard/defaults/DefaultSettingsModelTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/defaults/DefaultSettingsModelTests.java
@@ -1,4 +1,4 @@
-package com.carolinarollergirls.scoreboard;
+package com.carolinarollergirls.scoreboard.defaults;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -8,9 +8,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import com.carolinarollergirls.scoreboard.defaults.DefaultScoreBoardEventProvider;
-import com.carolinarollergirls.scoreboard.defaults.DefaultScoreBoardModel;
-import com.carolinarollergirls.scoreboard.defaults.DefaultSettingsModel;
+import com.carolinarollergirls.scoreboard.Clock;
+import com.carolinarollergirls.scoreboard.Ruleset;
+
 
 public class DefaultSettingsModelTests {
 


### PR DESCRIPTION
I don't know if I just didn't run this test before adding it or what, but set() doesn't actually do what I expected to the setting dictionary -- it makes an existing key '' instead of null.

I've updated the test to reflect that functionality and all the tests pass.