### PR TITLE
Use the "default" operator by default.

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -88,7 +88,7 @@ function showOverlays() {
         <div class="btn">
           <h2><span class="fa fa-2x fa-gamepad"></span> OPERATOR &amp CONTROLS</h2>
           <ul>
-            <li><a href="controls/operator.html"><strong>Scoreboard Operator Panel</strong></a></li>
+            <li><a href="controls/operator.html?operator=default"><strong>Scoreboard Operator Panel</strong></a></li>
             <li><a href="controls/lineups.html">Scoreboard Assistant (Lineup Tracking)</a></li>
             <li><a href="controls/mobile.html">Jam Timer (Mobile Control)</a></li>
           </ul>


### PR DESCRIPTION
Multiple sets of keybindings is a fairly advanced feature,
and asking new users to login as their first experience of CRG
can be a bit overwhelming. Instead use the default user, which
there's a good change they were using anyway as that's what you
get if you hit the X on the login dialog.