### PR TITLE
Add unit tests for game state

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -41,6 +41,7 @@
 		<pathelement location="test-libs/junit-4.11.jar"/>
 		<pathelement location="test-libs/hamcrest-core-1.3.jar"/>
 		<pathelement location="test-libs/mockito-all-1.9.5.jar"/>
+		<fileset dir="${jar.dir}" includes="deps/*.jar" />
 		<pathelement location="${dest.dir}"/>
 	</path>
 
@@ -52,7 +53,8 @@
 		<echo message=""/>
 		<echo message="	all							clean compile"/>
 		<echo message="	clean						Clean everything"/>
-		<echo message="	compile					Compile all classes and create jarfile (default)"/>
+		<echo message="	compile					Compile all classes and create jarfile"/>
+		<echo message="	test					Compile all classes and run unit tests (default)"/>
 		<echo message="	launcher				 Create Windows scoreboard.exe"/>
 		<echo message="	manifest				 (Re)create the manifest file"/>
 		<echo message="	help						 Show this help"/>
@@ -164,7 +166,7 @@
 	</target>
 
 	<!-- Do everything -->
-	<target name="all" depends="clean,compile"/>
+	<target name="all" depends="clean,test"/>
 
 	<!-- Create Windows scoreboard.exe -->
 	<taskdef name="launch4j" classname="net.sf.launch4j.ant.Launch4jTask" classpath="${launch4j.dir}/launch4j.jar:${launch4j.dir}/lib/xstream.jar" />

--- a/src/com/carolinarollergirls/scoreboard/ScoreBoardManager.java
+++ b/src/com/carolinarollergirls/scoreboard/ScoreBoardManager.java
@@ -235,7 +235,10 @@ public class ScoreBoardManager {
 	public static void setLogger(Logger l) { logger = l; }
 	public static File getDefaultPath() { return defaultPath; }
 	public static void setDefaultPath(File f) { defaultPath = f; }
-	public static void setPropertyOverride(String key, String value) { properties_overrides.put(key, value); }
+	public static void setPropertyOverride(String key, String value) { 
+		properties_overrides.put(key, value);
+		properties.put(key, value);
+	}
 
 	private static Properties properties = new Properties();
 	private static Map<String,String> properties_overrides = new HashMap<String,String>();

--- a/src/com/carolinarollergirls/scoreboard/defaults/DefaultClockModel.java
+++ b/src/com/carolinarollergirls/scoreboard/defaults/DefaultClockModel.java
@@ -166,9 +166,11 @@ public class DefaultClockModel extends DefaultScoreBoardEventProvider implements
 			if (isRunning() && isSyncTime())
 				ms = ((ms / 1000) * 1000) + (time % 1000);
 			time = checkNewTime(ms);
-			scoreBoardChange(new ScoreBoardEvent(this, EVENT_TIME, new Long(time), last));
-			scoreBoardChange(new ScoreBoardEvent(this, EVENT_INVERTED_TIME, new Long(maximumTime) - new Long(time), maximumTime - last));
-			doStop = checkStop();
+			if (isDisplayChange(time, last)) {
+				scoreBoardChange(new ScoreBoardEvent(this, EVENT_TIME, new Long(time), last));
+				scoreBoardChange(new ScoreBoardEvent(this, EVENT_INVERTED_TIME, new Long(maximumTime) - new Long(time), maximumTime - last));
+			}
+			doStop = isTimeAtEnd();
 		}
 		if (doStop)
 			stop();
@@ -181,11 +183,11 @@ public class DefaultClockModel extends DefaultScoreBoardEventProvider implements
 			if (sync && isRunning() && isSyncTime())
 				change = ((change / 1000) * 1000);
 			time = checkNewTime(time + change);
-			if (time % 1000 == 0 || Math.abs(last - time) >= 1000) {
+			if (isDisplayChange(time, last)) {
 				scoreBoardChange(new ScoreBoardEvent(this, EVENT_TIME, new Long(time), last));
 				scoreBoardChange(new ScoreBoardEvent(this, EVENT_INVERTED_TIME, new Long(maximumTime) - new Long(time), maximumTime - last));
 			}
-			doStop = checkStop();
+			doStop = isTimeAtEnd();
 		}
 		if (doStop)
 			stop();
@@ -207,8 +209,13 @@ public class DefaultClockModel extends DefaultScoreBoardEventProvider implements
 		else
 			return ms;
 	}
-	protected boolean checkStop() {
-		return (getTime() == (isCountDirectionDown() ? getMinimumTime() : getMaximumTime()));
+	protected boolean isDisplayChange(long current, long last) {
+		//on count down clocks are rounded down for display, on count up they are rounded down.
+		if (isCountDirectionDown()) {
+			return ((current-1)/1000 != (last-1)/1000);
+		} else {
+			return (current/1000 != last/1000);
+		}
 	}
 
 	public long getMinimumTime() { return minimumTime; }
@@ -444,6 +451,7 @@ public class DefaultClockModel extends DefaultScoreBoardEventProvider implements
 		}
 
 		public void run() {
+			if (paused) return;
 			long curSystemTime = System.currentTimeMillis();
 			long curTicks = (curSystemTime - startSystemTime) / update_interval;
 			while (curTicks != ticks) {
@@ -456,9 +464,23 @@ public class DefaultClockModel extends DefaultScoreBoardEventProvider implements
 			return currentTime;
 		}
 
+		// For unittests.
+		protected void advance(long time_ms) {
+			long curTicks = time_ms / update_interval;
+			while (curTicks != 0) {
+				curTicks--;
+				tick();
+			}
+		}
+		protected void setPaused(boolean p) {
+			paused = p;
+		}
+
+
 		private long currentTime = 0;
 		private long startSystemTime = 0;
 		private long ticks = 0;
+		private boolean paused = false;
 		protected static Timer timer = new Timer();
 		protected Object clockLock = new Object();
 		protected DefaultClockModel masterClock = null;

--- a/src/com/carolinarollergirls/scoreboard/defaults/DefaultClockModel.java
+++ b/src/com/carolinarollergirls/scoreboard/defaults/DefaultClockModel.java
@@ -210,7 +210,8 @@ public class DefaultClockModel extends DefaultScoreBoardEventProvider implements
 			return ms;
 	}
 	protected boolean isDisplayChange(long current, long last) {
-		//on count down clocks are rounded down for display, on count up they are rounded down.
+		//the frontend rounds values that are not full seconds to the earlier second
+		//i.e. 3600ms will be displayed as 3s on a count up clock and as 4s on a count down clock.
 		if (isCountDirectionDown()) {
 			return ((current-1)/1000 != (last-1)/1000);
 		} else {

--- a/src/com/carolinarollergirls/scoreboard/defaults/DefaultTeamModel.java
+++ b/src/com/carolinarollergirls/scoreboard/defaults/DefaultTeamModel.java
@@ -372,7 +372,6 @@ public class DefaultTeamModel extends DefaultScoreBoardEventProvider implements 
 	public void resetTimeouts(boolean gameStart) {
 		setInTimeout(false);
 		setInOfficialReview(false);
-		setRetainedOfficialReview(false);
 		if (gameStart || timeoutsPerPeriod) {
 			setTimeouts(maximumTimeouts);
 		}
@@ -493,7 +492,7 @@ public class DefaultTeamModel extends DefaultScoreBoardEventProvider implements 
 		synchronized (skaterLock) {
 			requestBatchStart();
 
-			Boolean last = new Boolean(starPass);
+			Boolean last = new Boolean(this.starPass);
 			this.starPass = starPass;
 			scoreBoardChange(new ScoreBoardEvent(this, EVENT_STAR_PASS, new Boolean(starPass), last));
 
@@ -514,17 +513,17 @@ public class DefaultTeamModel extends DefaultScoreBoardEventProvider implements 
 
 	protected String id;
 	protected String name;
-	protected String logo;
-	protected int score;
-	protected int lastscore;
-	protected int timeouts;
-	protected int maximumTimeouts;
-	protected boolean timeoutsPerPeriod;
-	protected int officialReviews;
-	protected int maximumOfficialReviews;
-	protected boolean officialReviewsPerPeriod;
-	protected String leadJammer = Team.LEAD_NO_LEAD;
-	protected boolean starPass = false;
+	protected String logo = DEFAULT_LOGO;
+	protected int score = DEFAULT_SCORE;
+	protected int lastscore = DEFAULT_SCORE;
+	protected int timeouts = DEFAULT_TIMEOUTS;
+	protected int maximumTimeouts = DEFAULT_TIMEOUTS;
+	protected boolean timeoutsPerPeriod = DEFAULT_TIMEOUTS_PER_PERIOD;
+	protected int officialReviews = DEFAULT_OFFICIAL_REVIEWS;
+	protected int maximumOfficialReviews = DEFAULT_OFFICIAL_REVIEWS;
+	protected boolean officialReviewsPerPeriod = DEFAULT_REVIEWS_PER_PERIOD;
+	protected String leadJammer = DEFAULT_LEADJAMMER;
+	protected boolean starPass = DEFAULT_STARPASS;
 	protected boolean in_timeout = false;
 	protected boolean in_official_review = false;
 	protected boolean retained_official_review = false;
@@ -554,7 +553,9 @@ public class DefaultTeamModel extends DefaultScoreBoardEventProvider implements 
 	public static final String DEFAULT_LOGO = "";
 	public static final int DEFAULT_SCORE = 0;
 	public static final int DEFAULT_TIMEOUTS = 3;
+	public static final boolean DEFAULT_TIMEOUTS_PER_PERIOD = false;
 	public static final int DEFAULT_OFFICIAL_REVIEWS = 1;
+	public static final boolean DEFAULT_REVIEWS_PER_PERIOD = true;
 	public static final String DEFAULT_LEADJAMMER = Team.LEAD_NO_LEAD;
 	public static final boolean DEFAULT_STARPASS = false;
 

--- a/tests/com/carolinarollergirls/scoreboard/defaults/DefaultClockModelTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/defaults/DefaultClockModelTests.java
@@ -4,6 +4,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.LinkedList;
+import java.util.Queue;
+
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -13,6 +17,9 @@ import org.mockito.stubbing.Answer;
 import com.carolinarollergirls.scoreboard.Clock;
 import com.carolinarollergirls.scoreboard.Ruleset;
 import com.carolinarollergirls.scoreboard.Settings;
+import com.carolinarollergirls.scoreboard.event.ConditionalScoreBoardListener;
+import com.carolinarollergirls.scoreboard.event.ScoreBoardEvent;
+import com.carolinarollergirls.scoreboard.event.ScoreBoardListener;
 import com.carolinarollergirls.scoreboard.model.ScoreBoardModel;
 
 public class DefaultClockModelTests {
@@ -21,15 +28,33 @@ public class DefaultClockModelTests {
 	private Ruleset ruleMock;
 	private Settings settingsMock;
 	
+	private ScoreBoardEventProviderManager sbepm;
+	private Queue<ScoreBoardEvent> collectedEvents;
+	public ScoreBoardListener listener = new ScoreBoardListener() {
+		
+		@Override
+		public void scoreBoardChange(ScoreBoardEvent event) {
+			collectedEvents.add(event);
+		}
+	};
+	
 	
 	private DefaultClockModel clock;
 	private static String ID = "TEST";
 	
 	private boolean syncStatus = false;
 	
+	private void advance(long time_ms) {
+	    DefaultClockModel.updateClockTimerTask.advance(time_ms);
+	    sbepm.waitForEvents();
+	}
+	
 	@Before
 	public void setUp() throws Exception {
 		syncStatus = false;
+		sbepm = ScoreBoardEventProviderManager.getSingleton();
+		collectedEvents = new LinkedList<ScoreBoardEvent>();
+		
 		sbModelMock = Mockito.mock(DefaultScoreBoardModel.class);
 		
 		ruleMock = Mockito.mock(Ruleset.class);
@@ -49,7 +74,7 @@ public class DefaultClockModelTests {
 		
 		// makes it easier to test both sync and non-sync paths through clock model
 		Mockito
-			.when(settingsMock.getBoolean("Scoreboard.Clock.Sync"))
+			.when(settingsMock.getBoolean("ScoreBoard.Clock.Sync"))
 			.thenAnswer(new Answer<Boolean>() {
 				public Boolean answer(InvocationOnMock invocation) throws Throwable {
 					return syncStatus;
@@ -57,8 +82,14 @@ public class DefaultClockModelTests {
 			});
 		
 		clock = new DefaultClockModel(sbModelMock, ID);
+		DefaultClockModel.updateClockTimerTask.setPaused(true);
 	}
 	
+	@After
+	public void tearDown() throws Exception {
+		DefaultClockModel.updateClockTimerTask.setPaused(false);
+	}
+
 	@Test
 	public void test_defaults() {
 		assertEquals(0, clock.getMinimumNumber());
@@ -79,149 +110,327 @@ public class DefaultClockModelTests {
 		assertEquals(ID, clock.getProviderId());
 		assertEquals(Clock.class, clock.getProviderClass());
 	}
+
+	@Test
+	public void test_reset() {
+		clock.setMaximumNumber(5);
+		clock.setMinimumNumber(2);
+		clock.setNumber(4);
+		clock.setMaximumTime(1200000);
+		clock.setTime(5000);
+		clock.setCountDirectionDown(true);
+		
+		clock.reset();
+		
+		assertTrue(clock.isCountDirectionDown());
+		assertEquals(clock.getMinimumNumber(), clock.getNumber());
+		assertTrue(clock.isTimeAtStart());
+	}
 	
 	@Test
 	public void syncTimeTest() {
+		//add a master clock
+		DefaultClockModel clock2 = new DefaultClockModel(sbModelMock, Clock.ID_TIMEOUT);
+		syncStatus = true;
+		clock.setMaximumTime(10000);
+		clock2.setMaximumTime(10000);
+		clock2.setTime(3400);
+		assertEquals(3400, clock2.getTime());
 		
-	}
+		//no syncing is done if the clock is stopped
+		clock.setTime(4200);
+		assertEquals(4200, clock.getTime());
 
+		//when the clocks are started the non-master clock is synced to the master clock
+		clock2.start();
+		clock.start();
+		assertEquals(4400, clock.getTime());
+
+		//changes under 1s are ignored. Even if multiple changes accumulate to more than 1s
+		clock.changeTime(500);
+		clock.changeTime(800);
+		assertEquals(4400, clock.getTime());
+
+		//changes over 1s are rounded down
+		clock.changeTime(1100);
+		assertEquals(5400, clock.getTime());
+
+		//the previous statements also apply to the master clock
+		clock2.changeTime(500);
+		clock2.changeTime(800);
+		assertEquals(3400, clock2.getTime());
+		clock2.changeTime(1000);
+		assertEquals(4400, clock2.getTime());
+
+		//advancing the time affects both clocks even if less than 1s
+		advance(400);
+		assertEquals(4800, clock2.getTime());
+		assertEquals(5800, clock.getTime());
+	}
 	
 	@Test
 	public void test_name() {
+		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_NAME, listener));
+		
 		clock.setName("Test Clock");
+		advance(0);
 		
 		assertEquals("Test Clock", clock.getName());
-		//TODO: Test Event system
+		assertEquals(1, collectedEvents.size());
+		ScoreBoardEvent event = collectedEvents.poll();
+		assertEquals("Test Clock", event.getValue());
+		assertEquals(null, event.getPreviousValue());
+	}
+	
+	public void test_count_direction_setter() {
+		assertFalse(clock.isCountDirectionDown());
+		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_DIRECTION, listener));
+		
+		clock.setCountDirectionDown(true);
+		advance(0);
+		assertTrue(clock.isCountDirectionDown());
+		assertEquals(1, collectedEvents.size());
+		ScoreBoardEvent event = collectedEvents.poll();
+		assertTrue((Boolean)event.getValue());
+		assertFalse((Boolean)event.getPreviousValue());
+
+		//check idempotency
+		clock.setCountDirectionDown(true);
+		advance(0);
+		assertTrue(clock.isCountDirectionDown());
+		assertEquals(1, collectedEvents.size());
+		
+		clock.setCountDirectionDown(false);
+		advance(0);
+		assertFalse(clock.isCountDirectionDown());
 	}
 	
 	@Test
 	public void test_min_number_setter() {
-		clock.setMinimumNumber(1);
+		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MINIMUM_NUMBER, listener));
 		
-		// validate constraint: max > min
+		clock.setMinimumNumber(1);
+		advance(0);
+		
+		// validate constraint: max >= number >= min
 		assertEquals(1, clock.getMinimumNumber());
 		assertEquals(1, clock.getMaximumNumber());
 		assertEquals(1, clock.getNumber());
 
+		assertEquals(1, collectedEvents.size());
+		ScoreBoardEvent event = collectedEvents.poll();
+		assertEquals(1, event.getValue());
+		assertEquals(0, event.getPreviousValue());
 	}
 	
 	@Test
 	public void test_min_number_setter2() {
+		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MINIMUM_NUMBER, listener));
+		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MAXIMUM_NUMBER, listener));
+		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_NUMBER, listener));
+
+		
 		clock.setMinimumNumber(10);
