### PR TITLE
Improve usability of the lineup tracker screen

### DIFF
--- a/html/controls/lineups.css
+++ b/html/controls/lineups.css
@@ -25,12 +25,12 @@ div#tableDiv table td.Position,div#tableDiv table td.Box {
 	padding-bottom: 3px;
 }
 
-div#tableDiv table th.Name { width: 15%; }
 div#tableDiv table th.Number { width: 10%; }
+div#tableDiv table th.Name { width: 15%; }
 div#tableDiv table th.Bench { width: 15%; }
+div#tableDiv table th.Jammer { width: 15%; }
 div#tableDiv table th.Pivot { width: 15%; }
 div#tableDiv table th.Blocker { width: 15%; }
-div#tableDiv table th.Jammer { width: 15%; }
 div#tableDiv table th.Box { width: 15%; }
 
 div#tableDiv table.Template { display: none; }
@@ -40,18 +40,18 @@ div#tableDiv table tr>td>a.Name { font-weight: bold; }
 
 div#tableDiv table tr.Bench>td.Bench { background: #0f0; }
 div#tableDiv table tr.Bench>td.Bench>a.Bench { display: none; }
-div#tableDiv table tr:not(.Bench)>td.Bench>a.Name { display: none; }
-div#tableDiv table tr.Pivot>td.Pivot { background: #0f0; }
-div#tableDiv table tr.Pivot>td.Pivot>a.Pivot { display: none; }
-div#tableDiv table tr:not(.Pivot)>td.Pivot>a.Name { display: none; }
-div#tableDiv table tr.Blocker>td.Blocker { background: #0f0; }
-div#tableDiv table tr.Blocker>td.Blocker>a.Blocker { display: none; }
-div#tableDiv table tr:not(.Blocker)>td.Blocker>a.Name { display: none; }
+div#tableDiv table tr:not(.Bench)>td.Bench>a.Number { display: none; }
 div#tableDiv table tr.Jammer>td.Jammer { background: #0f0; }
 div#tableDiv table tr.Jammer>td.Jammer>a.Jammer { display: none; }
-div#tableDiv table tr:not(.Jammer)>td.Jammer>a.Name { display: none; }
+div#tableDiv table tr:not(.Jammer)>td.Jammer>a.Number { display: none; }
+div#tableDiv table tr.Pivot>td.Pivot { background: #0f0; }
+div#tableDiv table tr.Pivot>td.Pivot>a.Pivot { display: none; }
+div#tableDiv table tr:not(.Pivot)>td.Pivot>a.Number { display: none; }
+div#tableDiv table tr.Blocker>td.Blocker { background: #0f0; }
+div#tableDiv table tr.Blocker>td.Blocker>a.Blocker { display: none; }
+div#tableDiv table tr:not(.Blocker)>td.Blocker>a.Number { display: none; }
 
 div#tableDiv table tr>td.Box.InBox { background: #f00; }
-div#tableDiv table tr>td.Box:not(.InBox)>a.Name { display: none; }
+div#tableDiv table tr>td.Box:not(.InBox)>a.Number { display: none; }
 div#tableDiv table tr>td.Box.InBox>a.Box { display: none; }
 

--- a/html/controls/lineups.html
+++ b/html/controls/lineups.html
@@ -31,38 +31,38 @@
 				</th>
 			</tr>
 			<tr class="Header">
-				<th class="Name">Name</th>
 				<th class="Number">#</th>
+				<th class="Name">Name</th>
 				<th class="Bench">Bench</th>
+				<th class="Jammer">Jammer</th>
 				<th class="Pivot">Pivot</th>
 				<th class="Blocker">Blocker</th>
-				<th class="Jammer">Jammer</th>
 				<th class="Box">Box</th>
 			</tr>
 		</thead>
 		<tbody>
 			<tr class="Template">
-				<td class="Name"><a class="Name"></a></td>
 				<td class="Number"><a class="Number"></a></td>
+				<td class="Name"><a class="Name"></a></td>
 				<td class="Bench Position">
 					<a class="Bench">Bench</a>
-					<a class="Name"></a>
-				</td>
-				<td class="Pivot Position">
-					<a class="Pivot">Pivot</a>
-					<a class="Name"></a>
-				</td>
-				<td class="Blocker Position">
-					<a class="Blocker">Blocker</a>
-					<a class="Name"></a>
+					<a class="Number"></a>
 				</td>
 				<td class="Jammer Position">
 					<a class="Jammer">Jammer</a>
-					<a class="Name"></a>
+					<a class="Number"></a>
+				</td>
+				<td class="Pivot Position">
+					<a class="Pivot">Pivot</a>
+					<a class="Number"></a>
+				</td>
+				<td class="Blocker Position">
+					<a class="Blocker">Blocker</a>
+					<a class="Number"></a>
 				</td>
 				<td class="Box">
 					<a class="Box">Box</a>
-					<a class="Name"></a>
+					<a class="Number"></a>
 				</td>
 			</tr>
 		</tbody>

--- a/html/javascript/sortedtable.js
+++ b/html/javascript/sortedtable.js
@@ -65,8 +65,8 @@
 				doSort(table);
 			})
 			.each(function(i, e) {
-				$("<span>^</span>").addClass(SORT_ASCEND).appendTo(e);
-				$("<span>v</span>").addClass(SORT_DESCEND).appendTo(e);
+				$("<span> ▲</span>").addClass(SORT_ASCEND).appendTo(e);
+				$("<span> ▼</span>").addClass(SORT_DESCEND).appendTo(e);
 			})
 			.first();
 		if (!th.length)


### PR DESCRIPTION
- Use roster numbers instead of skater names as main identifier
- Sort skaters by number by default
- Order positions as Jammer, Pivot, Blocker