### PR TITLE
Move Clock handling code out of event handlers

### DIFF
--- a/src/com/carolinarollergirls/scoreboard/Ruleset.java
+++ b/src/com/carolinarollergirls/scoreboard/Ruleset.java
@@ -86,7 +86,7 @@ public class Ruleset {
 			newRule(   new TimeRule(false, "Clock", Clock.ID_PERIOD,       "MaximumTime",   "Duration of a period", "30:00"));
 
 			newRule( new StringRule(false, "Clock", Clock.ID_JAM,          "Name",          "", Clock.ID_JAM));
-			newRule(new IntegerRule(false, "Clock", Clock.ID_JAM,          "MinimumNumber", "", 1));
+			newRule(new IntegerRule(false, "Clock", Clock.ID_JAM,          "MinimumNumber", "", 0));
 			newRule(new IntegerRule(false, "Clock", Clock.ID_JAM,          "MaximumNumber", "", 999));
 			newRule(new BooleanRule(false, "Clock", Clock.ID_JAM,          "Direction",     "Which way should this clock count?", true, "Count Down", "Count Up"));
 			newRule(   new TimeRule(false, "Clock", Clock.ID_JAM,          "MinimumTime",   "", "0:00"));

--- a/src/com/carolinarollergirls/scoreboard/defaults/DefaultClockModel.java
+++ b/src/com/carolinarollergirls/scoreboard/defaults/DefaultClockModel.java
@@ -315,9 +315,11 @@ public class DefaultClockModel extends DefaultScoreBoardEventProvider implements
 	}
 	
 	public void startNext() {
+		requestBatchStart();
 		changeNumber(1);
 		resetTime();
 		start();
+		requestBatchEnd();
 	}
 
 	protected void timerTick(long delta) {

--- a/src/com/carolinarollergirls/scoreboard/defaults/DefaultClockModel.java
+++ b/src/com/carolinarollergirls/scoreboard/defaults/DefaultClockModel.java
@@ -313,6 +313,12 @@ public class DefaultClockModel extends DefaultScoreBoardEventProvider implements
 			scoreBoardChange(new ScoreBoardEvent(this, EVENT_RUNNING, Boolean.FALSE, Boolean.TRUE));
 		}
 	}
+	
+	public void startNext() {
+		changeNumber(1);
+		resetTime();
+		start();
+	}
 
 	protected void timerTick(long delta) {
 		if (!isRunning())

--- a/src/com/carolinarollergirls/scoreboard/defaults/DefaultScoreBoardModel.java
+++ b/src/com/carolinarollergirls/scoreboard/defaults/DefaultScoreBoardModel.java
@@ -208,7 +208,7 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 			ScoreBoardManager.gameSnapshot();
 		}
 	}