+		advance(0);
+		collectedEvents.clear();
+
 		clock.setMinimumNumber(5);
+		advance(0);
 		
 		// validate constraint: number is automatically set to max
 		assertEquals(5, clock.getMinimumNumber());
 		assertEquals(10, clock.getMaximumNumber());
 		assertEquals(10, clock.getNumber());
 
+		assertEquals(1, collectedEvents.size());
 	}
 	
 	@Test
 	public void test_max_number_setter() {
-		clock.setMaximumNumber(5);
+		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MAXIMUM_NUMBER, listener));
 		
+		clock.setMaximumNumber(5);
+		advance(0);
 		
 		assertEquals(0, clock.getMinimumNumber());
 		assertEquals(5, clock.getMaximumNumber());
 		assertEquals(0, clock.getNumber());
+
+		assertEquals(1, collectedEvents.size());
+		ScoreBoardEvent event = collectedEvents.poll();
+		assertEquals(5, event.getValue());
+		assertEquals(0, event.getPreviousValue());
 	}
 	
 	@Test
 	public void test_max_number_setter2() {
+		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MINIMUM_NUMBER, listener));
+		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MAXIMUM_NUMBER, listener));
+		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_NUMBER, listener));
+
+		
 		clock.setMinimumNumber(10);
+		advance(0);
+		collectedEvents.clear();
+
 		clock.setMaximumNumber(5);
+		advance(0);
 		
 		// validate constraint: cannot set a max that is < min
 		assertEquals(10, clock.getMinimumNumber());
 		assertEquals(10, clock.getMaximumNumber());
 		assertEquals(10, clock.getNumber());
+
+		assertEquals(1, collectedEvents.size());
 	}
 	
 	@Test
 	public void test_max_number_change() {
+		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MAXIMUM_NUMBER, listener));
+		
 		clock.setMaximumNumber(5);
+		advance(0);
+		collectedEvents.clear();
+
 		clock.changeMaximumNumber(2);
+		advance(0);
 		
 		assertEquals(0, clock.getMinimumNumber());
 		assertEquals(7, clock.getMaximumNumber());
 		assertEquals(0, clock.getNumber());
+
+		assertEquals(1, collectedEvents.size());
+		ScoreBoardEvent event = collectedEvents.poll();
+		assertEquals(7, event.getValue());
+		assertEquals(5, event.getPreviousValue());
 	}
 	
 	@Test
 	public void test_min_number_change() {
+		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MINIMUM_NUMBER, listener));
+		
 		clock.setMinimumNumber(5);
+		advance(0);
+		collectedEvents.clear();
+
 		clock.changeMinimumNumber(2);
+		advance(0);
 		
 		assertEquals(7, clock.getMinimumNumber());
 		assertEquals(7, clock.getMaximumNumber());
 		assertEquals(7, clock.getNumber());
+
+		assertEquals(1, collectedEvents.size());
+		ScoreBoardEvent event = collectedEvents.poll();
+		assertEquals(7, event.getValue());
+		assertEquals(5, event.getPreviousValue());
 	}
 	
 	@Test
 	public void test_number_changing() {
+		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_NUMBER, listener));
+		
 		clock.setMaximumNumber(12);
 		clock.setMinimumNumber(3);
+		advance(0);
+		collectedEvents.clear();
 		
 		clock.setNumber(5);
+		advance(0);
 		assertEquals(5, clock.getNumber());
+		assertEquals(1, collectedEvents.size());
+		ScoreBoardEvent event = collectedEvents.poll();
+		assertEquals(5, event.getValue());
+		assertEquals(3, event.getPreviousValue());
 		
 		clock.changeNumber(3);
+		advance(0);
 		assertEquals(8, clock.getNumber());
-		
+		assertEquals(1, collectedEvents.size());
+		collectedEvents.clear();
+	
 		// validate constraint: cannot set number above maximum
 		clock.setNumber(23);
+		advance(0);
 		assertEquals(12, clock.getNumber());
+		assertEquals(1, collectedEvents.size());
+		collectedEvents.clear();
 		
 		// validate constraint: cannot set number below minimum
 		clock.setNumber(-2);
+		advance(0);
 		assertEquals(3, clock.getNumber());
+		assertEquals(1, collectedEvents.size());
+		collectedEvents.clear();
 		
 		// ...and check that constraint is not a >0 type constraint
 		clock.setNumber(1);
+		advance(0);
 		assertEquals(3, clock.getNumber());
+		assertEquals(1, collectedEvents.size());
+		collectedEvents.clear();
 		
 		clock.changeNumber(6);
+		advance(0);
 		assertEquals(9, clock.getNumber());
+		assertEquals(1, collectedEvents.size());
+		collectedEvents.clear();
 		
 		// validate constraint: cannot changeNumber above maximum
 		clock.changeNumber(6);
+		advance(0);
 		assertEquals(12, clock.getNumber());
+		assertEquals(1, collectedEvents.size());
+		collectedEvents.clear();
 		
 		
 		clock.setNumber(5);
 		clock.changeNumber(-1);
+		advance(0);
 		assertEquals(4, clock.getNumber());
+		assertEquals(2, collectedEvents.size());
+		collectedEvents.clear();
 		
 		// validate constraint: cannot changeNumber below minimum
 		clock.changeNumber(-4);
+		advance(0);
 		assertEquals(3, clock.getNumber());
+		assertEquals(1, collectedEvents.size());
 	}
 	
 	@Test
 	public void test_min_time_setter() {
+		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MINIMUM_TIME, listener));
+		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MAXIMUM_TIME, listener));
+		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_TIME, listener));
+		
 		clock.setMinimumTime(1000);
+		advance(0);
 		
 		// validate constraint: max > min
 		assertEquals(1000, clock.getMinimumTime());
 		assertEquals(1000, clock.getMaximumTime());
 		assertEquals(1000, clock.getTime());
-		
-		clock.setMinimumTime(500);
-		
 
+		assertEquals(3, collectedEvents.size());
+		ScoreBoardEvent event = collectedEvents.poll();
+		assertEquals(1000, (long)event.getValue());
+		assertEquals(0, (long)event.getPreviousValue());
 	}
 	
 	@Test
 	public void test_min_time_setter2() {
+		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MINIMUM_TIME, listener));
+
+		
 		clock.setMinimumTime(2000);
 		clock.setMinimumTime(1000);
+		advance(0);
 		
 		// validate constraint: reducing min time doesn't reset max or current time
 		assertEquals(1000, clock.getMinimumTime());
 		assertEquals(2000, clock.getMaximumTime());
 		assertEquals(2000, clock.getTime());
-
 	}
 	
 	@Test
@@ -238,12 +447,20 @@ public class DefaultClockModelTests {
 	
 	@Test
 	public void test_max_time_setter() {
+		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MAXIMUM_TIME, listener));
+		
 		clock.setMaximumTime(5000);
+		advance(0);
 		
 		// validate constraint: increase max time doesn't reset min or current time
 		assertEquals(0, clock.getMinimumTime());
 		assertEquals(5000, clock.getMaximumTime());
 		assertEquals(0, clock.getTime());
+
+		assertEquals(1, collectedEvents.size());
+		ScoreBoardEvent event = collectedEvents.poll();
+		assertEquals(5000, (long)event.getValue());
+		assertEquals(0, (long)event.getPreviousValue());
 	}
 	
 	@Test
@@ -259,65 +476,125 @@ public class DefaultClockModelTests {
 	
 	@Test
 	public void test_max_time_change() {
+		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MAXIMUM_TIME, listener));
+		
 		clock.setMaximumTime(1000);
+		advance(0);
+		collectedEvents.clear();
+		
 		clock.changeMaximumTime(2000);
+		advance(0);
 		
 		assertEquals(0, clock.getMinimumTime());
 		assertEquals(3000, clock.getMaximumTime());
 		assertEquals(0, clock.getTime());
+		assertEquals(1, collectedEvents.size());
+		ScoreBoardEvent event = collectedEvents.poll();
+		assertEquals(3000, (long)event.getValue());
+		assertEquals(1000, (long)event.getPreviousValue());
 	}
 	
 	@Test
 	public void test_min_time_change() {
+		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MINIMUM_TIME, listener));
+		
 		clock.setMinimumTime(5000);
+		advance(0);
+		collectedEvents.clear();
+
 		clock.changeMinimumTime(2000);
+		advance(0);
 		
 		assertEquals(7000, clock.getMinimumTime());
 		assertEquals(7000, clock.getMaximumTime());
 		assertEquals(7000, clock.getTime());
+
+		assertEquals(1, collectedEvents.size());
+		ScoreBoardEvent event = collectedEvents.poll();
+		assertEquals(7000, (long)event.getValue());
+		assertEquals(5000, (long)event.getPreviousValue());
 	}
 	
 	@Test
 	public void test_time_changing() {
+		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_TIME, listener));
+		
 		clock.setMaximumTime(5000);
 		clock.setMinimumTime(1000);
+		advance(0);
+		collectedEvents.clear();
 		
 		clock.setTime(2000);
+		advance(0);
 		assertEquals(2000, clock.getTime());
 		assertEquals(3000, clock.getInvertedTime());
+		assertEquals(1, collectedEvents.size());
+		ScoreBoardEvent event = collectedEvents.poll();
+		assertEquals(2000, (long)event.getValue());
+		assertEquals(1000, (long)event.getPreviousValue());
 		
 		clock.setTime(6000);
+		advance(0);
 		assertEquals(5000, clock.getTime());
 		assertEquals(0, clock.getInvertedTime());
+		assertEquals(1, collectedEvents.size());
+		assertEquals(5000, (long)collectedEvents.poll().getValue());
 		
 		clock.setTime(400);
+		advance(0);
 		assertEquals(1000, clock.getTime());
 		assertEquals(4000, clock.getInvertedTime());
+		assertEquals(1, collectedEvents.size());
+		collectedEvents.clear();
 		
-		clock.setTime(600);
-		assertEquals(600, clock.getTime());
-		assertEquals(4400, clock.getInvertedTime());
-		//TODO: validate that event DOES NOT fire in this case
+		clock.setTime(1200);
+		advance(0);
+		assertEquals(1200, clock.getTime());
+		assertEquals(3800, clock.getInvertedTime());
+		assertEquals(0, collectedEvents.size());
 		
+		clock.changeTime(-201);
+		advance(0);
+		assertEquals(999, clock.getTime());
+		assertEquals(1, collectedEvents.size());
+		collectedEvents.clear();
+
+		clock.setCountDirectionDown(true);
+		clock.changeTime(1);
+		advance(0);
+		assertEquals(0, collectedEvents.size());
+
 		clock.setTime(2000);
 		clock.changeTime(1200);
+		advance(0);
 		assertEquals(3200, clock.getTime());
 		assertEquals(1800, clock.getInvertedTime());
-		//TODO: validate that events fire in this case
+		assertEquals(2, collectedEvents.size());
+		collectedEvents.clear();
 		
