### PR TITLE
When there's an penalty id we don't know, add the penalty.

### DIFF
--- a/src/com/carolinarollergirls/scoreboard/defaults/DefaultSkaterModel.java
+++ b/src/com/carolinarollergirls/scoreboard/defaults/DefaultSkaterModel.java
@@ -169,9 +169,14 @@ public class DefaultSkaterModel extends DefaultScoreBoardEventProvider implement
 							penalties.remove(p2);
 							scoreBoardChange(new ScoreBoardEvent(getSkater(), EVENT_REMOVE_PENALTY, null, p2));
 						}
-						break;
+						return;
 					}
 				}
+				// Penalty has an ID we don't have likely from the autosave, add it.
+				DefaultPenaltyModel dpm = new DefaultPenaltyModel(id, period, jam, code);
+				penalties.add(dpm);
+				sortPenalties();
+				scoreBoardChange(new ScoreBoardEvent(getSkater(), EVENT_PENALTY, getPenalties(), null));
 			}
 		}
 	}

--- a/tests/com/carolinarollergirls/scoreboard/defaults/DefaultSkaterModelTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/defaults/DefaultSkaterModelTests.java
@@ -41,6 +41,21 @@ public class DefaultSkaterModelTests {
 		assertEquals(3, penalty.getJam());
 		
 	}
+
+	@Test
+	public void add_penalty_with_id() {
+		model.AddPenaltyModel("f03d5e2e-e581-4fcb-99c7-7fbd49101a36", false, 1, 3, "C");
+
+		assertEquals(1, model.getPenalties().size());
+		assertNull(model.getFOEXPPenalty());
+
+		Skater.Penalty penalty = model.getPenalties().get(0);
+
+		assertEquals("C", penalty.getCode());
+		assertEquals(1, penalty.getPeriod());
+		assertEquals(3, penalty.getJam());
+
+	}
 	
 	@Test
 	public void add_ooo_penalty() {


### PR DESCRIPTION
PR #97 had a regression that started setting an ID
when reading in penalties from the autosave, causing them to
get silently disgarded.