### PR TITLE
Add an explicit place to put custom screens.

### DIFF
--- a/html/custom/readme.txt
+++ b/html/custom/readme.txt
@@ -1,0 +1,8 @@
+This directory is for custom screens such as different broadcast overlays,
+penalty views, scoreboards etc. to be placed in.
+
+It maps to the html/custom directory in your CRG install.
+
+It is recommended that each set of screens gets its own subdirectory under
+custom, to allow multiple to co-exist. All assets such as images and javascript
+should also be kept under here.

--- a/html/index.html
+++ b/html/index.html
@@ -132,6 +132,7 @@ function showOverlays() {
           <ul>
             <li><a href="controls/rulesets.html">Ruleset Editor</a></li>
             <li><a href="controls/media_management.html">Media Management</a></li>
+            <li><a href="custom/">Custom Screens</a></li>
             <li><a href="controls/twitter.html">Twitter Controls <span class="pill pill-beta">BETA</span></a></li>
             <li><a href="controls/stream.html">Load/Save Scoreboard "Stream" <span class="pill pill-beta">BETA</span></a></li>
           </ul>


### PR DESCRIPTION
As it stands there's nowhere official to put these, and
you have to know what's installed. By using the index rendering
feature of our webserver, we get a basic listing for free.