+		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_INVERTED_TIME, listener));
 		clock.changeTime(-5000);
+		advance(0);
 		assertEquals(1000, clock.getTime());
 		assertEquals(4000, clock.getInvertedTime());
+		assertEquals(2, collectedEvents.size());
+		event = collectedEvents.poll();
+		assertEquals(1000, (long)event.getValue());
+		assertEquals(3200, (long)event.getPreviousValue());
+		event = collectedEvents.poll();
+		assertEquals(4000, (long)event.getValue());
+		assertEquals(1800, (long)event.getPreviousValue());
 		
 		clock.changeTime(4100);
+		advance(0);
 		assertEquals(5100, clock.getTime());
 		assertEquals(-100, clock.getInvertedTime());
 	}
 	
-	
 	@Test
 	public void test_time_elapse_count_up()
 	{
+		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_TIME, listener));
 		clock.setMaximumTime(5000);
 		
 		clock.setTime(2000);
@@ -325,9 +602,11 @@ public class DefaultClockModelTests {
 		assertEquals(3000, clock.getTimeRemaining());
 
 		clock.elapseTime(1000);
+		advance(0);
 		assertEquals(3000, clock.getTime());
 		assertEquals(3000, clock.getTimeElapsed());
 		assertEquals(2000, clock.getTimeRemaining());
+		assertEquals(2, collectedEvents.size());
 	}
 
 	@Test
@@ -389,14 +668,17 @@ public class DefaultClockModelTests {
 	@Test
 	public void test_reset_time()
 	{
+		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_TIME, listener));
 		clock.setMaximumTime(5000);
 		clock.setMinimumTime(1000);
 		
 		clock.setTime(3000);
 		
 		clock.resetTime();
+		advance(0);
 		
 		assertEquals(1000, clock.getTime());
+		assertEquals(3, collectedEvents.size());
 		
 		clock.setTime(3000);
 		clock.setCountDirectionDown(true);
@@ -406,11 +688,57 @@ public class DefaultClockModelTests {
 		assertEquals(5000, clock.getTime());
 	}
 	
+	public void test_running() {
+		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_RUNNING, listener));
+		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_TIME, listener));
+		clock.setMaximumTime(30000);
+		assertFalse(clock.isCountDirectionDown());
+		assertTrue(clock.isTimeAtStart());
+
+		clock.start();
+		advance(0);
+		assertEquals(1, collectedEvents.size());
+		ScoreBoardEvent event = collectedEvents.poll();
+		assertEquals(Clock.EVENT_RUNNING, event.getProperty());
+		assertTrue((Boolean)event.getValue());
+		assertFalse((Boolean)event.getPreviousValue());
+		
+		advance(1000);
+		advance(500);
+		advance(500);
+		assertEquals(2000, clock.getTimeElapsed());
+		assertEquals(2, collectedEvents.size());
+		assertEquals(Clock.EVENT_TIME, collectedEvents.poll().getProperty());
+		assertEquals(Clock.EVENT_TIME, collectedEvents.poll().getProperty());
+		
+		advance(2000);
+		assertEquals(4000, clock.getTimeElapsed());
+		assertEquals(1, collectedEvents.size());
+		assertEquals(Clock.EVENT_TIME, collectedEvents.poll().getProperty());
+
+		clock.stop();
+		advance(0);
+		assertEquals(1, collectedEvents.size());
+		event = collectedEvents.poll();
+		assertEquals(Clock.EVENT_RUNNING, event.getProperty());
+		assertFalse((Boolean)event.getValue());
+		assertTrue((Boolean)event.getPreviousValue());
+
+		clock.setCountDirectionDown(true);
+		clock.resetTime();
+		clock.start();
+		advance(2000);
+		assertEquals(2000, clock.getTimeElapsed());
+	}
+	
 	@Test
 	public void test_apply_rules_name()
 	{
-		clock.applyRule("Clock.TEST.Name", "New Name");
+		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_NAME, listener));
+		clock.applyRule("Clock." + ID + ".Name", "New Name");
+		advance(0);
 		assertEquals("New Name", clock.getName());
+		assertEquals(1, collectedEvents.size());
 		
 		clock.applyRule("Clock.OTHER.Name", "Shouldn't Change");
 		assertEquals("New Name", clock.getName());
@@ -419,8 +747,11 @@ public class DefaultClockModelTests {
 	@Test
 	public void test_apply_rules_direction()
 	{
+		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_DIRECTION, listener));
 		clock.applyRule("Clock." + ID + ".Direction", true);
+		advance(0);
 		assertTrue(clock.isCountDirectionDown());
+		assertEquals(1, collectedEvents.size());
 		
 		clock.applyRule("Clock.OTHER.Direction", false);
 		assertTrue(clock.isCountDirectionDown());
@@ -429,10 +760,13 @@ public class DefaultClockModelTests {
 	@Test
 	public void test_apply_rules_min_number()
 	{
+		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MINIMUM_NUMBER, listener));
 		clock.applyRule("Clock." + ID + ".MinimumNumber", 10);
+		advance(0);
 		assertEquals(10, clock.getMinimumNumber());
 		assertEquals(10, clock.getMaximumNumber());
 		assertEquals(10, clock.getNumber());
+		assertEquals(1, collectedEvents.size());
 
 		
 		clock.applyRule("Clock.OTHER.MaximumNumber", 20);
@@ -444,10 +778,13 @@ public class DefaultClockModelTests {
 	@Test
 	public void test_apply_rules_max_number()
 	{
+		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MAXIMUM_NUMBER, listener));
 		clock.applyRule("Clock." + ID + ".MaximumNumber", 10);
+		advance(0);
 		assertEquals(0, clock.getMinimumNumber());
 		assertEquals(10, clock.getMaximumNumber());
 		assertEquals(0, clock.getNumber());
+		assertEquals(1, collectedEvents.size());
 
 		
 		clock.applyRule("Clock.OTHER.MaximumNumber", 20);
@@ -459,10 +796,13 @@ public class DefaultClockModelTests {
 	@Test
 	public void test_apply_rules_min_time()
 	{
+		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MINIMUM_TIME, listener));
 		clock.applyRule("Clock." + ID + ".MinimumTime", (long)10000);
+		advance(0);
 		assertEquals(10000, clock.getMinimumTime());
 		assertEquals(10000, clock.getMaximumTime());
 		assertEquals(10000, clock.getTime());
+		assertEquals(1, collectedEvents.size());
 
 		
 		clock.applyRule("Clock.OTHER.MinimumTime", (long)20000);
@@ -474,10 +814,13 @@ public class DefaultClockModelTests {
 	@Test
 	public void test_apply_rules_max_time()
 	{
+		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MAXIMUM_TIME, listener));
 		clock.applyRule("Clock." + ID + ".MaximumTime", (long)10000);
+		advance(0);
 		assertEquals(0, clock.getMinimumTime());
 		assertEquals(10000, clock.getMaximumTime());
 		assertEquals(0, clock.getTime());
+		assertEquals(1, collectedEvents.size());
 
 		
 		clock.applyRule("Clock.OTHER.MaximumTime", (long)20000);

--- a/tests/com/carolinarollergirls/scoreboard/defaults/DefaultClockModelTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/defaults/DefaultClockModelTests.java
@@ -91,7 +91,7 @@ public class DefaultClockModelTests {
 	}
 
 	@Test
-	public void test_defaults() {
+	public void testDefaults() {
 		assertEquals(0, clock.getMinimumNumber());
 		assertEquals(0, clock.getMaximumNumber());
 		assertEquals(0, clock.getNumber());
@@ -112,7 +112,7 @@ public class DefaultClockModelTests {
 	}
 
 	@Test
-	public void test_reset() {
+	public void testReset() {
 		clock.setMaximumNumber(5);
 		clock.setMinimumNumber(2);
 		clock.setNumber(4);
@@ -128,7 +128,7 @@ public class DefaultClockModelTests {
 	}
 	
 	@Test
-	public void syncTimeTest() {
+	public void testSetting_ClockSync() {
 		//add a master clock
 		DefaultClockModel clock2 = new DefaultClockModel(sbModelMock, Clock.ID_TIMEOUT);
 		syncStatus = true;
@@ -169,7 +169,7 @@ public class DefaultClockModelTests {
 	}
 	
 	@Test
-	public void test_name() {
+	public void testSetName() {
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_NAME, listener));
 		
 		clock.setName("Test Clock");
@@ -182,7 +182,7 @@ public class DefaultClockModelTests {
 		assertEquals(null, event.getPreviousValue());
 	}
 	
-	public void test_count_direction_setter() {
+	public void testSetCountDirectionDown() {
 		assertFalse(clock.isCountDirectionDown());
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_DIRECTION, listener));
 		
@@ -206,7 +206,7 @@ public class DefaultClockModelTests {
 	}
 	
 	@Test
-	public void test_min_number_setter() {
+	public void testSetMinimumNumber() {
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MINIMUM_NUMBER, listener));
 		
 		clock.setMinimumNumber(1);
@@ -224,7 +224,7 @@ public class DefaultClockModelTests {
 	}
 	
 	@Test
-	public void test_min_number_setter2() {
+	public void testSetMinimumNumber2() {
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MINIMUM_NUMBER, listener));
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MAXIMUM_NUMBER, listener));
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_NUMBER, listener));
@@ -246,7 +246,7 @@ public class DefaultClockModelTests {
 	}
 	
 	@Test
-	public void test_max_number_setter() {
+	public void testSetMaximumNumber() {
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MAXIMUM_NUMBER, listener));
 		
 		clock.setMaximumNumber(5);
@@ -263,7 +263,7 @@ public class DefaultClockModelTests {
 	}
 	
 	@Test
-	public void test_max_number_setter2() {
+	public void testSetMaximumNumber2() {
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MINIMUM_NUMBER, listener));
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MAXIMUM_NUMBER, listener));
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_NUMBER, listener));
@@ -285,7 +285,7 @@ public class DefaultClockModelTests {
 	}
 	
 	@Test
-	public void test_max_number_change() {
+	public void testChangeMaximumNumber() {
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MAXIMUM_NUMBER, listener));
 		
 		clock.setMaximumNumber(5);
@@ -306,7 +306,7 @@ public class DefaultClockModelTests {
 	}
 	
 	@Test
-	public void test_min_number_change() {
+	public void testChangeMinimumNumber() {
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MINIMUM_NUMBER, listener));
 		
 		clock.setMinimumNumber(5);
@@ -327,7 +327,7 @@ public class DefaultClockModelTests {
 	}
 	
 	@Test
-	public void test_number_changing() {
+	public void testChangeNumber() {
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_NUMBER, listener));
 		
 		clock.setMaximumNumber(12);
@@ -399,7 +399,7 @@ public class DefaultClockModelTests {
 	}
 	
 	@Test
-	public void test_min_time_setter() {
+	public void testSetMinimumTime() {
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MINIMUM_TIME, listener));
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MAXIMUM_TIME, listener));
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_TIME, listener));
@@ -419,7 +419,7 @@ public class DefaultClockModelTests {
 	}
 	
 	@Test
-	public void test_min_time_setter2() {
+	public void testSetMinimumTime2() {
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MINIMUM_TIME, listener));
 
 		
@@ -434,7 +434,7 @@ public class DefaultClockModelTests {
 	}
 	
 	@Test
-	public void test_min_time_setter3() {
+	public void testSetMinimumTime3() {
 		clock.setMaximumTime(2000);
 		clock.setMinimumTime(1000);
 		
@@ -446,7 +446,7 @@ public class DefaultClockModelTests {
 	}
 	
 	@Test
-	public void test_max_time_setter() {
+	public void testSetMaximumTime() {
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MAXIMUM_TIME, listener));
 		
 		clock.setMaximumTime(5000);
@@ -464,7 +464,7 @@ public class DefaultClockModelTests {
 	}
 	
 	@Test
-	public void test_max_time_setter2() {
+	public void testSetMaximumTime2() {
 		clock.setMinimumTime(2000);
 		clock.setMaximumTime(1000);
 		
@@ -475,7 +475,7 @@ public class DefaultClockModelTests {
 	} 
 	
 	@Test
-	public void test_max_time_change() {
+	public void testChangeMaximumTime() {
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MAXIMUM_TIME, listener));
 		
 		clock.setMaximumTime(1000);
@@ -495,7 +495,7 @@ public class DefaultClockModelTests {
 	}
 	
 	@Test
-	public void test_min_time_change() {
+	public void testChangeMinimumTime() {
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MINIMUM_TIME, listener));
 		
 		clock.setMinimumTime(5000);
@@ -516,7 +516,7 @@ public class DefaultClockModelTests {
 	}
 	
 	@Test
-	public void test_time_changing() {
+	public void testChangeTime() {
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_TIME, listener));
 		
 		clock.setMaximumTime(5000);
@@ -592,7 +592,7 @@ public class DefaultClockModelTests {
 	}
 	
 	@Test
-	public void test_time_elapse_count_up()
+	public void testElapseTime_countUp()
 	{
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_TIME, listener));
 		clock.setMaximumTime(5000);
@@ -610,7 +610,7 @@ public class DefaultClockModelTests {
 	}
 
 	@Test
-	public void test_time_elapse_count_down()
+	public void testElapseTime_countDown()
 	{
 		clock.setCountDirectionDown(true);
 		clock.setMaximumTime(5000);
@@ -626,7 +626,7 @@ public class DefaultClockModelTests {
 	}
 	
 	@Test
-	public void test_time_at_start_count_up()
+	public void testIsTimeAtStart_countUp()
 	{
 		clock.setMaximumTime(5000);
 		
@@ -645,7 +645,7 @@ public class DefaultClockModelTests {
 	}
 	
 	@Test
-	public void test_time_at_start_count_down()
+	public void testIsTimeAtStart_countDown()
 	{
 		clock.setCountDirectionDown(true);
 		clock.setMaximumTime(5000);
@@ -666,7 +666,7 @@ public class DefaultClockModelTests {
 	}
 	
 	@Test
-	public void test_reset_time()
+	public void testResetTime()
 	{
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_TIME, listener));
 		clock.setMaximumTime(5000);
@@ -688,7 +688,7 @@ public class DefaultClockModelTests {
 		assertEquals(5000, clock.getTime());
 	}
 	
-	public void test_running() {
+	public void testRunning() {
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_RUNNING, listener));
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_TIME, listener));
 		clock.setMaximumTime(30000);
@@ -732,7 +732,7 @@ public class DefaultClockModelTests {
 	}
 	
 	@Test
-	public void test_apply_rules_name()
+	public void testApplyRule_name()
 	{
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_NAME, listener));
 		clock.applyRule("Clock." + ID + ".Name", "New Name");
@@ -745,7 +745,7 @@ public class DefaultClockModelTests {
 	}
 	
 	@Test
-	public void test_apply_rules_direction()
+	public void testApplyRule_direction()
 	{
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_DIRECTION, listener));
 		clock.applyRule("Clock." + ID + ".Direction", true);
@@ -758,7 +758,7 @@ public class DefaultClockModelTests {
 	}
 	
 	@Test
-	public void test_apply_rules_min_number()
+	public void testApplyRule_minimumNumber()
 	{
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MINIMUM_NUMBER, listener));
 		clock.applyRule("Clock." + ID + ".MinimumNumber", 10);
