### PR TITLE
Fix lockup when overtime is called during a jam.

### DIFF
--- a/src/com/carolinarollergirls/scoreboard/defaults/DefaultStatsModel.java
+++ b/src/com/carolinarollergirls/scoreboard/defaults/DefaultStatsModel.java
@@ -231,7 +231,7 @@ public class DefaultStatsModel extends DefaultScoreBoardEventProvider implements
     }
 
     public void truncateAfterNJams(int n) {
-      requestBatchEnd();
+      requestBatchStart();
       synchronized (this) {
         while (jams.size() > n) {
           JamStatsModel jsm = jams.get(jams.size() - 1);

--- a/tests/com/carolinarollergirls/scoreboard/defaults/DefaultScoreboardModelTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/defaults/DefaultScoreboardModelTests.java
@@ -32,12 +32,25 @@ public class DefaultScoreboardModelTests {
 	private ClockModel tc;
 	private ClockModel ic;
 	private Queue<ScoreBoardEvent> collectedEvents;
-	public ScoreBoardListener listener = new ScoreBoardListener() {
-	
+	private ScoreBoardListener listener = new ScoreBoardListener() {
 		@Override
 		public void scoreBoardChange(ScoreBoardEvent event) {
 			synchronized(collectedEvents) {
 				collectedEvents.add(event);
+			}
+		}
+	};
+
+	private int batchLevel;
+	private ScoreBoardListener batchCounter = new ScoreBoardListener() {
+		@Override
+		public void scoreBoardChange(ScoreBoardEvent event) {
+			synchronized(batchCounter) {
+				if (event.getProperty().equals(ScoreBoardEvent.BATCH_START)) {
+					batchLevel++;
+				} else if (event.getProperty().equals(ScoreBoardEvent.BATCH_END)) {
+					batchLevel--;
+				}
 			}
 		}
 	};
@@ -54,6 +67,7 @@ public class DefaultScoreboardModelTests {
 		tc = sbm.getClockModel(Clock.ID_TIMEOUT);
 		ic = sbm.getClockModel(Clock.ID_INTERMISSION);
 		collectedEvents = new LinkedList<ScoreBoardEvent>();
+		sbm.addScoreBoardListener(batchCounter);
 		//Clock Sync can cause clocks to be changed when started, breaking tests.
 		sbm.getSettingsModel().set("ScoreBoard.Clock.Sync", "False");
 	}
@@ -61,6 +75,9 @@ public class DefaultScoreboardModelTests {
 	@After
 	public void tearDown() throws Exception {
 		DefaultClockModel.updateClockTimerTask.setPaused(false);
+		// Check all started batches were ended.
+		advance(0);
+		assertEquals(0, batchLevel);
 	}
 
 	private void advance(long time_ms) {
@@ -454,7 +471,7 @@ public class DefaultScoreboardModelTests {
 
 		sbm.startJam();
 		advance(1000);
-		
+
 		assertEquals(DefaultScoreBoardModel.ACTION_START_JAM, sbm.snapshot.getType());
 		assertFalse(pc.isRunning());
 		assertEquals(1, pc.getNumber());
@@ -472,10 +489,10 @@ public class DefaultScoreboardModelTests {
 		jc.setTime(74000);
 		jc.setNumber(9);
 		jc.start();
-		
+
 		sbm.startJam();
 		advance(0);
-		
+
 		assertEquals(null, sbm.snapshot);
 		assertTrue(jc.isRunning());
 		assertEquals(9, jc.getNumber());


### PR DESCRIPTION
This was due to mismatched batches, so add
general testing for that. Fix one other place
where this was an issue revealed by the new test.