-	public void setTimeoutType(String owner, boolean review) {
+	public void startTimeoutType(String owner, boolean review) {
 		ClockModel tc = getClockModel(Clock.ID_TIMEOUT);
 
 		requestBatchStart();
@@ -314,7 +314,7 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 
 		requestBatchStart();
 		if (tc.isRunning()) {
-			//TODO: Make Official Timeout its own button that calls setTimeoutType()
+			//TODO: Make Official Timeout its own button that calls startTimeoutType()
 			if (getTimeoutOwner()==TIMEOUT_OWNER_NONE) {
 				setTimeoutOwner(TIMEOUT_OWNER_OTO);
 			} else {

--- a/src/com/carolinarollergirls/scoreboard/defaults/DefaultScoreBoardModel.java
+++ b/src/com/carolinarollergirls/scoreboard/defaults/DefaultScoreBoardModel.java
@@ -103,7 +103,8 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 		setOfficialReview(false);
 		setInPeriod(false);
 		setInOvertime(false);
-
+		restartPcAfterTimeout = false;
+		
 		settings.reset();
 		stats.reset();
 	}
@@ -111,26 +112,22 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 	public boolean isInPeriod() { return inPeriod; }
 	public void setInPeriod(boolean p) {
 		synchronized (inPeriodLock) {
+			if (p == inPeriod) { return; }
 			Boolean last = new Boolean(inPeriod);
 			inPeriod = p;
 			scoreBoardChange(new ScoreBoardEvent(this, EVENT_IN_PERIOD, new Boolean(inPeriod), last));
 		}
 	}
 	protected void addInPeriodListeners() {
-		addScoreBoardListener(new ConditionalScoreBoardListener(Clock.class, Clock.ID_PERIOD, "Running", Boolean.TRUE, periodStartListener));
 		addScoreBoardListener(new ConditionalScoreBoardListener(Clock.class, Clock.ID_PERIOD, "Running", Boolean.FALSE, periodEndListener));
 		addScoreBoardListener(new ConditionalScoreBoardListener(Clock.class, Clock.ID_JAM, "Running", Boolean.FALSE, jamEndListener));
-		addScoreBoardListener(new ConditionalScoreBoardListener(Clock.class, Clock.ID_JAM, "Running", Boolean.FALSE, periodEndListener));
-		addScoreBoardListener(new ConditionalScoreBoardListener(Clock.class, Clock.ID_JAM, "Running", Boolean.TRUE, jamStartListener));
-		addScoreBoardListener(new ConditionalScoreBoardListener(Clock.class, Clock.ID_TIMEOUT, "Running", Boolean.FALSE, periodEndListener));
-		addScoreBoardListener(new ConditionalScoreBoardListener(Clock.class, Clock.ID_TIMEOUT, "Running", Boolean.TRUE, timeoutStartListener));
-		addScoreBoardListener(new ConditionalScoreBoardListener(Clock.class, Clock.ID_TIMEOUT, "Running", Boolean.FALSE, timeoutEndListener));
 		addScoreBoardListener(new ConditionalScoreBoardListener(Clock.class, Clock.ID_INTERMISSION, "Running", Boolean.FALSE, intermissionEndListener));
-		addScoreBoardListener(new ConditionalScoreBoardListener(Clock.class, Clock.ID_INTERMISSION, "Time", lineupClockListener));
+		addScoreBoardListener(new ConditionalScoreBoardListener(Clock.class, Clock.ID_LINEUP, "Time", lineupClockListener));
 	}
 
 	public boolean isInOvertime() { return inOvertime; }
 	public void setInOvertime(boolean o) {
+		if (o == inOvertime) { return; }
 		synchronized (inOvertimeLock) {
 			Boolean last = new Boolean(inOvertime);
 			inOvertime = o;
@@ -148,7 +145,6 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 			ClockModel jc = getClockModel(Clock.ID_JAM);
 			ClockModel lc = getClockModel(Clock.ID_LINEUP);
 			ClockModel tc = getClockModel(Clock.ID_TIMEOUT);
-			ClockModel ic = getClockModel(Clock.ID_INTERMISSION);
 			if (pc.isRunning() || jc.isRunning())
 				return;
 			if (pc.getNumber() < pc.getMaximumNumber())
@@ -157,17 +153,15 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 				return;
 			createSnapshot(ACTION_OVERTIME);
 			
-			pc.setTime(1000); //TODO: Should not be needed
-			setInPeriod(true);
 			setInOvertime(true);
-			tc.stop();
-			ic.stop();
+			if (tc.isRunning()) {
+				_endTimeout();
+			}
 			long otLineupTime = settings.getLong("Clock." + Clock.ID_LINEUP + ".OvertimeTime");
 			if (lc.getMaximumTime() < otLineupTime) {
 				lc.setMaximumTime(otLineupTime);
 			}
-			lc.resetTime();
-			lc.start();
+			_startLineup();
 			requestBatchEnd();
 		}
 	}
@@ -185,143 +179,209 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 		synchronized (runLock) {
 			if (!getClock(Clock.ID_JAM).isRunning()) {
 				createSnapshot(ACTION_START_JAM);
-				
-				requestBatchStart();
-				ClockModel pc = getClockModel(Clock.ID_PERIOD);
-				ClockModel jc = getClockModel(Clock.ID_JAM);
-				ClockModel tc = getClockModel(Clock.ID_TIMEOUT);
-				ClockModel ic = getClockModel(Clock.ID_INTERMISSION);
-
-				ic.stop();
-				pc.start();
-
-				if (!jc.isTimeAtStart())
-					jc.changeNumber(1);
-				jc.resetTime();
-				jc.start();
-
-				tc.stop();
-
-				getTeamModel("1").startJam();
-				getTeamModel("2").startJam();
-				requestBatchEnd();
-
+				_startJam();
 				ScoreBoardManager.gameSnapshot();
 			}
 		}
 	}
-	public void stopJam() {
+	public void stopJamTO() {
 		synchronized (runLock) {
-			if (getClockModel(Clock.ID_JAM).isRunning()) {
-				_stopJam();
-			} else if (getClockModel(Clock.ID_TIMEOUT).isRunning()) {
-				_stopTimeout();
-			} else if (!getClockModel(Clock.ID_LINEUP).isRunning()) {
+			ClockModel jc = getClockModel(Clock.ID_JAM);
+			ClockModel lc = getClockModel(Clock.ID_LINEUP);
+			ClockModel tc = getClockModel(Clock.ID_TIMEOUT);
+
+			if (jc.isRunning()) {
+				ScoreBoardManager.gameSnapshot(true);
+				createSnapshot(ACTION_STOP_JAM);
+				_endJam(false);
+			} else if (tc.isRunning()) {
+				createSnapshot(ACTION_STOP_TO);
+				_endTimeout();
+			} else if (!lc.isRunning()) {
+				createSnapshot(ACTION_LINEUP);
 				_startLineup();
 			}
 		}
 	}
-	private void _stopJam() {
+	public void timeout() { 
 		synchronized (runLock) {
-			ScoreBoardManager.gameSnapshot(true);
-			createSnapshot(ACTION_STOP_JAM);
-
-			ClockModel pc = getClockModel(Clock.ID_PERIOD);
-			ClockModel jc = getClockModel(Clock.ID_JAM);
-			ClockModel lc = getClockModel(Clock.ID_LINEUP);
-
-			requestBatchStart();
-			jc.stop();
-			getTeamModel("1").stopJam();
-			getTeamModel("2").stopJam();
-
-			if (pc.isRunning()) {
-				lc.resetTime();
-				lc.start();
-			}
-			if (inOvertime) {
-				setInOvertime(false);
-			}
-			requestBatchEnd();
-		}
-	}
-	private void _stopTimeout() {
-		synchronized (runLock) {
-			createSnapshot(ACTION_STOP_TO);
-			
-			ClockModel tc = getClockModel(Clock.ID_TIMEOUT);
-			ClockModel lc = getClockModel(Clock.ID_LINEUP);
-			ClockModel pc = getClockModel(Clock.ID_PERIOD);
-			ClockModel ic = getClockModel(Clock.ID_INTERMISSION);
-			
-			requestBatchStart();
-			if (pc.isTimeAtEnd()) {
-				ic.resetTime(); //TODO: add a rule to make this optional
-				ic.start();
-			} else {
-				lc.resetTime();
-				lc.start();
-			}
-			tc.stop();
-			requestBatchEnd();
-		}
-	}
-	private void _startLineup() {
-		synchronized (runLock) {
-			createSnapshot(ACTION_LINEUP);
-			
-			ClockModel lc = getClockModel(Clock.ID_LINEUP);
-			ClockModel ic = getClockModel(Clock.ID_INTERMISSION);
-
-			ic.stop();
-
-			requestBatchStart();
-			lc.resetTime();
-			lc.start();
-			requestBatchEnd();
-		}
-	}
-
-	public void timeout() { timeout(null); }
-	public void timeout(TeamModel team) { timeout(team, false); }
-	public void timeout(TeamModel team, boolean review) {
-		synchronized (runLock) {
-			requestBatchStart();
 			createSnapshot(ACTION_TIMEOUT);
-			
-			ClockModel tc = getClockModel(Clock.ID_TIMEOUT);
-			ClockModel pc = getClockModel(Clock.ID_PERIOD);
-			ClockModel jc = getClockModel(Clock.ID_JAM);
-			ClockModel lc = getClockModel(Clock.ID_LINEUP);
 
-			if (null==team && tc.isRunning() && getTimeoutOwner() == "") {
-				setTimeoutOwner("O");
-			} else {
-				setTimeoutOwner(null==team?"":team.getId());
-			}
-			setOfficialReview(review);
-
-			if (!tc.isRunning()) {
-				// Make sure period clock, jam clock, and lineup clock are stopped
-				boolean jamClockWasRunning = jc.isRunning();
-
-				pc.stop();
-				jc.stop();
-				lc.stop();
-
-				tc.resetTime();
-				tc.start();
-
-				if (jamClockWasRunning) {
-					getTeamModel("1").stopJam();
-					getTeamModel("2").stopJam();
-				}
-			}
+			requestBatchStart();
+			_startTimeout();
 			requestBatchEnd();
 
 			ScoreBoardManager.gameSnapshot();
 		}
 	}
+	public void setTimeoutType(String owner, boolean review) {
+		ClockModel tc = getClockModel(Clock.ID_TIMEOUT);
+
+		requestBatchStart();
+		if (!tc.isRunning()) {
+			timeout();
+		}
+		setTimeoutOwner(owner);
+		setOfficialReview(review);
+		if (owner != "" && owner != "O") {
+			restartPcAfterTimeout = false;
+		}
+		requestBatchEnd();
+	}
+	private void _preparePeriod() {
+		ClockModel pc = getClockModel(Clock.ID_PERIOD);
+		ClockModel jc = getClockModel(Clock.ID_JAM);
+		ClockModel ic = getClockModel(Clock.ID_INTERMISSION);
+
+		requestBatchStart();
+		pc.setNumber(ic.getNumber()+1);
+		pc.resetTime();
+		restartPcAfterTimeout = false;
+		if (settings.getBoolean("ScoreBoard." + Clock.ID_JAM + ".ResetNumberEachPeriod")) {
+			jc.setNumber(jc.getMinimumNumber());
+		}
+		for (TeamModel t : getTeamModels()) {
+			t.resetTimeouts(false);
+		}		
+		requestBatchEnd();
+	}
+	private void _possiblyEndPeriod() {
+		ClockModel pc = getClockModel(Clock.ID_PERIOD);
+		ClockModel jc = getClockModel(Clock.ID_JAM);
+		ClockModel tc = getClockModel(Clock.ID_TIMEOUT);
+
+		if (pc.isTimeAtEnd() && !pc.isRunning() && !jc.isRunning() && !tc.isRunning()) {
+			requestBatchStart();
+			setInPeriod(false);
+			setOfficialScore(false);
+			_endLineup();
+			_startIntermission();
+			requestBatchEnd();
+		}
+	}
+	private void _startJam() {
+		ClockModel pc = getClockModel(Clock.ID_PERIOD);
+		ClockModel jc = getClockModel(Clock.ID_JAM);
+
+		requestBatchStart();
+		_endIntermission(false);
+		_endTimeout();
+		_endLineup();
+		setInPeriod(true);
+		pc.start();
+		jc.startNext();
+
+		getTeamModel("1").startJam();
+		getTeamModel("2").startJam();
+		requestBatchEnd();
+	}
+	private void _endJam(boolean force) {
+		ClockModel pc = getClockModel(Clock.ID_PERIOD);
+		ClockModel jc = getClockModel(Clock.ID_JAM);
+
+		if (!jc.isRunning() && !force) { return; }
+		
+		requestBatchStart();
+		jc.stop();
+		getTeamModel("1").stopJam();
+		getTeamModel("2").stopJam();
+		setInOvertime(false);
+
+		if (pc.getTimeRemaining() < 30000) {
+			restartPcAfterTimeout = true;
+		}
+		if (pc.isRunning()) {
+			_startLineup();
+		} else {
+			_possiblyEndPeriod();
+		}
+		requestBatchEnd();
+	}
+	private void _startLineup() {
+		ClockModel lc = getClockModel(Clock.ID_LINEUP);
+
+		requestBatchStart();
+		_endIntermission(false);
+		setInPeriod(true);
+		lc.startNext();
+		requestBatchEnd();
+	}
+	private void _endLineup() {
+		ClockModel lc = getClockModel(Clock.ID_LINEUP);
+
+		requestBatchStart();
+		lc.stop();
+		requestBatchEnd();
+	}
+	private void _startTimeout() {
+		ClockModel pc = getClockModel(Clock.ID_PERIOD);
+		ClockModel tc = getClockModel(Clock.ID_TIMEOUT);
+
+		requestBatchStart();
+		if (tc.isRunning()) {
+			//TODO: Make Official Timeout its own button that calls setTimeoutType()
+			if (getTimeoutOwner()=="") {
+				setTimeoutOwner("O");
+			} else {
+				setTimeoutOwner("");
+			}
+			return; 
+		}
+		
+		pc.stop();
+		_endLineup();
+		_endJam(false);
+		_endIntermission(false);
+		setInPeriod(true);
+		tc.startNext();
+	}
+	private void _endTimeout() {
+		ClockModel tc = getClockModel(Clock.ID_TIMEOUT);
+		ClockModel pc = getClockModel(Clock.ID_PERIOD);
+
+		if (!tc.isRunning()) { return; }
+		
+		requestBatchStart();
+		tc.stop();
+		setTimeoutOwner("");
+		setOfficialReview(false);
+		if (pc.isTimeAtEnd()) {
+			_possiblyEndPeriod();
+		} else {
+			if (restartPcAfterTimeout) {
+				pc.start();
+			}
+			_startLineup();
+		}
+		requestBatchEnd();
+	}
+	private void _startIntermission() {
+		ClockModel pc = getClockModel(Clock.ID_PERIOD);
+		ClockModel ic = getClockModel(Clock.ID_INTERMISSION);
+
+		requestBatchStart();
+		ic.setNumber(pc.getNumber());
+		ic.setMaximumTime(settings.getLong("Clock." + Clock.ID_INTERMISSION + ".Time"));
+		ic.resetTime();
+		ic.start();		
+		requestBatchEnd();
+	}
+	private void _endIntermission(boolean force) {
+		ClockModel ic = getClockModel(Clock.ID_INTERMISSION);
+		ClockModel pc = getClockModel(Clock.ID_PERIOD);
+
+		if (!ic.isRunning() && !force) { return; }
+		
+		requestBatchStart();
+		ic.stop();
+		if (ic.getTimeRemaining() < 60000 && pc.getNumber() < pc.getMaximumNumber()) {
+			//If less than one minute of intermission is left and there is another period, 
+			// go to the next period. Otherwise extend the previous period.
+			_preparePeriod();
+		}
+		requestBatchEnd();
+	}
+
 
 	protected void createSnapshot(String type) {
 		snapshot = new ScoreBoardSnapshot(this, DefaultClockModel.updateClockTimerTask.getCurrentTime(), type);
@@ -489,6 +549,7 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 	protected Object timeoutOwnerLock = new Object();
 	protected boolean officialReview;
 	protected Object officialReviewLock = new Object();
+	protected boolean restartPcAfterTimeout;
 
 	protected boolean inPeriod = false;
 	protected Object inPeriodLock = new Object();
@@ -506,91 +567,25 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 
 	protected XmlScoreBoard xmlScoreBoard;
 
-	protected ScoreBoardListener periodStartListener = new ScoreBoardListener() {
-		public void scoreBoardChange(ScoreBoardEvent event) {
-			if (!isInPeriod())
-				setInPeriod(true);
-		}
-	};
 	protected ScoreBoardListener periodEndListener = new ScoreBoardListener() {
 		public void scoreBoardChange(ScoreBoardEvent event) {
-			ClockModel pc = getClockModel(Clock.ID_PERIOD);
-			ClockModel jc = getClockModel(Clock.ID_JAM);
-			ClockModel tc = getClockModel(Clock.ID_TIMEOUT);
-			ClockModel ic = getClockModel(Clock.ID_INTERMISSION);
-			ClockModel lc = getClockModel(Clock.ID_LINEUP);
-			if (isInPeriod() && !pc.isRunning() && pc.isTimeAtEnd() && !jc.isRunning() && !tc.isRunning()) {
-				requestBatchStart();
-				setInPeriod(false);
-				setOfficialScore(false);
-				lc.stop();
-				lc.resetTime();
-				if (!ic.isRunning()) {
-					ic.setNumber(pc.getNumber());
-					ic.setMaximumTime(settings.getLong("Clock." + Clock.ID_INTERMISSION + ".Time"));
-					ic.resetTime();
-					ic.start();
-				}
-				requestBatchEnd();
-			}
-		}
-	};
-	protected ScoreBoardListener jamStartListener = new ScoreBoardListener() {
-		public void scoreBoardChange(ScoreBoardEvent event) {
-			ClockModel lc = getClockModel(Clock.ID_LINEUP);
-			if (lc.isRunning())
-				lc.stop();
+			_possiblyEndPeriod();
 		}
 	};
 	protected ScoreBoardListener jamEndListener = new ScoreBoardListener() {
 		public void scoreBoardChange(ScoreBoardEvent event) {
 			ClockModel jc = getClockModel(Clock.ID_JAM);
 			if (jc.isTimeAtEnd()) {
-				_stopJam();
+				//clock has run down naturally
+				_endJam(true);
 			}
-		}
-	};
-	protected ScoreBoardListener timeoutStartListener = new ScoreBoardListener() {
-		public void scoreBoardChange(ScoreBoardEvent event) {
-			ClockModel ic = getClockModel(Clock.ID_INTERMISSION);
-			ClockModel tc = getClockModel(Clock.ID_TIMEOUT);
-
-			if (!isInPeriod() && ic.isRunning() && tc.isRunning()) {
-				ic.stop();
-				setInPeriod(true);
-			}
-		}
-	};
-	protected ScoreBoardListener timeoutEndListener = new ScoreBoardListener() {
-		public void scoreBoardChange(ScoreBoardEvent event) {
-			requestBatchStart();
-			setTimeoutOwner("");
-			setOfficialReview(false);
-			getClockModel(Clock.ID_TIMEOUT).changeNumber(1);
-			requestBatchEnd();
 		}
 	};
 	protected ScoreBoardListener intermissionEndListener = new ScoreBoardListener() {
 		public void scoreBoardChange(ScoreBoardEvent event) {
-			ClockModel ic = getClockModel(Clock.ID_INTERMISSION);
-			ClockModel pc = getClockModel(Clock.ID_PERIOD);
-			ClockModel jc = getClockModel(Clock.ID_JAM);
-			if (ic.getTimeRemaining() < 60000 && pc.getNumber() < pc.getMaximumNumber()) {
-				//If less than one minute of intermission is left and there is another period, 
-				// start the next period. Otherwise extend the previous period.
-				requestBatchStart();
-				pc.setNumber(ic.getNumber()+1);
-				pc.resetTime();
-				if (settings.getBoolean("ScoreBoard." + Clock.ID_JAM + ".ResetNumberEachPeriod")) {
-					jc.setNumber(jc.getMinimumNumber());
-				} else {
-					jc.changeNumber(1);
-				}
-				jc.resetTime();
-				for (TeamModel t : getTeamModels()) {
-					t.resetTimeouts(false);
-				}
-				requestBatchEnd();
+			if (getClock(Clock.ID_INTERMISSION).isTimeAtEnd()) {
+				//clock has run down naturally
+				_endIntermission(true);
 			}
 		}
 	};

--- a/src/com/carolinarollergirls/scoreboard/defaults/DefaultTeamModel.java
+++ b/src/com/carolinarollergirls/scoreboard/defaults/DefaultTeamModel.java
@@ -242,13 +242,13 @@ public class DefaultTeamModel extends DefaultScoreBoardEventProvider implements 
 	public void timeout() {
 		if (getTimeouts() > 0) {
 			changeTimeouts(-1);
-			getScoreBoardModel().setTimeoutType(getId(), false);
+			getScoreBoardModel().startTimeoutType(getId(), false);
 		}
 	}
 	public void officialReview() {
 		if (getOfficialReviews() > 0) {
 			changeOfficialReviews(-1);
-			getScoreBoardModel().setTimeoutType(getId(), true);
+			getScoreBoardModel().startTimeoutType(getId(), true);
 		}
 	}
 

--- a/src/com/carolinarollergirls/scoreboard/defaults/DefaultTeamModel.java
+++ b/src/com/carolinarollergirls/scoreboard/defaults/DefaultTeamModel.java
@@ -242,13 +242,13 @@ public class DefaultTeamModel extends DefaultScoreBoardEventProvider implements 
 	public void timeout() {
 		if (getTimeouts() > 0) {
 			changeTimeouts(-1);
-			getScoreBoardModel().timeout(this);
+			getScoreBoardModel().setTimeoutType(getId(), false);
 		}
 	}
 	public void officialReview() {
 		if (getOfficialReviews() > 0) {
 			changeOfficialReviews(-1);
-			getScoreBoardModel().timeout(this, true);
+			getScoreBoardModel().setTimeoutType(getId(), true);
 		}
 	}
 

--- a/src/com/carolinarollergirls/scoreboard/model/ClockModel.java
+++ b/src/com/carolinarollergirls/scoreboard/model/ClockModel.java
@@ -23,6 +23,7 @@ public interface ClockModel extends Clock
 
 	public void start();
 	public void stop();
+	public void startNext();
 
 	public void setName(String name);
 

--- a/src/com/carolinarollergirls/scoreboard/model/ScoreBoardModel.java
+++ b/src/com/carolinarollergirls/scoreboard/model/ScoreBoardModel.java
@@ -30,11 +30,10 @@ public interface ScoreBoardModel extends ScoreBoard
 	public void setOfficialScore(boolean official);
 
 	public void startJam();
-	public void stopJam();
+	public void stopJamTO();
 
 	public void timeout();
-	public void timeout(TeamModel team);
-	public void timeout(TeamModel team, boolean review);
+	public void setTimeoutType(String team, boolean review);
 
 	public void clockUndo();
 	public void unStartJam();

--- a/src/com/carolinarollergirls/scoreboard/model/ScoreBoardModel.java
+++ b/src/com/carolinarollergirls/scoreboard/model/ScoreBoardModel.java
@@ -33,7 +33,7 @@ public interface ScoreBoardModel extends ScoreBoard
 	public void stopJamTO();
 
 	public void timeout();
-	public void setTimeoutType(String team, boolean review);
+	public void startTimeoutType(String team, boolean review);
 
 	public void clockUndo();
 	public void unStartJam();

--- a/src/com/carolinarollergirls/scoreboard/xml/ScoreBoardXmlConverter.java
+++ b/src/com/carolinarollergirls/scoreboard/xml/ScoreBoardXmlConverter.java
@@ -304,7 +304,7 @@ public class ScoreBoardXmlConverter
 					else if (name.equals("StartJam"))
 						scoreBoardModel.startJam();
 					else if (name.equals("StopJam"))
-						scoreBoardModel.stopJam();
+						scoreBoardModel.stopJamTO();
 					else if (name.equals("Timeout"))
 						scoreBoardModel.timeout();
 					else if (name.equals("UnStartJam"))

--- a/tests/com/carolinarollergirls/scoreboard/defaults/DefaultClockModelTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/defaults/DefaultClockModelTests.java
@@ -609,12 +609,25 @@ public class DefaultClockModelTests {
 		assertEquals(1000, clock.getTime());
 		assertEquals(4000, clock.getInvertedTime());
 		assertEquals(2, collectedEvents.size());
+		Boolean firstEventInverted;
 		event = collectedEvents.poll();
-		assertEquals(1000, (long)event.getValue());
-		assertEquals(3200, (long)event.getPreviousValue());
+		if (event.getProperty() == Clock.EVENT_TIME) {
+			firstEventInverted = false;
+			assertEquals(1000, (long)event.getValue());
+			assertEquals(3200, (long)event.getPreviousValue());
+		} else {
+			firstEventInverted = true;
+			assertEquals(4000, (long)event.getValue());
+			assertEquals(1800, (long)event.getPreviousValue());			
+		}
 		event = collectedEvents.poll();
-		assertEquals(4000, (long)event.getValue());
-		assertEquals(1800, (long)event.getPreviousValue());
+		if (firstEventInverted) {
+			assertEquals(1000, (long)event.getValue());
+			assertEquals(3200, (long)event.getPreviousValue());
+		} else {
+			assertEquals(4000, (long)event.getValue());
+			assertEquals(1800, (long)event.getPreviousValue());			
+		}
 		
 		clock.changeTime(4100);
 		advance(0);

--- a/tests/com/carolinarollergirls/scoreboard/defaults/DefaultClockModelTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/defaults/DefaultClockModelTests.java
@@ -763,6 +763,22 @@ public class DefaultClockModelTests {
 	}
 	
 	@Test
+	public void testStartNext() {
+		clock.setMaximumNumber(5);
+		clock.setNumber(2);
+		clock.setMaximumTime(60000);
+		clock.setTime(45000);
+		assertFalse(clock.isRunning());
+		advance(0);
+		
+		clock.startNext();
+		advance(0);
+		assertTrue(clock.isRunning());
+		assertEquals(3, clock.getNumber());
+		assertTrue(clock.isTimeAtStart());
+	}
+	
+	@Test
 	public void testApplyRule_name()
 	{
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_NAME, listener));

--- a/tests/com/carolinarollergirls/scoreboard/defaults/DefaultScoreboardModelTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/defaults/DefaultScoreboardModelTests.java
@@ -93,7 +93,6 @@ public class DefaultScoreboardModelTests {
 
 	@Test
 	public void testSetInOvertime() {
-		ClockModel lc = sbm.getClockModel(Clock.ID_LINEUP);
 		(sbm.getSettingsModel()).set("Clock." + Clock.ID_LINEUP + ".Time", "30000");
 		lc.setMaximumTime(999999999);
 

--- a/tests/com/carolinarollergirls/scoreboard/defaults/DefaultScoreboardModelTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/defaults/DefaultScoreboardModelTests.java
@@ -48,12 +48,14 @@ public class DefaultScoreboardModelTests {
 		ScoreBoardManager.setPropertyOverride(JettyServletScoreBoardController.class.getName() + ".html.dir", "html");
 		sbepm = ScoreBoardEventProviderManager.getSingleton();
 		sbm = new DefaultScoreBoardModel();
-		pc = sbm.getClockModel(Clock.ID_PERIOD);      
-		jc = sbm.getClockModel(Clock.ID_JAM);         
-		lc = sbm.getClockModel(Clock.ID_LINEUP);      
-		tc = sbm.getClockModel(Clock.ID_TIMEOUT);     
+		pc = sbm.getClockModel(Clock.ID_PERIOD);
+		jc = sbm.getClockModel(Clock.ID_JAM);
+		lc = sbm.getClockModel(Clock.ID_LINEUP);
+		tc = sbm.getClockModel(Clock.ID_TIMEOUT);
 		ic = sbm.getClockModel(Clock.ID_INTERMISSION);
 		collectedEvents = new LinkedList<ScoreBoardEvent>();
+		//Clock Sync can cause clocks to be changed when started, breaking tests.
+		sbm.getSettingsModel().set("ScoreBoard.Clock.Sync", "False");
 	}
 	
 	@After
@@ -787,7 +789,7 @@ public class DefaultScoreboardModelTests {
 		sbm.setTimeoutOwner("");
 		advance(0);
 		
-		sbm.setTimeoutType("2", false);
+		sbm.startTimeoutType("2", false);
 		advance(0);
 
 		assertEquals(DefaultScoreBoardModel.ACTION_TIMEOUT, sbm.snapshot.getType());
@@ -799,7 +801,7 @@ public class DefaultScoreboardModelTests {
 		assertEquals("2", sbm.getTimeoutOwner());
 		assertFalse(sbm.isOfficialReview());
 
-		sbm.setTimeoutType("1", true);
+		sbm.startTimeoutType("1", true);
 		advance(0);
 		assertEquals("1", sbm.getTimeoutOwner());
 		assertTrue(sbm.isOfficialReview());
@@ -1017,7 +1019,7 @@ public class DefaultScoreboardModelTests {
 		
 		//follow up with team timeout
 		advance(2000);
-		sbm.setTimeoutType("1", false);
+		sbm.startTimeoutType("1", false);
 		advance(60000);
 		sbm.stopJamTO();
 		advance(0);

--- a/tests/com/carolinarollergirls/scoreboard/defaults/DefaultScoreboardModelTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/defaults/DefaultScoreboardModelTests.java
@@ -84,7 +84,7 @@ public class DefaultScoreboardModelTests {
 		sbm.setInPeriod(true);
 		advance(0);
 		assertTrue(sbm.isInPeriod());
-		assertEquals(1, collectedEvents.size());
+		assertEquals(0, collectedEvents.size());
 		
 		sbm.setInPeriod(false);
 		advance(0);
@@ -114,7 +114,7 @@ public class DefaultScoreboardModelTests {
 		sbm.setInOvertime(true);
 		advance(0);
 		assertTrue(sbm.isInOvertime());
-		assertEquals(1, collectedEvents.size());
+		assertEquals(0, collectedEvents.size());
 
 		sbm.setInOvertime(true);
 		advance(0);
@@ -126,6 +126,8 @@ public class DefaultScoreboardModelTests {
 		assertEquals(999999999, lc.getMaximumTime());
 
 		//check that lineup clock maximum time is reset for countdown lineup clock
+		sbm.setInOvertime(true);
+		advance(0);
 		lc.setCountDirectionDown(true);
 		sbm.setInOvertime(false);
 		advance(0);
@@ -254,7 +256,7 @@ public class DefaultScoreboardModelTests {
 		assertFalse(jc.isRunning());
 		assertTrue(lc.isRunning());
 		assertFalse(tc.isRunning());
-		assertEquals(7, tc.getNumber());
+		assertEquals(6, tc.getNumber());
 		assertFalse(ic.isRunning());
 	}
 
@@ -340,7 +342,7 @@ public class DefaultScoreboardModelTests {
 		assertEquals(18, jc.getNumber());
 		assertFalse(lc.isRunning());
 		assertFalse(tc.isRunning());
-		assertEquals(4, tc.getNumber());
+		assertEquals(3, tc.getNumber());
 		assertEquals("", sbm.getTimeoutOwner());
 		assertFalse(sbm.isOfficialReview());
 		assertFalse(ic.isRunning());
@@ -380,7 +382,7 @@ public class DefaultScoreboardModelTests {
 		assertEquals(1, pc.getNumber());
 		assertFalse(jc.isRunning());
 		assertTrue(jc.isTimeAtStart());
-		assertEquals(1, jc.getNumber());
+		assertEquals(0, jc.getNumber());
 		assertFalse(lc.isRunning());
 		assertFalse(tc.isRunning());
 		assertFalse(ic.isRunning());
@@ -490,7 +492,7 @@ public class DefaultScoreboardModelTests {
 		sbm.getTeamModel("1").setStarPass(true);
 		sbm.getTeamModel("2").setLeadJammer(Team.LEAD_NO_LEAD);
 		
-		sbm.stopJam();
+		sbm.stopJamTO();
 		advance(0);
 		
 		assertEquals(DefaultScoreBoardModel.ACTION_STOP_JAM, sbm.snapshot.getType());
@@ -520,7 +522,7 @@ public class DefaultScoreboardModelTests {
 		sbm.setInPeriod(true);
 		sbm.setOfficialScore(true);
 		
-		sbm.stopJam();
+		sbm.stopJamTO();
 		advance(0);
 		
 		assertEquals(DefaultScoreBoardModel.ACTION_STOP_JAM, sbm.snapshot.getType());
@@ -550,7 +552,7 @@ public class DefaultScoreboardModelTests {
 		sbm.setTimeoutOwner("O");
 		sbm.setOfficialReview(true);
 		
-		sbm.stopJam();
+		sbm.stopJamTO();
 		advance(0);
 		
 		assertEquals(DefaultScoreBoardModel.ACTION_STOP_TO, sbm.snapshot.getType());
@@ -559,7 +561,7 @@ public class DefaultScoreboardModelTests {
 		assertTrue(lc.isRunning());
 		assertTrue(lc.isTimeAtStart());
 		assertFalse(tc.isRunning());
-		assertEquals(5, tc.getNumber());
+		assertEquals(4, tc.getNumber());
 		assertFalse(ic.isRunning());
 		assertEquals("", sbm.getTimeoutOwner());
 		assertFalse(sbm.isOfficialReview());
@@ -576,7 +578,7 @@ public class DefaultScoreboardModelTests {
 		tc.setNumber(3);
 		assertFalse(ic.isRunning());
 		
-		sbm.stopJam();
+		sbm.stopJamTO();
 		advance(0);
 		
 		assertEquals(DefaultScoreBoardModel.ACTION_STOP_TO, sbm.snapshot.getType());
@@ -584,7 +586,7 @@ public class DefaultScoreboardModelTests {
 		assertFalse(jc.isRunning());
 		assertFalse(lc.isRunning());
 		assertFalse(tc.isRunning());
-		assertEquals(4, tc.getNumber());
+		assertEquals(3, tc.getNumber());
 		assertTrue(ic.isRunning());
 		assertTrue(ic.isTimeAtStart());
 	}
@@ -602,7 +604,7 @@ public class DefaultScoreboardModelTests {
 		ic.setTime(880000);
 		ic.start();
 		
-		sbm.stopJam();
+		sbm.stopJamTO();
 		advance(0);
 		
 		assertEquals(DefaultScoreBoardModel.ACTION_LINEUP, sbm.snapshot.getType());
@@ -632,7 +634,7 @@ public class DefaultScoreboardModelTests {
 		ic.setNumber(1);
 		ic.start();
 		
-		sbm.stopJam();
+		sbm.stopJamTO();
 		advance(0);
 		
 		assertEquals(DefaultScoreBoardModel.ACTION_LINEUP, sbm.snapshot.getType());
@@ -652,7 +654,7 @@ public class DefaultScoreboardModelTests {
 		lc.setNumber(9);
 		lc.start();
 		
-		sbm.stopJam();
+		sbm.stopJamTO();
 		advance(0);
 		
 		assertEquals(null, sbm.snapshot);
@@ -681,7 +683,7 @@ public class DefaultScoreboardModelTests {
 		assertFalse(lc.isRunning());
 		assertTrue(tc.isRunning());
 		assertTrue(tc.isTimeAtStart());
-		assertEquals(2, tc.getNumber());
+		assertEquals(3, tc.getNumber());
 		assertFalse(ic.isRunning());
 		assertEquals("", sbm.getTimeoutOwner());
 		assertFalse(sbm.isOfficialReview());
@@ -749,7 +751,7 @@ public class DefaultScoreboardModelTests {
 		assertTrue(tc.isTimeAtStart());
 		assertFalse(ic.isRunning());
 	}
-
+	
 	@Test
 	public void testTimeout_fromTimeout() {
 		assertFalse(pc.isRunning());
@@ -782,33 +784,11 @@ public class DefaultScoreboardModelTests {
 	}
 
 	@Test
-	public void testTimeoutTeamModel() {
+	public void testSetTimeoutType() {
 		sbm.setTimeoutOwner("");
 		advance(0);
 		
-		sbm.timeout(sbm.getTeamModel("1"));
-		advance(0);
-
-		assertEquals(DefaultScoreBoardModel.ACTION_TIMEOUT, sbm.snapshot.getType());
-		assertFalse(pc.isRunning());
-		assertFalse(jc.isRunning());
-		assertFalse(lc.isRunning());
-		assertTrue(tc.isRunning());
-		assertFalse(ic.isRunning());
-		assertEquals("1", sbm.getTimeoutOwner());
-		assertFalse(sbm.isOfficialReview());
-
-		sbm.timeout(sbm.getTeamModel("1"));
-		advance(0);
-		assertEquals("1", sbm.getTimeoutOwner());
-	}
-
-	@Test
-	public void testTimeoutTeamModelBoolean() {
-		sbm.setTimeoutOwner("");
-		advance(0);
-		
-		sbm.timeout(sbm.getTeamModel("2"), false);
+		sbm.setTimeoutType("2", false);
 		advance(0);
 
 		assertEquals(DefaultScoreBoardModel.ACTION_TIMEOUT, sbm.snapshot.getType());
@@ -820,7 +800,7 @@ public class DefaultScoreboardModelTests {
 		assertEquals("2", sbm.getTimeoutOwner());
 		assertFalse(sbm.isOfficialReview());
 
-		sbm.timeout(sbm.getTeamModel("1"), true);
+		sbm.setTimeoutType("1", true);
 		advance(0);
 		assertEquals("1", sbm.getTimeoutOwner());
 		assertTrue(sbm.isOfficialReview());
@@ -832,6 +812,7 @@ public class DefaultScoreboardModelTests {
 		sbm.getSettingsModel().set("ScoreBoard.Clock.Sync", "False");
 		pc.start();
 		jc.start();
+		sbm.setInPeriod(true);
 		advance(0);
 		assertFalse(lc.isRunning());
 		assertFalse(tc.isRunning());
@@ -968,8 +949,7 @@ public class DefaultScoreboardModelTests {
 		assertTrue(pc.isTimeAtStart());
 		assertEquals(2, pc.getNumber());
 		assertFalse(jc.isRunning());
-		assertEquals(1, jc.getNumber());
-		assertTrue(jc.isTimeAtStart());
+		assertEquals(0, jc.getNumber());
 		assertFalse(lc.isRunning());
 		assertFalse(tc.isRunning());
 		assertFalse(ic.isRunning());
@@ -1007,5 +987,42 @@ public class DefaultScoreboardModelTests {
 		assertFalse(ic.isRunning());
 		assertTrue(ic.isTimeAtEnd());
 		assertEquals(pc.getMaximumNumber(), ic.getNumber());
+	}
+
+	@Test
+	public void testTimeoutInLast30s() {
+		//jam ended before 30s mark, official timeout after 30s mark
+		assertTrue(pc.isCountDirectionDown());
+		pc.setTime(35000);
+		pc.start();
+		lc.start();
+		advance(10000);
+		sbm.timeout();
+		advance(20000);
+		sbm.stopJamTO();
+		advance(0);
+		assertFalse(pc.isRunning());
+
+		//jam ended after 30s mark, official timeout
+		sbm.startJam();
+		advance(0);
+		sbm.stopJamTO();
+		assertEquals(25000, pc.getTime());
+		assertTrue(pc.isRunning());
+		advance(1000);
+		sbm.timeout();
+		advance(35000);
+		sbm.stopJamTO();
+		advance(0);
+		assertTrue(pc.isRunning());
+		
+		//follow up with team timeout
+		advance(2000);
+		sbm.setTimeoutType("1", false);
+		advance(60000);
+		sbm.stopJamTO();
+		advance(0);
+		assertFalse(pc.isRunning());
+		assertEquals(22000, pc.getTimeRemaining());
 	}
 }

--- a/tests/com/carolinarollergirls/scoreboard/defaults/DefaultStatsModelTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/defaults/DefaultStatsModelTests.java
@@ -5,8 +5,6 @@ import static org.junit.Assert.assertEquals;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
-
 import java.util.Arrays;
 
 import com.carolinarollergirls.scoreboard.Clock;
@@ -20,7 +18,6 @@ import com.carolinarollergirls.scoreboard.model.ClockModel;
 import com.carolinarollergirls.scoreboard.model.ScoreBoardModel;
 import com.carolinarollergirls.scoreboard.model.StatsModel;
 import com.carolinarollergirls.scoreboard.model.TeamModel;
-import com.carolinarollergirls.scoreboard.xml.XmlScoreBoard;
 
 public class DefaultStatsModelTests {
 
@@ -77,7 +74,7 @@ public class DefaultStatsModelTests {
 
 
     // Start the second jam and confirm it's there.
-    sbm.stopJam();
+    sbm.stopJamTO();
     advance(0);
     sbm.startJam();
     advance(1000);
@@ -93,7 +90,7 @@ public class DefaultStatsModelTests {
     for (int i = 0; i < 3; i++) {
       sbm.startJam();
       advance(1000);
-      sbm.stopJam();
+      sbm.stopJamTO();
       advance(0);
     }
     assertEquals(2, sm.getPeriodStats().size());
@@ -135,7 +132,7 @@ public class DefaultStatsModelTests {
     team1.changeScore(5);
     advance(0);
 
-    sbm.stopJam();
+    sbm.stopJamTO();
     advance(1000);
     sbm.startJam();
     advance(1000);
@@ -159,7 +156,7 @@ public class DefaultStatsModelTests {
   public void testJamStopListener() {
     sbm.startJam();
     advance(1000);
-    sbm.stopJam();
+    sbm.stopJamTO();
     advance(1000);
 
     // Confirm stats are as expected at end of first jam.
@@ -170,7 +167,7 @@ public class DefaultStatsModelTests {
 
     sbm.startJam();
     advance(1000);
-    sbm.stopJam();
+    sbm.stopJamTO();
     advance(1000);
     jsm = psm.getJamStatsModel(2);
     assertEquals(1000, jsm.getJamClockElapsedEnd());
@@ -202,7 +199,7 @@ public class DefaultStatsModelTests {
     advance(0);
     assertEquals(Team.LEAD_LEAD, tsm1.getLeadJammer());
 
-    sbm.stopJam();
+    sbm.stopJamTO();
     advance(1000);
     // Star pass and lead still correct after jam end.
     assertEquals(true, tsm1.getStarPass());
@@ -276,7 +273,7 @@ public class DefaultStatsModelTests {
     assertEquals(false, tsm1.getSkaterStatsModel(ID_PREFIX + "100").getPenaltyBox());
 
     // Jam ends.
-    sbm.stopJam();
+    sbm.stopJamTO();
     advance(1000);
     // New jammer does not replace jammer from previous jam.
     team1.getSkaterModel(ID_PREFIX + "103").setPosition(Position.ID_JAMMER);

--- a/tests/com/carolinarollergirls/scoreboard/defaults/DefaultTeamModelTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/defaults/DefaultTeamModelTests.java
@@ -168,20 +168,20 @@ public class DefaultTeamModelTests {
 		
 		team.timeout();
 		assertEquals(0, team.getTimeouts());
-		Mockito.verify(sbModelMock).setTimeoutType("TEST", false);
+		Mockito.verify(sbModelMock).startTimeoutType("TEST", false);
 		
 		team.timeout();
-		Mockito.verify(sbModelMock, Mockito.times(1)).setTimeoutType("TEST", false);
+		Mockito.verify(sbModelMock, Mockito.times(1)).startTimeoutType("TEST", false);
 	}
 
 	@Test
 	public void testOfficialReview() {
 		team.officialReview();
 		assertEquals(0, team.getOfficialReviews());
-		Mockito.verify(sbModelMock).setTimeoutType("TEST", true);
+		Mockito.verify(sbModelMock).startTimeoutType("TEST", true);
 		
 		team.officialReview();
-		Mockito.verify(sbModelMock, Mockito.times(1)).setTimeoutType("TEST", true);
+		Mockito.verify(sbModelMock, Mockito.times(1)).startTimeoutType("TEST", true);
 	}
 
 	@Test

--- a/tests/com/carolinarollergirls/scoreboard/defaults/DefaultTeamModelTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/defaults/DefaultTeamModelTests.java
@@ -168,20 +168,20 @@ public class DefaultTeamModelTests {
 		
 		team.timeout();
 		assertEquals(0, team.getTimeouts());
-		Mockito.verify(sbModelMock).timeout(Mockito.eq(team));
+		Mockito.verify(sbModelMock).setTimeoutType("TEST", false);
 		
 		team.timeout();
-		Mockito.verify(sbModelMock, Mockito.times(1)).timeout(Mockito.eq(team));
+		Mockito.verify(sbModelMock, Mockito.times(1)).setTimeoutType("TEST", false);
 	}
 
 	@Test
 	public void testOfficialReview() {
 		team.officialReview();
 		assertEquals(0, team.getOfficialReviews());
-		Mockito.verify(sbModelMock).timeout(team, true);
+		Mockito.verify(sbModelMock).setTimeoutType("TEST", true);
 		
 		team.officialReview();
-		Mockito.verify(sbModelMock, Mockito.times(1)).timeout(team, true);
+		Mockito.verify(sbModelMock, Mockito.times(1)).setTimeoutType("TEST", true);
 	}
 
 	@Test


### PR DESCRIPTION
Visible changes:
- Before the start of a period the scoreboard will now display Jam 0 instead of Jam 1. This makes the behaviour consistent with any other time where no Jam is on and the number of the previous Jam is displayed.
- Proper fix to #48

Internal changes:
- The code from the button handling functions and event listeners has
been factored into a private set of methods that clearly spell out what each of
them does and run serialized. Only event listeners that trigger
independent of any button presses have remained and those have been
reduced to a single method call.
- With the exception of the period clock all clocks are reset and the
number increased as they are started. A convenience method has been
added to ClockModel to do this in one call. (Period clock is special as
we reset it when the intermission ends, but only start it at the first
Jam.)
- ScoreBoardModel.stopJam() has been renamed to stopJamTO() to better reflect
its current function.
- ScoreBoardModel.timeout() with parameter(s) has been renamed setTimeoutType() and the code that handles the clocks has been separated from the code that handles ownership as far as currently possible. (Since the "Timeout" button currently doubles to mark a timeout as OTO, some ownership code currently has to reside in the clock handling function. Fixing this will require a UI change.)

Closes #48 