@@ -776,7 +776,7 @@ public class DefaultClockModelTests {
 	}
 	
 	@Test
-	public void test_apply_rules_max_number()
+	public void testApplyRule_maximumNumber()
 	{
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MAXIMUM_NUMBER, listener));
 		clock.applyRule("Clock." + ID + ".MaximumNumber", 10);
@@ -794,7 +794,7 @@ public class DefaultClockModelTests {
 	}
 	
 	@Test
-	public void test_apply_rules_min_time()
+	public void testApplyRule_minimumTime()
 	{
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MINIMUM_TIME, listener));
 		clock.applyRule("Clock." + ID + ".MinimumTime", (long)10000);
@@ -812,7 +812,7 @@ public class DefaultClockModelTests {
 	}
 	
 	@Test
-	public void test_apply_rules_max_time()
+	public void testApplyRule_maximumTime()
 	{
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MAXIMUM_TIME, listener));
 		clock.applyRule("Clock." + ID + ".MaximumTime", (long)10000);

--- a/tests/com/carolinarollergirls/scoreboard/defaults/DefaultScoreboardModelTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/defaults/DefaultScoreboardModelTests.java
@@ -1,0 +1,1073 @@
+package com.carolinarollergirls.scoreboard.defaults;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.LinkedList;
+import java.util.Queue;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.carolinarollergirls.scoreboard.Clock;
+import com.carolinarollergirls.scoreboard.ScoreBoard;
+import com.carolinarollergirls.scoreboard.ScoreBoardManager;
+import com.carolinarollergirls.scoreboard.Team;
+import com.carolinarollergirls.scoreboard.event.ConditionalScoreBoardListener;
+import com.carolinarollergirls.scoreboard.event.ScoreBoardEvent;
+import com.carolinarollergirls.scoreboard.event.ScoreBoardListener;
+import com.carolinarollergirls.scoreboard.jetty.JettyServletScoreBoardController;
+import com.carolinarollergirls.scoreboard.model.ClockModel;
+
+public class DefaultScoreboardModelTests {
+	
+	private DefaultScoreBoardModel sbm;
+	private ScoreBoardEventProviderManager sbepm;
+	private Queue<ScoreBoardEvent> collectedEvents;
+	public ScoreBoardListener listener = new ScoreBoardListener() {
+		
+		@Override
+		public void scoreBoardChange(ScoreBoardEvent event) {
+			collectedEvents.add(event);
+		}
+	};
+	
+	@Before
+	public void setUp() throws Exception {
+		DefaultClockModel.updateClockTimerTask.setPaused(true);
+		ScoreBoardManager.setPropertyOverride(JettyServletScoreBoardController.class.getName() + ".html.dir", "html");
+		sbepm = ScoreBoardEventProviderManager.getSingleton();
+		sbm = new DefaultScoreBoardModel();
+		collectedEvents = new LinkedList<ScoreBoardEvent>();
+	}
+	
+	@After
+	public void tearDown() throws Exception {
+		DefaultClockModel.updateClockTimerTask.setPaused(false);
+	}
+
+	private void advance(long time_ms) {
+	    DefaultClockModel.updateClockTimerTask.advance(time_ms);
+	    sbepm.waitForEvents();
+	}
+	
+	@Test
+	public void testSetInPeriod() {
+		assertFalse(sbm.isInPeriod());
+		sbm.addScoreBoardListener(new ConditionalScoreBoardListener(sbm, ScoreBoard.EVENT_IN_PERIOD, listener));
+		
+		sbm.setInPeriod(true);
+		advance(0);
+		assertTrue(sbm.isInPeriod());
+		assertEquals(1, collectedEvents.size());
+		ScoreBoardEvent event = collectedEvents.poll();
+		assertTrue((Boolean)event.getValue());
+		assertFalse((Boolean)event.getPreviousValue());
+		
+		//check idempotency
+		sbm.setInPeriod(true);
+		advance(0);
+		assertTrue(sbm.isInPeriod());
+		assertEquals(1, collectedEvents.size());
+		
+		sbm.setInPeriod(false);
+		advance(0);
+		assertFalse(sbm.isInPeriod());
+	}
+
+	@Test
+	public void testSetInOvertime() {
+		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
+		((DefaultSettingsModel) sbm.getSettings()).set("Clock." + Clock.ID_LINEUP + ".Time", "30000");
+		lc.setMaximumTime(999999999);
+
+		assertFalse(lc.isCountDirectionDown());
+		assertFalse(sbm.isInOvertime());
+		sbm.addScoreBoardListener(new ConditionalScoreBoardListener(sbm, ScoreBoard.EVENT_IN_OVERTIME, listener));
+		
+		sbm.setInOvertime(true);
+		advance(0);
+		assertTrue(sbm.isInOvertime());
+		assertEquals(999999999, lc.getMaximumTime());
+		assertEquals(1, collectedEvents.size());
+		ScoreBoardEvent event = collectedEvents.poll();
+		assertTrue((Boolean)event.getValue());
+		assertFalse((Boolean)event.getPreviousValue());
+		
+		//check idempotency
+		sbm.setInOvertime(true);
+		advance(0);
+		assertTrue(sbm.isInOvertime());
+		assertEquals(1, collectedEvents.size());
+
+		sbm.setInOvertime(true);
+		advance(0);
+		assertTrue(sbm.isInOvertime());
+
+		sbm.setInOvertime(false);
+		advance(0);
+		assertFalse(sbm.isInOvertime());
+		assertEquals(999999999, lc.getMaximumTime());
+
+		//check that lineup clock maximum time is reset for countdown lineup clock
+		lc.setCountDirectionDown(true);
+		sbm.setInOvertime(false);
+		advance(0);
+		assertEquals(30000, lc.getMaximumTime());
+	}
+
+	@Test
+	public void testSetOfficialScore() {
+		assertFalse(sbm.isOfficialScore());
+		sbm.addScoreBoardListener(new ConditionalScoreBoardListener(sbm, ScoreBoard.EVENT_OFFICIAL_SCORE, listener));
+		
+		sbm.setOfficialScore(true);
+		advance(0);
+		assertTrue(sbm.isOfficialScore());
+		assertEquals(1, collectedEvents.size());
+		ScoreBoardEvent event = collectedEvents.poll();
+		assertTrue((Boolean)event.getValue());
+		assertFalse((Boolean)event.getPreviousValue());
+		
+		//check idempotency
+		sbm.setOfficialScore(true);
+		advance(0);
+		assertTrue(sbm.isOfficialScore());
+		assertEquals(1, collectedEvents.size());
+		
+		sbm.setOfficialScore(false);
+		advance(0);
+		assertFalse(sbm.isOfficialScore());
+	}
+
+	@Test
+	public void testSetOfficialReview() {
+		assertFalse(sbm.isOfficialReview());
+		sbm.addScoreBoardListener(new ConditionalScoreBoardListener(sbm, ScoreBoard.EVENT_OFFICIAL_REVIEW, listener));
+		
+		sbm.setOfficialReview(true);
+		advance(0);
+		assertTrue(sbm.isOfficialReview());
+		assertEquals(1, collectedEvents.size());
+		ScoreBoardEvent event = collectedEvents.poll();
+		assertTrue((Boolean)event.getValue());
+		assertFalse((Boolean)event.getPreviousValue());
+		
+		//check idempotency
+		sbm.setOfficialReview(true);
+		advance(0);
+		assertTrue(sbm.isOfficialReview());
+		assertEquals(1, collectedEvents.size());
+		
+		sbm.setOfficialReview(false);
+		advance(0);
+		assertFalse(sbm.isOfficialReview());
+	}
+
+	@Test
+	public void testSetTimeoutOwner() {
+		assertEquals("", sbm.getTimeoutOwner());
+		sbm.addScoreBoardListener(new ConditionalScoreBoardListener(sbm, ScoreBoard.EVENT_TIMEOUT_OWNER, listener));
+		
+		sbm.setTimeoutOwner("testOwner");
+		assertEquals("testOwner", sbm.getTimeoutOwner());
+		advance(0);
+		assertEquals(1, collectedEvents.size());
+		ScoreBoardEvent event = collectedEvents.poll();
+		assertEquals("testOwner", event.getValue());
+		assertEquals("", event.getPreviousValue());
+		
+		sbm.setTimeoutOwner("");
+		advance(0);
+		assertEquals("", sbm.getTimeoutOwner());
+		assertEquals(1, collectedEvents.size());
+		event = collectedEvents.poll();
+		assertEquals("", event.getValue());
+		assertEquals("testOwner", event.getPreviousValue());
+	}
+
+	@Test
+	public void testStartOvertime_default() {
+		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
+		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
+		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
+		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
+		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
+		((DefaultSettingsModel) sbm.getSettings()).set("Clock." + Clock.ID_LINEUP + ".OvertimeTime", "60000");
+
+		assertFalse(pc.isRunning());
+		pc.setTime(0);
+		assertTrue(pc.isTimeAtEnd());
+		pc.setNumber(pc.getMaximumNumber());
+		assertFalse(jc.isRunning());
+		jc.setTime(0);
+		assertTrue(jc.isTimeAtEnd());
+		assertFalse(lc.isRunning());
+		lc.setMaximumTime(30000);
+		assertFalse(tc.isRunning());
+		ic.start();
+		
+		sbm.startOvertime();
+		advance(0);
+
+		assertTrue(sbm.isInOvertime());
+		assertFalse(pc.isRunning());
+		assertFalse(jc.isRunning());
+		assertTrue(lc.isRunning());
+		assertEquals(60000, lc.getMaximumTime());
+		assertFalse(tc.isRunning());
+		assertFalse(ic.isRunning());
+	}
+
+	@Test
+	public void testStartOvertime_fromTimeout() {
+		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
+		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
+		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
+		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
+		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
+		
+		assertFalse(pc.isRunning());
+		pc.setTime(0);
+		assertTrue(pc.isTimeAtEnd());
+		pc.setNumber(pc.getMaximumNumber());
+		assertFalse(jc.isRunning());
+		jc.setTime(0);
+		assertTrue(jc.isTimeAtEnd());
+		assertFalse(lc.isRunning());
+		tc.start();
+		tc.setNumber(6);
+		ic.start();
+		
+		sbm.startOvertime();
+		advance(0);
+		
+		assertTrue(sbm.isInOvertime());
+		assertFalse(pc.isRunning());
+		assertFalse(jc.isRunning());
+		assertTrue(lc.isRunning());
+		assertFalse(tc.isRunning());
+		assertEquals(7, tc.getNumber());
+		assertFalse(ic.isRunning());
+	}
+
+	@Test
+	public void testStartOvertime_notLastPeriod() {
+		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
+		
+		assertNotEquals(pc.getNumber(), pc.getMaximumNumber());
+		
+		sbm.startOvertime();
+
+		assertFalse(sbm.isInOvertime());
+	}
+
+	@Test
+	public void testStartOvertime_periodRunning() {
+		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
+		
+		pc.start();
+		
+		sbm.startOvertime();
+
+		assertFalse(sbm.isInOvertime());
+	}
+
+	@Test
+	public void testStartOvertime_jamRunning() {
+		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
+		
+		pc.start();
+		
+		sbm.startOvertime();
+
+		assertFalse(sbm.isInOvertime());
+	}
+
+	@Test
+	public void testStartJam_duringPeriod() {
+		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
+		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
+		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
+		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
+		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
+
+		pc.start();
+		assertEquals(1, pc.getNumber());
+		assertFalse(jc.isRunning());
+		jc.setTime(34000);
+		jc.setNumber(5);
+		lc.start();
+		assertFalse(tc.isRunning());
+		assertFalse(ic.isRunning());
+		
+		sbm.startJam();
+		advance(0);
+		
+		assertTrue(pc.isRunning());
+		assertEquals(1, pc.getNumber());
+		assertTrue(jc.isRunning());
+		assertTrue(jc.isTimeAtStart());
+		assertEquals(6, jc.getNumber());
+		assertFalse(lc.isRunning());
+		assertFalse(tc.isRunning());
+		assertFalse(ic.isRunning());
+	}
+
+	@Test
+	public void testStartJam_fromTimeout() {
+		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
+		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
+		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
+		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
+		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
+
+		assertFalse(pc.isRunning());
+		assertEquals(1, pc.getNumber());
+		assertFalse(jc.isRunning());
+		jc.setTime(100000);
+		jc.setNumber(17);
+		assertFalse(lc.isRunning());
+		tc.setNumber(3);
+		sbm.setTimeoutOwner("2");
+		sbm.setOfficialReview(true);
+		tc.start();
+		assertFalse(ic.isRunning());
+		sbm.getTeamModel("2").setInTimeout(true);
+		sbm.getTeamModel("2").setInOfficialReview(true);
+		
+		sbm.startJam();
+		advance(0);
+		
+		assertTrue(pc.isRunning());
+		assertEquals(1, pc.getNumber());
+		assertTrue(jc.isRunning());
+		assertTrue(jc.isTimeAtStart());
+		assertEquals(18, jc.getNumber());
+		assertFalse(lc.isRunning());
+		assertFalse(tc.isRunning());
+		assertEquals(4, tc.getNumber());
+		assertEquals("", sbm.getTimeoutOwner());
+		assertFalse(sbm.isOfficialReview());
+		assertFalse(ic.isRunning());
+		assertFalse(sbm.getTeamModel("2").inTimeout());
+		assertFalse(sbm.getTeamModel("2").inOfficialReview());
+	}
+
+	@Test
+	public void testStartJam_fromLineupAfterTimeout() {
+		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
+		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
+		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
+		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
+		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
+
+		assertFalse(pc.isRunning());
+		assertEquals(1, pc.getNumber());
+		assertFalse(jc.isRunning());
+		jc.setTime(45000);
+		jc.setNumber(22);
+		lc.start();
+		assertFalse(tc.isRunning());
+		assertFalse(ic.isRunning());
+		
+		sbm.startJam();
+		advance(0);
+		
+		assertTrue(pc.isRunning());
+		assertEquals(1, pc.getNumber());
+		assertTrue(jc.isRunning());
+		assertTrue(jc.isTimeAtStart());
+		assertEquals(23, jc.getNumber());
+		assertFalse(lc.isRunning());
+		assertFalse(tc.isRunning());
+		assertFalse(ic.isRunning());
+	}
+
+	@Test
+	public void testStartJam_startOfPeriod() {
+		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
+		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
+		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
+		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
+		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
+
+		assertFalse(pc.isRunning());
+		assertTrue(pc.isTimeAtStart());
+		assertEquals(1, pc.getNumber());
+		assertFalse(jc.isRunning());
+		assertTrue(jc.isTimeAtStart());
+		assertEquals(1, jc.getNumber());
+		assertFalse(lc.isRunning());
+		assertFalse(tc.isRunning());
+		assertFalse(ic.isRunning());
+		
+		sbm.startJam();
+		advance(0);
+		
+		assertTrue(pc.isRunning());
+		assertEquals(1, pc.getNumber());
+		assertTrue(jc.isRunning());
+		assertEquals(1, jc.getNumber());
+		assertFalse(lc.isRunning());
+		assertFalse(tc.isRunning());
+		assertFalse(ic.isRunning());
+	}
+
+	@Test
+	public void testStartJam_lateInIntermission() {
+		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
+		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
+		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
+		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
+		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
+
+		assertFalse(pc.isRunning());
+		pc.setTime(pc.getMinimumTime());
+		assertTrue(pc.isTimeAtEnd());
+		assertEquals(1, pc.getNumber());
+		assertFalse(jc.isRunning());
+		jc.setTime(55000);
+		jc.setNumber(21);
+		assertFalse(lc.isRunning());
+		assertFalse(tc.isRunning());
+		ic.setNumber(1);
+		assertTrue(ic.isCountDirectionDown());
+		ic.setMaximumTime(900000);
+		ic.setTime(55000);
+		ic.start();
+		assertFalse(sbm.isInPeriod());
+
+		sbm.startJam();
+		advance(0);
+		
+		assertTrue(pc.isRunning());
+		assertEquals(2, pc.getNumber());
+		assertTrue(jc.isRunning());
+		assertEquals(1, jc.getNumber());
+		assertTrue(jc.isTimeAtStart());
+		assertFalse(lc.isRunning());
+		assertFalse(tc.isRunning());
+		assertFalse(ic.isRunning());
+		assertTrue(sbm.isInPeriod());
+	}
+
+	@Test
+	public void testStartJam_earlyInIntermission() {
+		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
+		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
+		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
+		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
+		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
+
+		assertFalse(pc.isRunning());
+		pc.setTime(pc.getMinimumTime());
+		assertTrue(pc.isTimeAtEnd());
+		assertEquals(1, pc.getNumber());
+		assertFalse(jc.isRunning());
+		jc.setTime(55000);
+		jc.setNumber(21);
+		assertFalse(lc.isRunning());
+		assertFalse(tc.isRunning());
+		ic.setNumber(1);
+		assertTrue(ic.isCountDirectionDown());
+		ic.setMaximumTime(900000);
+		ic.setTime(890000);
+		ic.start();
+		assertFalse(sbm.isInPeriod());
+
+		sbm.startJam();
+		advance(1000);
+		
+		assertFalse(pc.isRunning());
+		assertEquals(1, pc.getNumber());
+		assertTrue(jc.isRunning());
+		assertEquals(22, jc.getNumber());
+		assertEquals(1000, jc.getTimeElapsed());
+		assertFalse(lc.isRunning());
+		assertFalse(tc.isRunning());
+		assertFalse(ic.isRunning());
+		assertTrue(sbm.isInPeriod());
+	}
+
+	@Test
+	public void testStartJam_jamRunning() {
+		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
+
+		jc.setTime(74000);
+		jc.setNumber(9);
+		jc.start();
+		
+		sbm.startJam();
+		advance(0);
+		
+		assertTrue(jc.isRunning());
+		assertEquals(9, jc.getNumber());
+		assertEquals(74000, jc.getTime());
+	}
+
+	@Test
+	public void testStopJam_duringPeriod() {
+		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
+		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
+		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
+		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
+		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
+
+		pc.start();
+		jc.start();
+		assertFalse(lc.isRunning());
+		lc.setTime(50000);
+		assertFalse(tc.isRunning());
+		assertFalse(ic.isRunning());
+		sbm.getTeamModel("1").setStarPass(true);
+		sbm.getTeamModel("2").setLeadJammer(Team.LEAD_NO_LEAD);
+		
+		sbm.stopJam();
+		advance(0);
+		
+		assertTrue(pc.isRunning());
+		assertFalse(jc.isRunning());
+		assertTrue(lc.isRunning());
+		assertTrue(lc.isTimeAtStart());
+		assertFalse(tc.isRunning());
+		assertFalse(ic.isRunning());
+		assertFalse(sbm.getTeamModel("1").isStarPass());
+		assertEquals(Team.LEAD_NO_LEAD, sbm.getTeamModel("2").getLeadJammer());
+	}
+
+	@Test
+	public void testStopJam_endOfPeriod() {
+		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
+		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
+		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
+		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
+		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
+
+		assertFalse(pc.isRunning());
+		pc.setTime(0);
+		assertTrue(pc.isTimeAtEnd());
+		pc.setNumber(2);
+		jc.start();
+		assertFalse(lc.isRunning());
+		assertFalse(tc.isRunning());
+		assertFalse(ic.isRunning());
+		ic.setNumber(0);
+		ic.setMaximumTime(90000000);
+		ic.setTime(784000);
+		sbm.setInPeriod(true);
+		sbm.setOfficialScore(true);
+		
+		sbm.stopJam();
+		advance(0);
+		
+		assertFalse(pc.isRunning());
+		assertTrue(pc.isTimeAtEnd());
+		assertFalse(jc.isRunning());
+		assertFalse(lc.isRunning());
+		assertFalse(tc.isRunning());
+		assertTrue(ic.isRunning());
+		assertEquals(2, ic.getNumber());
+		assertEquals(sbm.getSettings().getLong("Clock." + Clock.ID_INTERMISSION + ".Time"), ic.getMaximumTime());
+		assertTrue(ic.isTimeAtStart());
+		assertFalse(sbm.isInPeriod());
+		assertFalse(sbm.isOfficialScore());
+	}
+
+	@Test
+	public void testStopJam_endTimeoutDuringPeriod() {
+		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
+		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
+		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
+		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
+		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
+
+		assertFalse(pc.isRunning());
+		assertFalse(pc.isTimeAtEnd());
+		assertFalse(jc.isRunning());
+		assertFalse(lc.isRunning());
+		lc.setTime(37000);
+		tc.start();
+		tc.setNumber(4);
+		assertFalse(ic.isRunning());
+		sbm.setTimeoutOwner("O");
+		sbm.setOfficialReview(true);
+		
+		sbm.stopJam();
+		advance(0);
+		
+		assertFalse(pc.isRunning());
+		assertFalse(jc.isRunning());
+		assertTrue(lc.isRunning());
+		assertTrue(lc.isTimeAtStart());
+		assertFalse(tc.isRunning());
+		assertEquals(5, tc.getNumber());
+		assertFalse(ic.isRunning());
+		assertEquals("", sbm.getTimeoutOwner());
+		assertFalse(sbm.isOfficialReview());
+	}
+
+	@Test
+	public void testStopJam_endTimeoutAfterPeriod() {
+		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
+		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
+		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
+		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
+		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
+
+		assertFalse(pc.isRunning());
+		pc.setTime(0);
+		assertTrue(pc.isTimeAtEnd());
+		assertFalse(jc.isRunning());
+		assertFalse(lc.isRunning());
+		tc.start();
+		tc.setNumber(3);
+		assertFalse(ic.isRunning());
+		
+		sbm.stopJam();
+		advance(0);
+		
+		assertFalse(pc.isRunning());
+		assertFalse(jc.isRunning());
+		assertFalse(lc.isRunning());
+		assertFalse(tc.isRunning());
+		assertEquals(4, tc.getNumber());
+		assertTrue(ic.isRunning());
+		assertTrue(ic.isTimeAtStart());
+	}
+
+	@Test
+	public void testStopJam_lineupEarlyInIntermission() {
+		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
+		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
+		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
+		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
+		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
+
+		assertFalse(pc.isRunning());
+		pc.setNumber(1);
+		assertFalse(jc.isRunning());
+		assertFalse(lc.isRunning());
+		lc.setTime(30000);
+		assertFalse(tc.isRunning());
+		assertTrue(ic.isCountDirectionDown());
+		ic.setMaximumTime(900000);
+		ic.setTime(880000);
+		ic.start();
+		
+		sbm.stopJam();
+		advance(0);
+		
+		assertFalse(pc.isRunning());
+		assertEquals(1, pc.getNumber());
+		assertFalse(jc.isRunning());
+		assertTrue(lc.isRunning());
+		assertTrue(lc.isTimeAtStart());
+		assertFalse(tc.isRunning());
+		assertFalse(ic.isRunning());
+	}
+
+	@Test
+	public void testStopJam_lineupLateInIntermission() {
+		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
+		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
+		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
+		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
+		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
+
+		assertFalse(pc.isRunning());
+		pc.setNumber(1);
+		assertTrue(pc.isCountDirectionDown());
+		pc.setTime(0);
+		assertFalse(jc.isRunning());
+		assertFalse(lc.isRunning());
+		assertFalse(lc.isCountDirectionDown());
+		lc.setTime(30000);
+		assertFalse(tc.isRunning());
+		assertTrue(ic.isCountDirectionDown());
+		ic.setMaximumTime(900000);
+		ic.setTime(43000);
+		ic.start();
+		
+		sbm.stopJam();
+		advance(0);
+		
+		assertFalse(pc.isRunning());
+		assertEquals(2, pc.getNumber());
+		assertTrue(pc.isTimeAtStart());
+		assertFalse(jc.isRunning());
+		assertTrue(lc.isRunning());
+		assertTrue(lc.isTimeAtStart());
+		assertFalse(tc.isRunning());
+		assertFalse(ic.isRunning());
+	}
+
+	@Test
+	public void testTimeout_fromLineup() {
+		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
+		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
+		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
+		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
+		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
+
+		pc.start();
+		assertFalse(jc.isRunning());
+		lc.start();
+		assertFalse(tc.isRunning());
+		tc.setTime(23000);
+		tc.setNumber(2);
+		assertFalse(ic.isRunning());
+		advance(0);
+		
+		sbm.timeout();
+		advance(0);
+		
+		assertFalse(pc.isRunning());
+		assertFalse(jc.isRunning());
+		assertFalse(lc.isRunning());
+		assertTrue(tc.isRunning());
+		assertTrue(tc.isTimeAtStart());
+		assertEquals(2, tc.getNumber());
+		assertFalse(ic.isRunning());
+		assertEquals("", sbm.getTimeoutOwner());
+		assertFalse(sbm.isOfficialReview());
+	}
+
+	@Test
+	public void testTimeout_fromJam() {
+		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
+		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
+		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
+		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
+		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
+
+		pc.start();
+		jc.start();
+		assertFalse(lc.isRunning());
+		assertFalse(tc.isRunning());
+		assertFalse(ic.isRunning());
+		advance(0);
+		
+		sbm.timeout();
+		advance(0);
+		
+		assertFalse(pc.isRunning());
+		assertFalse(jc.isRunning());
+		assertFalse(lc.isRunning());
+		assertTrue(tc.isRunning());
+		assertTrue(tc.isTimeAtStart());
+		assertFalse(ic.isRunning());
+	}
+
+	@Test
+	public void testTimeout_fromIntermission() {
+		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
+		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
+		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
+		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
+		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
+
+		assertFalse(pc.isRunning());
+		assertFalse(jc.isRunning());
+		assertFalse(lc.isRunning());
+		assertFalse(tc.isRunning());
+		ic.start();
+		advance(0);
+		
+		sbm.timeout();
+		advance(0);
+		
+		assertFalse(pc.isRunning());
+		assertFalse(jc.isRunning());
+		assertFalse(lc.isRunning());
+		assertTrue(tc.isRunning());
+		assertTrue(tc.isTimeAtStart());
+		assertFalse(ic.isRunning());
+	}
+
+	@Test
+	public void testTimeout_AfterGame() {
+		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
+		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
+		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
+		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
+		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
+
+		assertFalse(pc.isRunning());
+		assertFalse(jc.isRunning());
+		assertFalse(lc.isRunning());
+		assertFalse(tc.isRunning());
+		assertFalse(ic.isRunning());
+		advance(0);
+		
+		sbm.timeout();
+		advance(0);
+		
+		assertFalse(pc.isRunning());
+		assertFalse(jc.isRunning());
+		assertFalse(lc.isRunning());
+		assertTrue(tc.isRunning());
+		assertTrue(tc.isTimeAtStart());
+		assertFalse(ic.isRunning());
+	}
+
+	@Test
+	public void testTimeout_fromTimeout() {
+		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
+		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
+		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
+		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
+		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
+
+		assertFalse(pc.isRunning());
+		assertFalse(jc.isRunning());
+		assertFalse(lc.isRunning());
+		tc.start();
+		tc.setTime(24000);
+		tc.setNumber(7);
+		assertFalse(ic.isRunning());
+		sbm.setTimeoutOwner("");
+		advance(0);
+		
+		sbm.timeout();
+		advance(0);
+		
+		assertFalse(pc.isRunning());
+		assertFalse(jc.isRunning());
+		assertFalse(lc.isRunning());
+		assertTrue(tc.isRunning());
+		assertEquals(24000, tc.getTime());
+		assertEquals(7, tc.getNumber());
+		assertFalse(ic.isRunning());
+		assertEquals("O", sbm.getTimeoutOwner());
+		
+		sbm.timeout();
+		advance(0);
+		
+		assertEquals("", sbm.getTimeoutOwner());
+	}
+
+	@Test
+	public void testTimeoutTeamModel() {
+		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
+		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
+		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
+		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
+		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
+
+		sbm.setTimeoutOwner("");
+		advance(0);
+		
+		sbm.timeout(sbm.getTeamModel("1"));
+		advance(0);
+
+		assertFalse(pc.isRunning());
+		assertFalse(jc.isRunning());
+		assertFalse(lc.isRunning());
+		assertTrue(tc.isRunning());
+		assertFalse(ic.isRunning());
+		assertEquals("1", sbm.getTimeoutOwner());
+		assertFalse(sbm.isOfficialReview());
+
+		sbm.timeout(sbm.getTeamModel("1"));
+		advance(0);
+		assertEquals("1", sbm.getTimeoutOwner());
+	}
+
+	@Test
+	public void testTimeoutTeamModelBoolean() {
+		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
+		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
+		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
+		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
+		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
+
+		sbm.setTimeoutOwner("");
+		advance(0);
+		
+		sbm.timeout(sbm.getTeamModel("2"), false);
+		advance(0);
+
+		assertFalse(pc.isRunning());
+		assertFalse(jc.isRunning());
+		assertFalse(lc.isRunning());
+		assertTrue(tc.isRunning());
+		assertFalse(ic.isRunning());
+		assertEquals("2", sbm.getTimeoutOwner());
+		assertFalse(sbm.isOfficialReview());
+
+		sbm.timeout(sbm.getTeamModel("1"), true);
+		advance(0);
+		assertEquals("1", sbm.getTimeoutOwner());
+		assertTrue(sbm.isOfficialReview());
+	}
+	
+	@Test
+	public void testPeriodClockEnd_duringLineup() {
+		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
+		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
+		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
+		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
+		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
+
+		pc.start();
+		assertTrue(pc.isCountDirectionDown());
+		pc.setTime(2000);
+		pc.setNumber(2);
+		assertFalse(jc.isRunning());
+		lc.start();
+		assertFalse(tc.isRunning());
+		assertFalse(ic.isRunning());
+		ic.setNumber(0);
+		ic.setTime(3000);
+		advance(0);
+		
+		advance(2000);
+		
+		assertFalse(pc.isRunning());
+		assertEquals(2, pc.getNumber());
+		assertFalse(jc.isRunning());
+		assertFalse(lc.isRunning());
+		assertFalse(tc.isRunning());
+		assertTrue(ic.isRunning());
+		assertTrue(ic.isTimeAtStart());
+		assertEquals(2, ic.getNumber());
+	}
+	
+	@Test
+	public void testPeriodClockEnd_duringJam() {
+		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
+		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
+		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
+		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
+		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
+
+		pc.start();
+		assertTrue(pc.isCountDirectionDown());
+		pc.setTime(2000);
+		jc.start();
+		jc.setNumber(17);
+		assertTrue(jc.isCountDirectionDown());
+		jc.setTime(10000);
+		assertFalse(lc.isRunning());
+		assertFalse(tc.isRunning());
+		assertFalse(ic.isRunning());
+		advance(0);
+		
+		advance(2000);
+		
+		assertFalse(pc.isRunning());
+		assertTrue(jc.isRunning());
+		assertEquals(17, jc.getNumber());
+		assertEquals(8000, jc.getTime());
+		assertFalse(lc.isRunning());
+		assertFalse(tc.isRunning());
+		assertFalse(ic.isRunning());
+	}
+	
+	@Test
+	public void testJamClockEnd() {
+		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
+		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
+		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
+		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
+		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
+
+		pc.start();
+		jc.start();
+		assertTrue(jc.isCountDirectionDown());
+		jc.setTime(3000);
+		assertFalse(lc.isRunning());
+		lc.setTime(50000);
+		assertFalse(tc.isRunning());
+		assertFalse(ic.isRunning());
+		
+		advance(3000);
+		
+		assertTrue(pc.isRunning());
+		assertFalse(jc.isRunning());
+		assertTrue(lc.isRunning());
+		assertTrue(lc.isTimeAtStart());
+		assertFalse(tc.isRunning());
+		assertFalse(ic.isRunning());
+	}
+
+	@Test
+	public void testIntermissionClockEnd_notLastPeriod() {
+		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
+		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
+		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
+		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
+		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
+
+		assertFalse(pc.isRunning());
+		assertTrue(pc.isCountDirectionDown());
+		pc.setTime(0);
+		pc.setNumber(1);
+		assertFalse(jc.isRunning());
+		jc.setTime(4000);
+		jc.setNumber(20);
+		assertFalse(lc.isRunning());
+		assertFalse(tc.isRunning());
+		ic.start();
+		assertTrue(ic.isCountDirectionDown());
+		ic.setNumber(1);
+		ic.setTime(3000);
+		advance(0);
+		
+		advance(3000);
+		
+		assertFalse(pc.isRunning());
+		assertTrue(pc.isTimeAtStart());
+		assertEquals(2, pc.getNumber());
+		assertFalse(jc.isRunning());
+		assertEquals(1, jc.getNumber());
+		assertTrue(jc.isTimeAtStart());
+		assertFalse(lc.isRunning());
+		assertFalse(tc.isRunning());
+		assertFalse(ic.isRunning());
+		assertTrue(ic.isTimeAtEnd());
+		assertEquals(1, ic.getNumber());
+	}
+
+	@Test
+	public void testIntermissionClockEnd_lastPeriod() {
+		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
+		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
+		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
+		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
+		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
+
+		assertFalse(pc.isRunning());
+		assertTrue(pc.isCountDirectionDown());
+		pc.setTime(0);
+		pc.setNumber(pc.getMaximumNumber());
+		assertFalse(jc.isRunning());
+		jc.setNumber(21);
+		jc.setTime(56000);
+		assertFalse(lc.isRunning());
+		assertFalse(tc.isRunning());
+		ic.start();
+		assertTrue(ic.isCountDirectionDown());
+		ic.setNumber(pc.getMaximumNumber());
+		ic.setTime(3000);
+		advance(0);
+		
+		advance(3000);
+		
+		assertFalse(pc.isRunning());
+		assertTrue(pc.isTimeAtEnd());
+		assertEquals(pc.getMaximumNumber(), pc.getNumber());
+		assertFalse(jc.isRunning());
+		assertEquals(21, jc.getNumber());
+		assertEquals(56000, jc.getTime());
+		assertFalse(lc.isRunning());
+		assertFalse(tc.isRunning());
+		assertFalse(ic.isRunning());
+		assertTrue(ic.isTimeAtEnd());
+		assertEquals(pc.getMaximumNumber(), ic.getNumber());
+	}
+}

