### PR TITLE
Fix occasional FileNotFoundException when loading penalty data

### DIFF
--- a/src/com/carolinarollergirls/scoreboard/json/ScoreBoardJSONListener.java
+++ b/src/com/carolinarollergirls/scoreboard/json/ScoreBoardJSONListener.java
@@ -319,21 +319,19 @@ public class ScoreBoardJSONListener implements ScoreBoardListener
 	}
 	
 	private void processPenaltyCodes(Settings s) {
-		PenaltyCodesManager pm = new PenaltyCodesManager(s);
 		updates.add(new WSUpdate("ScoreBoard.PenaltyCode", null));
-		
-        try {
-            PenaltyCodesDefinition penalties = pm.loadFromJSON();
-            for(PenaltyCode p : penalties.getPenalties()) {
-                
-                updates.add(new WSUpdate("ScoreBoard.PenaltyCode."+p.getCode(), p.CuesForWS(p)));
-            }
-            
-            
-            updates.add(new WSUpdate("ScoreBoard.PenaltyCode.?","Unknown"));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+		String file = s.get(PenaltyCodesManager.PenaltiesFileSetting);
+		if(file != null && !file.isEmpty()) {
+			try {
+				PenaltyCodesDefinition penalties = pm.loadFromJSON(file);
+				for(PenaltyCode p : penalties.getPenalties()) {
+					updates.add(new WSUpdate("ScoreBoard.PenaltyCode."+p.getCode(), p.CuesForWS(p)));
+				}
+				updates.add(new WSUpdate("ScoreBoard.PenaltyCode.?","Unknown"));
+			} catch (Exception e) {
+				throw new RuntimeException(e);
+			}
+		}
 
 	}
 
@@ -365,7 +363,9 @@ public class ScoreBoardJSONListener implements ScoreBoardListener
 		updateState();
 	}
 
+
 	private WS ws;
+	private PenaltyCodesManager pm = new PenaltyCodesManager();
 	private List<WSUpdate> updates = new LinkedList<WSUpdate>();
 	private long batch = 0;
 }

--- a/src/com/carolinarollergirls/scoreboard/json/ScoreBoardJSONListener.java
+++ b/src/com/carolinarollergirls/scoreboard/json/ScoreBoardJSONListener.java
@@ -322,15 +322,11 @@ public class ScoreBoardJSONListener implements ScoreBoardListener
 		updates.add(new WSUpdate("ScoreBoard.PenaltyCode", null));
 		String file = s.get(PenaltyCodesManager.PenaltiesFileSetting);
 		if(file != null && !file.isEmpty()) {
-			try {
-				PenaltyCodesDefinition penalties = pm.loadFromJSON(file);
-				for(PenaltyCode p : penalties.getPenalties()) {
-					updates.add(new WSUpdate("ScoreBoard.PenaltyCode."+p.getCode(), p.CuesForWS(p)));
-				}
-				updates.add(new WSUpdate("ScoreBoard.PenaltyCode.?","Unknown"));
-			} catch (Exception e) {
-				throw new RuntimeException(e);
+			PenaltyCodesDefinition penalties = pm.loadFromJSON(file);
+			for(PenaltyCode p : penalties.getPenalties()) {
+				updates.add(new WSUpdate("ScoreBoard.PenaltyCode."+p.getCode(), p.CuesForWS(p)));
 			}
+			updates.add(new WSUpdate("ScoreBoard.PenaltyCode.?","Unknown"));
 		}
 
 	}

--- a/src/com/carolinarollergirls/scoreboard/penalties/PenaltyCodesManager.java
+++ b/src/com/carolinarollergirls/scoreboard/penalties/PenaltyCodesManager.java
@@ -5,23 +5,21 @@ import java.io.FileReader;
 import java.io.Reader;
 
 import com.carolinarollergirls.scoreboard.ScoreBoardManager;
-import com.carolinarollergirls.scoreboard.Settings;
 import com.fasterxml.jackson.jr.ob.JSON;
 
 public class PenaltyCodesManager {
 
-	public PenaltyCodesManager(Settings settings) {
-		this.settings = settings;
+	public PenaltyCodesManager() {
+
 	}
 	
-	public PenaltyCodesDefinition loadFromJSON() {
-		synchronized(lock) {
-			File penaltyFile = new File(ScoreBoardManager.getDefaultPath(),settings.get(PenaltiesFileSetting));
-			try(Reader reader = new FileReader(penaltyFile)) {
-				return JSON.std.beanFrom(PenaltyCodesDefinition.class, reader);
-			} catch (Exception e) {
-				throw new RuntimeException("Failed to load Penalty Data from file", e);
-			}
+	public PenaltyCodesDefinition loadFromJSON(String file) {
+		File folder = ScoreBoardManager.getDefaultPath();
+		File penaltyFile = new File(folder,file);
+		try(Reader reader = new FileReader(penaltyFile)) {
+			return JSON.std.beanFrom(PenaltyCodesDefinition.class, reader);
+		} catch (Exception e) {
+			throw new RuntimeException("Failed to load Penalty Data from file", e);
 		}
 	}
 	
@@ -33,7 +31,5 @@ public class PenaltyCodesManager {
 		}
 	}
 	
-	private final Settings settings;
-	private final Object lock = new Object();
 	public static final String PenaltiesFileSetting = "ScoreBoard.PenaltyDefinitionFile";
 }

--- a/src/com/carolinarollergirls/scoreboard/penalties/PenaltyCodesManager.java
+++ b/src/com/carolinarollergirls/scoreboard/penalties/PenaltyCodesManager.java
@@ -15,19 +15,12 @@ public class PenaltyCodesManager {
 	}
 	
 	public PenaltyCodesDefinition loadFromJSON() {
-		Reader reader = null;
-		try {
-			reader = new FileReader(new File(ScoreBoardManager.getDefaultPath(),settings.get(PenaltiesFileSetting)));
-			return JSON.std.beanFrom(PenaltyCodesDefinition.class, reader);
-		} catch (Exception e) {
-			throw new RuntimeException("Failed to load Penalty Data from file", e);
-		} finally {
-			try {
-				if(reader != null) {
-					reader.close();
-				}
-			} catch(Exception i) {
-				//ignored
+		synchronized(lock) {
+			File penaltyFile = new File(ScoreBoardManager.getDefaultPath(),settings.get(PenaltiesFileSetting));
+			try(Reader reader = new FileReader(penaltyFile)) {
+				return JSON.std.beanFrom(PenaltyCodesDefinition.class, reader);
+			} catch (Exception e) {
+				throw new RuntimeException("Failed to load Penalty Data from file", e);
 			}
 		}
 	}
@@ -41,5 +34,6 @@ public class PenaltyCodesManager {
 	}
 	
 	private final Settings settings;
+	private final Object lock = new Object();
 	public static final String PenaltiesFileSetting = "ScoreBoard.PenaltyDefinitionFile";
 }


### PR DESCRIPTION
the root exception message is `Caused by: java.io.FileNotFoundException: . (Access is denied)`, which suggests to me that this is a threading-related issue.  I added a synchronized block around the file access portion.  I tried to recreate the exception by rapidly starting new games (which had triggered it in the past) and was unable to.

I haven't observed this causing a functional problem, the codes are always still delivered.  I suspect this is maybe related to a lot of change handlers being triggered by the *Stats classes in the game folder, but that's just a suspicion.

Additionally, since I was editing this code, I went ahead and updated the pattern to a Java 7's try-with-resources (I promise this is actually in Java 7, unlike String.join())