--- a/tests/com/carolinarollergirls/scoreboard/defaults/DefaultScoreboardModelTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/defaults/DefaultScoreboardModelTests.java
@@ -26,9 +26,14 @@ public class DefaultScoreboardModelTests {
 	
 	private DefaultScoreBoardModel sbm;
 	private ScoreBoardEventProviderManager sbepm;
+	private ClockModel pc;
+	private ClockModel jc;
+	private ClockModel lc;
+	private ClockModel tc;
+	private ClockModel ic;
 	private Queue<ScoreBoardEvent> collectedEvents;
 	public ScoreBoardListener listener = new ScoreBoardListener() {
-		
+	
 		@Override
 		public void scoreBoardChange(ScoreBoardEvent event) {
 			collectedEvents.add(event);
@@ -41,6 +46,11 @@ public class DefaultScoreboardModelTests {
 		ScoreBoardManager.setPropertyOverride(JettyServletScoreBoardController.class.getName() + ".html.dir", "html");
 		sbepm = ScoreBoardEventProviderManager.getSingleton();
 		sbm = new DefaultScoreBoardModel();
+		pc = sbm.getClockModel(Clock.ID_PERIOD);      
+		jc = sbm.getClockModel(Clock.ID_JAM);         
+		lc = sbm.getClockModel(Clock.ID_LINEUP);      
+		tc = sbm.getClockModel(Clock.ID_TIMEOUT);     
+		ic = sbm.getClockModel(Clock.ID_INTERMISSION);
 		collectedEvents = new LinkedList<ScoreBoardEvent>();
 	}
 	
@@ -81,7 +91,7 @@ public class DefaultScoreboardModelTests {
 	@Test
 	public void testSetInOvertime() {
 		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
-		((DefaultSettingsModel) sbm.getSettings()).set("Clock." + Clock.ID_LINEUP + ".Time", "30000");
+		(sbm.getSettingsModel()).set("Clock." + Clock.ID_LINEUP + ".Time", "30000");
 		lc.setMaximumTime(999999999);
 
 		assertFalse(lc.isCountDirectionDown());
@@ -191,12 +201,7 @@ public class DefaultScoreboardModelTests {
 
 	@Test
 	public void testStartOvertime_default() {
-		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
-		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
-		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
-		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
-		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
-		((DefaultSettingsModel) sbm.getSettings()).set("Clock." + Clock.ID_LINEUP + ".OvertimeTime", "60000");
+		(sbm.getSettingsModel()).set("Clock." + Clock.ID_LINEUP + ".OvertimeTime", "60000");
 
 		assertFalse(pc.isRunning());
 		pc.setTime(0);
@@ -224,12 +229,6 @@ public class DefaultScoreboardModelTests {
 
 	@Test
 	public void testStartOvertime_fromTimeout() {
-		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
-		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
-		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
-		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
-		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
-		
 		assertFalse(pc.isRunning());
 		pc.setTime(0);
 		assertTrue(pc.isTimeAtEnd());
@@ -256,8 +255,6 @@ public class DefaultScoreboardModelTests {
 
 	@Test
 	public void testStartOvertime_notLastPeriod() {
-		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
-		
 		assertNotEquals(pc.getNumber(), pc.getMaximumNumber());
 		
 		sbm.startOvertime();
@@ -267,8 +264,6 @@ public class DefaultScoreboardModelTests {
 
 	@Test
 	public void testStartOvertime_periodRunning() {
-		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
-		
 		pc.start();
 		
 		sbm.startOvertime();
@@ -278,8 +273,6 @@ public class DefaultScoreboardModelTests {
 
 	@Test
 	public void testStartOvertime_jamRunning() {
-		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
-		
 		pc.start();
 		
 		sbm.startOvertime();
@@ -289,12 +282,6 @@ public class DefaultScoreboardModelTests {
 
 	@Test
 	public void testStartJam_duringPeriod() {
-		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
-		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
-		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
-		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
-		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
-
 		pc.start();
 		assertEquals(1, pc.getNumber());
 		assertFalse(jc.isRunning());
@@ -319,12 +306,6 @@ public class DefaultScoreboardModelTests {
 
 	@Test
 	public void testStartJam_fromTimeout() {
-		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
-		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
-		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
-		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
-		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
-
 		assertFalse(pc.isRunning());
 		assertEquals(1, pc.getNumber());
 		assertFalse(jc.isRunning());
@@ -359,12 +340,6 @@ public class DefaultScoreboardModelTests {
 
 	@Test
 	public void testStartJam_fromLineupAfterTimeout() {
-		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
-		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
-		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
-		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
-		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
-
 		assertFalse(pc.isRunning());
 		assertEquals(1, pc.getNumber());
 		assertFalse(jc.isRunning());
@@ -389,12 +364,6 @@ public class DefaultScoreboardModelTests {
 
 	@Test
 	public void testStartJam_startOfPeriod() {
-		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
-		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
-		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
-		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
-		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
-
 		assertFalse(pc.isRunning());
 		assertTrue(pc.isTimeAtStart());
 		assertEquals(1, pc.getNumber());
@@ -419,12 +388,6 @@ public class DefaultScoreboardModelTests {
 
 	@Test
 	public void testStartJam_lateInIntermission() {
-		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
-		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
-		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
-		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
-		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
-
 		assertFalse(pc.isRunning());
 		pc.setTime(pc.getMinimumTime());
 		assertTrue(pc.isTimeAtEnd());
@@ -457,12 +420,6 @@ public class DefaultScoreboardModelTests {
 
 	@Test
 	public void testStartJam_earlyInIntermission() {
-		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
-		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
-		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
-		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
-		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
-
 		assertFalse(pc.isRunning());
 		pc.setTime(pc.getMinimumTime());
 		assertTrue(pc.isTimeAtEnd());
@@ -495,8 +452,6 @@ public class DefaultScoreboardModelTests {
 
 	@Test
 	public void testStartJam_jamRunning() {
-		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
-
 		jc.setTime(74000);
 		jc.setNumber(9);
 		jc.start();
@@ -511,12 +466,6 @@ public class DefaultScoreboardModelTests {
 
 	@Test
 	public void testStopJam_duringPeriod() {
-		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
-		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
-		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
-		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
-		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
-
 		pc.start();
 		jc.start();
 		assertFalse(lc.isRunning());
@@ -541,12 +490,6 @@ public class DefaultScoreboardModelTests {
 
 	@Test
 	public void testStopJam_endOfPeriod() {
-		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
-		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
-		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
-		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
-		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
-
 		assertFalse(pc.isRunning());
 		pc.setTime(0);
 		assertTrue(pc.isTimeAtEnd());
@@ -579,12 +522,6 @@ public class DefaultScoreboardModelTests {
 
 	@Test
 	public void testStopJam_endTimeoutDuringPeriod() {
-		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
-		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
-		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
-		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
-		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
-
 		assertFalse(pc.isRunning());
 		assertFalse(pc.isTimeAtEnd());
 		assertFalse(jc.isRunning());
@@ -612,12 +549,6 @@ public class DefaultScoreboardModelTests {
 
 	@Test
 	public void testStopJam_endTimeoutAfterPeriod() {
-		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
-		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
-		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
-		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
-		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
-
 		assertFalse(pc.isRunning());
 		pc.setTime(0);
 		assertTrue(pc.isTimeAtEnd());
@@ -641,12 +572,6 @@ public class DefaultScoreboardModelTests {
 
 	@Test
 	public void testStopJam_lineupEarlyInIntermission() {
-		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
-		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
-		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
-		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
-		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
-
 		assertFalse(pc.isRunning());
 		pc.setNumber(1);
 		assertFalse(jc.isRunning());
@@ -672,12 +597,6 @@ public class DefaultScoreboardModelTests {
 
 	@Test
 	public void testStopJam_lineupLateInIntermission() {
-		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
-		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
-		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
-		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
-		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
-
 		assertFalse(pc.isRunning());
 		pc.setNumber(1);
 		assertTrue(pc.isCountDirectionDown());
@@ -707,12 +626,6 @@ public class DefaultScoreboardModelTests {
 
 	@Test
 	public void testTimeout_fromLineup() {
-		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
-		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
-		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
-		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
-		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
-
 		pc.start();
 		assertFalse(jc.isRunning());
 		lc.start();
@@ -738,12 +651,6 @@ public class DefaultScoreboardModelTests {
 
 	@Test
 	public void testTimeout_fromJam() {
-		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
-		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
-		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
-		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
-		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
-
 		pc.start();
 		jc.start();
 		assertFalse(lc.isRunning());
@@ -764,12 +671,6 @@ public class DefaultScoreboardModelTests {
 
 	@Test
 	public void testTimeout_fromIntermission() {
-		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
-		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
-		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
-		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
-		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
-
 		assertFalse(pc.isRunning());
 		assertFalse(jc.isRunning());
 		assertFalse(lc.isRunning());
@@ -790,12 +691,6 @@ public class DefaultScoreboardModelTests {
 
 	@Test
 	public void testTimeout_AfterGame() {
-		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
-		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
-		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
-		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
-		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
-
 		assertFalse(pc.isRunning());
 		assertFalse(jc.isRunning());
 		assertFalse(lc.isRunning());
@@ -816,12 +711,6 @@ public class DefaultScoreboardModelTests {
 
 	@Test
 	public void testTimeout_fromTimeout() {
-		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
-		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
-		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
-		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
-		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
-
 		assertFalse(pc.isRunning());
 		assertFalse(jc.isRunning());
 		assertFalse(lc.isRunning());
@@ -852,12 +741,6 @@ public class DefaultScoreboardModelTests {
 
 	@Test
 	public void testTimeoutTeamModel() {
-		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
-		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
-		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
-		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
-		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
-
 		sbm.setTimeoutOwner("");
 		advance(0);
 		
@@ -879,12 +762,6 @@ public class DefaultScoreboardModelTests {
 
 	@Test
 	public void testTimeoutTeamModelBoolean() {
-		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
-		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
-		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
-		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
-		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
-
 		sbm.setTimeoutOwner("");
 		advance(0);
 		
@@ -907,12 +784,6 @@ public class DefaultScoreboardModelTests {
 	
 	@Test
 	public void testPeriodClockEnd_duringLineup() {
-		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
-		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
-		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
-		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
-		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
-
 		pc.start();
 		assertTrue(pc.isCountDirectionDown());
 		pc.setTime(2000);
@@ -939,12 +810,6 @@ public class DefaultScoreboardModelTests {
 	
 	@Test
 	public void testPeriodClockEnd_duringJam() {
-		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
-		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
-		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
-		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
-		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
-
 		pc.start();
 		assertTrue(pc.isCountDirectionDown());
 		pc.setTime(2000);
@@ -970,12 +835,6 @@ public class DefaultScoreboardModelTests {
 	
 	@Test
 	public void testJamClockEnd() {
-		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
-		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
-		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
-		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
-		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
-
 		pc.start();
 		jc.start();
 		assertTrue(jc.isCountDirectionDown());
@@ -997,12 +856,6 @@ public class DefaultScoreboardModelTests {
 
 	@Test
 	public void testIntermissionClockEnd_notLastPeriod() {
-		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
-		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
-		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
-		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
-		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
-
 		assertFalse(pc.isRunning());
 		assertTrue(pc.isCountDirectionDown());
 		pc.setTime(0);
@@ -1035,12 +888,6 @@ public class DefaultScoreboardModelTests {
 
 	@Test
 	public void testIntermissionClockEnd_lastPeriod() {
-		ClockModel pc = sbm.getClockModel(Clock.ID_PERIOD);
-		ClockModel jc = sbm.getClockModel(Clock.ID_JAM);
-		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
-		ClockModel tc = sbm.getClockModel(Clock.ID_TIMEOUT);
-		ClockModel ic = sbm.getClockModel(Clock.ID_INTERMISSION);
-
 		assertFalse(pc.isRunning());
 		assertTrue(pc.isCountDirectionDown());
 		pc.setTime(0);

--- a/tests/com/carolinarollergirls/scoreboard/defaults/DefaultTeamModelTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/defaults/DefaultTeamModelTests.java
@@ -1,0 +1,502 @@
+package com.carolinarollergirls.scoreboard.defaults;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.carolinarollergirls.scoreboard.Ruleset;
+import com.carolinarollergirls.scoreboard.Settings;
+import com.carolinarollergirls.scoreboard.Team;
+import com.carolinarollergirls.scoreboard.event.ConditionalScoreBoardListener;
+import com.carolinarollergirls.scoreboard.event.ScoreBoardEvent;
+import com.carolinarollergirls.scoreboard.event.ScoreBoardListener;
+import com.carolinarollergirls.scoreboard.model.ScoreBoardModel;
+import com.carolinarollergirls.scoreboard.model.TeamModel;
+
+public class DefaultTeamModelTests {
+
+	private ScoreBoardModel sbModelMock;
+	private Ruleset ruleMock;
+	private Settings settingsMock;
+	private TeamModel otherTeamMock;
+	
+	private ScoreBoardEventProviderManager sbepm;
+	private Queue<ScoreBoardEvent> collectedEvents;
+	public ScoreBoardListener listener = new ScoreBoardListener() {
+		
+		@Override
+		public void scoreBoardChange(ScoreBoardEvent event) {
+			collectedEvents.add(event);
+		}
+	};
+	
+	
+	private DefaultTeamModel team;
+	private static String ID = "TEST";
+	
+	private void advance(long time_ms) {
+	    DefaultClockModel.updateClockTimerTask.advance(time_ms);
+	    sbepm.waitForEvents();
+	}
+	
+	@Before
+	public void setUp() throws Exception {
+		sbepm = ScoreBoardEventProviderManager.getSingleton();
+		collectedEvents = new LinkedList<ScoreBoardEvent>();
+		
+		sbModelMock = Mockito.mock(DefaultScoreBoardModel.class);
+		
+		ruleMock = Mockito.mock(Ruleset.class);
+		settingsMock = Mockito.mock(Settings.class);
+		otherTeamMock = Mockito.mock(DefaultTeamModel.class);
+		
+		Mockito
+			.when(sbModelMock.getScoreBoard())
+			.thenReturn(sbModelMock);
+		
+		Mockito
+			.when(sbModelMock._getRuleset())
+			.thenReturn(ruleMock);
+		
+		Mockito
+			.when(sbModelMock.getSettings())
+			.thenReturn(settingsMock);
+		
+		Mockito
+			.when(sbModelMock.getTeamModel(Mockito.anyString()))
+			.thenReturn(otherTeamMock);
+		
+		team = new DefaultTeamModel(sbModelMock, ID);
+		DefaultClockModel.updateClockTimerTask.setPaused(true);
+}
+
+	@Test
+	public void testStartJam() {
+		team.setScore(34);
+		team.addScoreBoardListener(new ConditionalScoreBoardListener(team, Team.EVENT_LAST_SCORE, listener));
+		
+		team.startJam();
+		advance(0);
+		
+		assertEquals(34, team.getLastScore());
+		assertEquals(1, collectedEvents.size());
+	}
+
+	@Test
+	public void testStopJam() {
+		team.setLeadJammer(Team.LEAD_LOST_LEAD);
+		team.setStarPass(true);
+		team.addScoreBoardListener(new ConditionalScoreBoardListener(team, Team.EVENT_LEAD_JAMMER, listener));
+		team.addScoreBoardListener(new ConditionalScoreBoardListener(team, Team.EVENT_STAR_PASS, listener));
+		
+		team.stopJam();
+		advance(0);
+		
+		assertEquals(Team.LEAD_NO_LEAD, team.getLeadJammer());
+		assertEquals(false, team.isStarPass());
+		assertEquals(2, collectedEvents.size());
+		assertEquals(Team.EVENT_LEAD_JAMMER, collectedEvents.poll().getProperty());
+		assertEquals(Team.EVENT_STAR_PASS, collectedEvents.poll().getProperty());
+	}
+
+	@Test
+	public void testTimeout() {
+		team.setTimeouts(1);
+		
+		team.timeout();
+		assertEquals(0, team.getTimeouts());
+		Mockito.verify(sbModelMock).timeout(Mockito.eq(team));
+		
+		team.timeout();
+		Mockito.verify(sbModelMock, Mockito.times(1)).timeout(Mockito.eq(team));
+	}
+
+	@Test
+	public void testOfficialReview() {
+		team.officialReview();
+		assertEquals(0, team.getOfficialReviews());
+		Mockito.verify(sbModelMock).timeout(team, true);
+		
+		team.officialReview();
+		Mockito.verify(sbModelMock, Mockito.times(1)).timeout(team, true);
+	}
+
+	@Test
+	public void testSetScore() {
+		team.addScoreBoardListener(new ConditionalScoreBoardListener(team, Team.EVENT_SCORE, listener));
+		
+		team.setScore(5);
+		advance(0);
+		assertEquals(5, team.getScore());
+		assertEquals(1, collectedEvents.size());
+		ScoreBoardEvent event = collectedEvents.poll();
+		assertEquals(5, event.getValue());
+		assertEquals(0, event.getPreviousValue());
+		assertEquals(0, team.getLastScore());
+		
+		//setting a value below lastScore changes lastScore
+		team.setLastScore(4);
+		team.setScore(3);
+		advance(0);
+		assertEquals(3, team.getLastScore());
+		
+		//negative values are truncated
+		collectedEvents.clear();
+		team.setScore(-1);
+		advance(0);
+		assertEquals(0,team.getScore());
+		assertEquals(1, collectedEvents.size());
+		assertEquals(0, collectedEvents.poll().getValue());
+	}
+
+	@Test
+	public void testChangeScore() {
+		team.addScoreBoardListener(new ConditionalScoreBoardListener(team, Team.EVENT_SCORE, listener));
+
+		team.setScore(5);
+		team.changeScore(3);
+		advance(0);
+		assertEquals(8, team.getScore());
+		assertEquals(2, collectedEvents.size());
+		
+		team.changeScore(-5);
+		assertEquals(3, team.getScore());
+	}
+
+	@Test
+	public void testSetLastScore() {
+		team.addScoreBoardListener(new ConditionalScoreBoardListener(team, Team.EVENT_LAST_SCORE, listener));
+		team.setScore(10);
+		
+		team.setLastScore(5);
+		advance(0);
+		assertEquals(5, team.getLastScore());
+		assertEquals(1, collectedEvents.size());
+		ScoreBoardEvent event = collectedEvents.poll();
+		assertEquals(5, event.getValue());
+		assertEquals(0, event.getPreviousValue());
+
+		//values higher than score are truncated
+		team.setLastScore(12);
+		advance(0);
+		assertEquals(10, team.getLastScore());
+		assertEquals(1, collectedEvents.size());
+		assertEquals(10, collectedEvents.poll().getValue());
+		
+		//negative values are truncated
+		team.setLastScore(-2);
+		assertEquals(0, team.getLastScore());
+	}
+
+	@Test
+	public void testChangeLastScore() {
+		team.addScoreBoardListener(new ConditionalScoreBoardListener(team, Team.EVENT_LAST_SCORE, listener));
+
+		team.setScore(10);
+		team.setLastScore(5);
+		team.changeLastScore(3);
+		advance(0);
+		assertEquals(8, team.getLastScore());
+		assertEquals(2, collectedEvents.size());
+		
+		team.changeLastScore(-5);
+		assertEquals(3, team.getLastScore());
+	}
+
+	@Test
+	public void testSetInTimeout() {
+		assertFalse(team.inTimeout());
+		team.addScoreBoardListener(new ConditionalScoreBoardListener(team, Team.EVENT_IN_TIMEOUT, listener));
+		
+		team.setInTimeout(true);
+		advance(0);
+		assertTrue(team.inTimeout());
+		assertEquals(1, collectedEvents.size());
+		ScoreBoardEvent event = collectedEvents.poll();
+		assertTrue((Boolean)event.getValue());
+		assertFalse((Boolean)event.getPreviousValue());
+
+		//check idempotency
+		team.setInTimeout(true);
+		advance(0);
+		assertTrue(team.inTimeout());
+		assertEquals(0, collectedEvents.size());
+		
+		team.setInTimeout(false);
+		advance(0);
+		assertFalse(team.inTimeout());
+	}
+
+	@Test
+	public void testSetInOfficialReview() {
+		assertFalse(team.inOfficialReview());
+		team.addScoreBoardListener(new ConditionalScoreBoardListener(team, Team.EVENT_IN_OFFICIAL_REVIEW, listener));
+		
+		team.setInOfficialReview(true);
+		advance(0);
+		assertTrue(team.inOfficialReview());
+		assertEquals(1, collectedEvents.size());
+		ScoreBoardEvent event = collectedEvents.poll();
+		assertTrue((Boolean)event.getValue());
+		assertFalse((Boolean)event.getPreviousValue());
+
+		//check idempotency
+		team.setInOfficialReview(true);
+		advance(0);
+		assertTrue(team.inOfficialReview());
+		assertEquals(0, collectedEvents.size());
+		
+		team.setInOfficialReview(false);
+		advance(0);
+		assertFalse(team.inOfficialReview());
+	}
+
+	@Test
+	public void testSetRetainedOfficialReview() {
+		assertFalse(team.retainedOfficialReview());
+		assertEquals(1, team.getOfficialReviews());
+		team.addScoreBoardListener(new ConditionalScoreBoardListener(team, Team.EVENT_RETAINED_OFFICIAL_REVIEW, listener));
+		team.addScoreBoardListener(new ConditionalScoreBoardListener(team, Team.EVENT_OFFICIAL_REVIEWS, listener));
+		
+		team.setRetainedOfficialReview(true);
+		advance(0);
+		assertTrue(team.retainedOfficialReview());
+		assertEquals(1, team.getOfficialReviews());
+		assertEquals(1, collectedEvents.size());
+		ScoreBoardEvent event = collectedEvents.poll();
+		assertTrue((Boolean)event.getValue());
+		assertFalse((Boolean)event.getPreviousValue());
+
+		//check idempotency
+		team.setRetainedOfficialReview(true);
+		advance(0);
+		assertTrue(team.retainedOfficialReview());
+		assertEquals(0, collectedEvents.size());
+		
+		team.setRetainedOfficialReview(false);
+		advance(0);
+		assertFalse(team.retainedOfficialReview());
+	
+		team.setOfficialReviews(0);
+		advance(0);
+		collectedEvents.clear();
+		team.setRetainedOfficialReview(true);
+		advance(0);
+		assertEquals(1, team.getOfficialReviews());
+		assertEquals(2, collectedEvents.size());
+	}
+
+	@Test
+	public void testSetTimeouts() {
+		team.addScoreBoardListener(new ConditionalScoreBoardListener(team, Team.EVENT_TIMEOUTS, listener));
+		team.maximumTimeouts = 5;
+		
+		team.setTimeouts(4);
+		advance(0);
+		assertEquals(4, team.getTimeouts());
+		assertEquals(1, collectedEvents.size());
+		ScoreBoardEvent event = collectedEvents.poll();
+		assertEquals(4, event.getValue());
+		assertEquals(3, event.getPreviousValue());
+
+		//values higher than maximum are truncated
+		team.setTimeouts(12);
+		advance(0);
+		assertEquals(5, team.getTimeouts());
+		assertEquals(1, collectedEvents.size());
+		assertEquals(5, collectedEvents.poll().getValue());
+		
+		//negative values are truncated
+		team.setTimeouts(-2);
+		assertEquals(0, team.getTimeouts());
+	}
+
+	@Test
+	public void testChangeTimeouts() {
+		team.addScoreBoardListener(new ConditionalScoreBoardListener(team, Team.EVENT_TIMEOUTS, listener));
+		assertEquals(3, team.getTimeouts());
+
+		team.changeTimeouts(-2);
+		advance(0);
+		assertEquals(1, team.getTimeouts());
+		assertEquals(1, collectedEvents.size());
+		
+		team.changeTimeouts(1);
+		assertEquals(2, team.getTimeouts());
+	}
+
+	@Test
+	public void testSetOfficialReviews() {
+		team.addScoreBoardListener(new ConditionalScoreBoardListener(team, Team.EVENT_OFFICIAL_REVIEWS, listener));
+		team.maximumOfficialReviews = 5;
+		
+		team.setOfficialReviews(4);
+		advance(0);
+		assertEquals(4, team.getOfficialReviews());
+		assertEquals(1, collectedEvents.size());
+		ScoreBoardEvent event = collectedEvents.poll();
+		assertEquals(4, event.getValue());
+		assertEquals(1, event.getPreviousValue());
+
+		//values higher than maximum are truncated
+		team.setOfficialReviews(12);
+		advance(0);
+		assertEquals(5, team.getOfficialReviews());
+		assertEquals(1, collectedEvents.size());
+		assertEquals(5, collectedEvents.poll().getValue());
+		
+		//negative values are truncated
+		team.setOfficialReviews(-2);
+		assertEquals(0, team.getOfficialReviews());
+	}
+
+	@Test
+	public void testChangeOfficialReviews() {
+		team.addScoreBoardListener(new ConditionalScoreBoardListener(team, Team.EVENT_OFFICIAL_REVIEWS, listener));
+		team.maximumOfficialReviews = 3;
+		assertEquals(1, team.getOfficialReviews());
+
+		team.changeOfficialReviews(2);
+		advance(0);
+		assertEquals(3, team.getOfficialReviews());
+		assertEquals(1, collectedEvents.size());
+		
+		team.changeOfficialReviews(-1);
+		assertEquals(2, team.getOfficialReviews());
+	}
+
+	@Test
+	public void testResetTimeouts() {
+		team.addScoreBoardListener(new ConditionalScoreBoardListener(team, Team.EVENT_IN_TIMEOUT, listener));
+		team.addScoreBoardListener(new ConditionalScoreBoardListener(team, Team.EVENT_IN_OFFICIAL_REVIEW, listener));
+		team.addScoreBoardListener(new ConditionalScoreBoardListener(team, Team.EVENT_TIMEOUTS, listener));
+		team.addScoreBoardListener(new ConditionalScoreBoardListener(team, Team.EVENT_OFFICIAL_REVIEWS, listener));
+		team.addScoreBoardListener(new ConditionalScoreBoardListener(team, Team.EVENT_RETAINED_OFFICIAL_REVIEW, listener));
+		team.setInTimeout(true);
+		team.setInOfficialReview(true);
+		team.setRetainedOfficialReview(true);
+		team.setTimeouts(1);
+		team.setOfficialReviews(0);
+		advance(0);
+		collectedEvents.clear();
+		
+		team.resetTimeouts(false);
+		advance(0);
+		assertFalse(team.inTimeout());
+		assertFalse(team.inOfficialReview());
+		assertEquals(1, team.getTimeouts());
+		assertEquals(1, team.getOfficialReviews());
+		assertFalse(team.retainedOfficialReview());
+		assertEquals(4, collectedEvents.size());
+		List<String> events = new ArrayList<String>();
+		while(!collectedEvents.isEmpty()) {
+			events.add(collectedEvents.poll().getProperty());
+		}
+		assertTrue(events.contains(Team.EVENT_IN_TIMEOUT));
+		assertTrue(events.contains(Team.EVENT_IN_OFFICIAL_REVIEW));
+		assertTrue(events.contains(Team.EVENT_OFFICIAL_REVIEWS));
+		assertTrue(events.contains(Team.EVENT_RETAINED_OFFICIAL_REVIEW));
+
+		team.maximumOfficialReviews = 2;
+		team.setInTimeout(true);
+		team.setInOfficialReview(true);
+		team.setRetainedOfficialReview(true);
+		team.setTimeouts(1);
+		team.setOfficialReviews(0);
+		advance(0);
+		collectedEvents.clear();
+		team.resetTimeouts(true);
+		advance(0);
+		assertFalse(team.inTimeout());
+		assertFalse(team.inOfficialReview());
+		assertEquals(3, team.getTimeouts());
+		assertEquals(2, team.getOfficialReviews());
+		assertFalse(team.retainedOfficialReview());
+		assertEquals(5, collectedEvents.size());
+		events = new ArrayList<String>();
+		while(!collectedEvents.isEmpty()) {
+			events.add(collectedEvents.poll().getProperty());
+		}
+		assertTrue(events.contains(Team.EVENT_IN_TIMEOUT));
+		assertTrue(events.contains(Team.EVENT_IN_OFFICIAL_REVIEW));
+		assertTrue(events.contains(Team.EVENT_TIMEOUTS));
+		assertTrue(events.contains(Team.EVENT_OFFICIAL_REVIEWS));
+		assertTrue(events.contains(Team.EVENT_RETAINED_OFFICIAL_REVIEW));
+	
+		team.maximumTimeouts = 4;
+		team.timeoutsPerPeriod = true;
+		team.officialReviewsPerPeriod = false;
+		team.setRetainedOfficialReview(true);
+		team.setTimeouts(1);
+		team.setOfficialReviews(0);
+		advance(0);
+		collectedEvents.clear();
+		team.resetTimeouts(false);
+		advance(0);
+		assertEquals(4, team.getTimeouts());
+		assertEquals(0, team.getOfficialReviews());
+		assertTrue(team.retainedOfficialReview());
+		assertEquals(1, collectedEvents.size());
+		assertEquals(Team.EVENT_TIMEOUTS, collectedEvents.poll().getProperty());
+	}
+
+	@Test
+	public void testSetLeadJammer() {
+		assertEquals(Team.LEAD_NO_LEAD, team.getLeadJammer());
+		team.addScoreBoardListener(new ConditionalScoreBoardListener(team, Team.EVENT_LEAD_JAMMER, listener));
+		
+		team.setLeadJammer(Team.LEAD_LEAD);
+		advance(0);
+		assertEquals(Team.LEAD_LEAD, team.getLeadJammer());
+		assertEquals(1, collectedEvents.size());
+		ScoreBoardEvent event = collectedEvents.poll();
+		assertEquals(Team.LEAD_LEAD, event.getValue());
+		assertEquals(Team.LEAD_NO_LEAD, event.getPreviousValue());
+
+		//check idempotency
+		team.setLeadJammer(Team.LEAD_LEAD);
+		advance(0);
+		assertEquals(Team.LEAD_LEAD, team.getLeadJammer());
+		assertEquals(1, collectedEvents.size());
+		
+		team.setLeadJammer(Team.LEAD_LOST_LEAD);
+		advance(0);
+		assertEquals(Team.LEAD_LOST_LEAD, team.getLeadJammer());
+		
+		team.setLeadJammer(Team.LEAD_NO_LEAD);
+		advance(0);
+		assertEquals(Team.LEAD_NO_LEAD, team.getLeadJammer());
+	}
+
+	@Test
+	public void testSetStarPass() {
+		assertFalse(team.isStarPass());
+		team.addScoreBoardListener(new ConditionalScoreBoardListener(team, Team.EVENT_STAR_PASS, listener));
+		
+		team.setStarPass(true);
+		advance(0);
+		assertTrue(team.isStarPass());
+		assertEquals(1, collectedEvents.size());
+		ScoreBoardEvent event = collectedEvents.poll();
+		assertTrue((Boolean)event.getValue());
+		assertFalse((Boolean)event.getPreviousValue());
+
+		//check idempotency
+		team.setStarPass(true);
+		advance(0);
+		assertTrue(team.isStarPass());
+		assertEquals(1, collectedEvents.size());
+		
+		team.setStarPass(false);
+		advance(0);
+		assertFalse(team.isStarPass());
+	}
+
+}

--- a/tests/com/carolinarollergirls/scoreboard/defaults/DefaultTeamModelTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/defaults/DefaultTeamModelTests.java
@@ -147,7 +147,7 @@ public class DefaultTeamModelTests {
 		advance(0);
 		assertEquals(3, team.getLastScore());
 		
-		//negative values are truncated
+		//negative values are clamped
 		collectedEvents.clear();
 		team.setScore(-1);
 		advance(0);
@@ -183,14 +183,14 @@ public class DefaultTeamModelTests {
 		assertEquals(5, event.getValue());
 		assertEquals(0, event.getPreviousValue());
 
-		//values higher than score are truncated
+		//values higher than score are clamped
 		team.setLastScore(12);
 		advance(0);
 		assertEquals(10, team.getLastScore());
 		assertEquals(1, collectedEvents.size());
 		assertEquals(10, collectedEvents.poll().getValue());
 		
-		//negative values are truncated
+		//negative values are clamped
 		team.setLastScore(-2);
 		assertEquals(0, team.getLastScore());
 	}
@@ -306,14 +306,14 @@ public class DefaultTeamModelTests {
 		assertEquals(4, event.getValue());
 		assertEquals(3, event.getPreviousValue());
 
-		//values higher than maximum are truncated
+		//values higher than maximum are clamped
 		team.setTimeouts(12);
 		advance(0);
 		assertEquals(5, team.getTimeouts());
 		assertEquals(1, collectedEvents.size());
 		assertEquals(5, collectedEvents.poll().getValue());
 		
-		//negative values are truncated
+		//negative values are clamped
 		team.setTimeouts(-2);
 		assertEquals(0, team.getTimeouts());
 	}
@@ -345,14 +345,14 @@ public class DefaultTeamModelTests {
 		assertEquals(4, event.getValue());
 		assertEquals(1, event.getPreviousValue());
 
-		//values higher than maximum are truncated
+		//values higher than maximum are clamped
 		team.setOfficialReviews(12);
 		advance(0);
 		assertEquals(5, team.getOfficialReviews());
 		assertEquals(1, collectedEvents.size());
 		assertEquals(5, collectedEvents.poll().getValue());
 		
-		//negative values are truncated
+		//negative values are clamped
 		team.setOfficialReviews(-2);
 		assertEquals(0, team.getOfficialReviews());
 	}


### PR DESCRIPTION
These tests verify the behaviour of the game state as displayed on the main
scoreboard (except Jammer names).

Not included:
- Undo. This will be added together with the switch to a snapshot model
in a separate PR.
- Game Statistics (Penalties, Lineups)
- Settings other than WFTDA sanctioned (with a few exceptions).

In addition the PR contains fixes for a few minor bugs uncovered by the tests.