### PR TITLE
Store operator settings with login

### DIFF
--- a/html/controls/operator.css
+++ b/html/controls/operator.css
@@ -52,6 +52,7 @@ table.RowTable { border-spacing: 0px; }
 	#TeamTime table.JamControl>tbody>tr>td { width: 100%; }
 	#TeamTime table.JamControl>tbody>tr:first-of-type>td { border-radius: 12px; }
 	#TeamTime .UndoControls:not(.ShowUndo) { display: none; }
+	#TeamTime .SingleUndoControl:not(.ShowUndo) { display: none; }
 
 	#TeamTime table.Team>tbody>tr>td { width: 50%; }
 	#TeamTime table.Team tr.Name td.Name div { max-height: 100px; max-width: 300px; overflow: hidden; font-size: 150%; }

--- a/html/controls/operator.css
+++ b/html/controls/operator.css
@@ -51,6 +51,7 @@ table.RowTable { border-spacing: 0px; }
 
 	#TeamTime table.JamControl>tbody>tr>td { width: 100%; }
 	#TeamTime table.JamControl>tbody>tr:first-of-type>td { border-radius: 12px; }
+	#TeamTime table.JamControl .Label { display: inline-block; min-width:50px; }
 	#TeamTime .UndoControls:not(.ShowUndo) { display: none; }
 	#TeamTime .SingleUndoControl:not(.ShowUndo) { display: none; }
 

--- a/html/controls/operator.js
+++ b/html/controls/operator.js
@@ -401,7 +401,7 @@ function createPeriodEndTimeoutDialog(td) {
 
 function createOvertimeDialog() {
 	var dialog = $("<div>");
-	$("<span>").text("Overtime can only be started at the end of Period ").appendTo(dialog);
+	$("<span>").text("Note: Overtime can only be started at the end of Period ").appendTo(dialog);
 	$sb("ScoreBoard.Clock(Period).MaximumNumber").$sbElement("<span>").appendTo(dialog);
 	$("<button>").addClass("StartOvertime").text("Start Overtime Lineup clock").appendTo(dialog)
 		.click(function() {
@@ -511,30 +511,62 @@ function createJamControlTable() {
 	var table = $("<table><tr><td/></tr></table>").addClass("JamControl");
 	var controlsTr = createRowTable(4,1).appendTo(table.find("td")).find("tr:eq(0)").addClass("Controls");
 
-	$sb("ScoreBoard.StartJam").$sbControl("<button>").text("Start Jam").val("true")
-		.attr("id", "StartJam").addClass("KeyControl").button()
-		.appendTo(controlsTr.children("td:eq(0)"));
-	$sb("ScoreBoard.UnStartJam").$sbControl("<button>").text("UN-Start Jam").val("true")
-		.attr("id", "UnStartJam").addClass("KeyControl UndoControls").button()
-		.appendTo(controlsTr.children("td:eq(0)"));
-
-	$sb("ScoreBoard.StopJam").$sbControl("<button>").text("Stop Jam/TO").val("true")
-		.attr("id", "StopJam").addClass("KeyControl").button()
-		.appendTo(controlsTr.children("td:eq(1)"));
-	$sb("ScoreBoard.UnStopJam").$sbControl("<button>").text("UN-Stop Jam/TO").val("true")
-		.attr("id", "UnStopJam").addClass("KeyControl UndoControls").button()
-		.appendTo(controlsTr.children("td:eq(1)"));
-
-	$sb("ScoreBoard.Timeout").$sbControl("<button>").text("Timeout").val("true")
-		.attr("id", "Timeout").addClass("KeyControl").button()
-		.appendTo(controlsTr.children("td:eq(2)"));
-	$sb("ScoreBoard.UnTimeout").$sbControl("<button>").text("UN-Timeout").val("true")
-		.attr("id", "UnTimeout").addClass("KeyControl UndoControls").button()
-		.appendTo(controlsTr.children("td:eq(2)"));
-
-	$sb("ScoreBoard.ClockUndo").$sbControl("<button>").text("Undo").val("true")
-		.attr("id", "ClockUndo").addClass("KeyControl SingleUndoControl ShowUndo").button()
-		.appendTo(controlsTr.children("td:eq(3)"));
+	var jamStartButton = $sb("ScoreBoard.StartJam").$sbControl("<button>")
+		.html("<span class=\"Label\">Start Jam</span>").val("true")
+		.attr("id", "StartJam").addClass("KeyControl").button();
+	$sb("ScoreBoard.Settings.Setting(ScoreBoard.Button.StartLabel)").$sbBindAndRun("sbchange", function(event, val) {
+		jamStartButton.find("span.Label").html(val);
+		});
+	jamStartButton.appendTo(controlsTr.children("td:eq(0)"));
+	
+	var unStartButton = $sb("ScoreBoard.UnStartJam").$sbControl("<button>")
+		.html("<span class=\"Label\">UN-Start Jam</span>").val("true")
+		.attr("id", "UnStartJam").addClass("KeyControl UndoControls").button();
+	$sb("ScoreBoard.Settings.Setting(ScoreBoard.Button.UnStartLabel)").$sbBindAndRun("sbchange", function(event, val) {
+		unStartButton.find("span.Label").html(val);
+		});
+	unStartButton.appendTo(controlsTr.children("td:eq(0)"));
+	
+	var stopButton = $sb("ScoreBoard.StopJam").$sbControl("<button>")
+		.html("<span class=\"Label\">Stop Jam/TO</span>").val("true")
+		.attr("id", "StopJam").addClass("KeyControl").button();
+	$sb("ScoreBoard.Settings.Setting(ScoreBoard.Button.StopLabel)").$sbBindAndRun("sbchange", function(event, val) {
+		stopButton.find("span.Label").html(val);
+		});
+	stopButton.appendTo(controlsTr.children("td:eq(1)"));
+	
+	var unStopButton = $sb("ScoreBoard.UnStopJam").$sbControl("<button>")
+		.html("<span class=\"Label\">UN-Stop Jam/TO</span>").val("true")
+		.attr("id", "UnStopJam").addClass("KeyControl UndoControls").button();
+	$sb("ScoreBoard.Settings.Setting(ScoreBoard.Button.UnStopLabel)").$sbBindAndRun("sbchange", function(event, val) {
+		unStopButton.find("span.Label").html(val);
+		});
+	unStopButton.appendTo(controlsTr.children("td:eq(1)"));
+	
+	var timeoutButton = $sb("ScoreBoard.Timeout").$sbControl("<button>")
+		.html("<span class=\"Label\">Timeout</span>").val("true")
+		.attr("id", "Timeout").addClass("KeyControl").button();
+	$sb("ScoreBoard.Settings.Setting(ScoreBoard.Button.TimeoutLabel)").$sbBindAndRun("sbchange", function(event, val) {
+		timeoutButton.find("span.Label").html(val);
+		});
+	timeoutButton.appendTo(controlsTr.children("td:eq(2)"));
+	
+	var unTimeoutButton = $sb("ScoreBoard.UnTimeout").$sbControl("<button>")
+		.html("<span class=\"Label\">UN-Timeout</span>").val("true")
+		.attr("id", "UnTimeout").addClass("KeyControl UndoControls").button();
+	$sb("ScoreBoard.Settings.Setting(ScoreBoard.Button.UnTimeoutLabel)").$sbBindAndRun("sbchange", function(event, val) {
+		unTimeoutButton.find("span.Label").html(val);
+		});
+	unTimeoutButton.appendTo(controlsTr.children("td:eq(2)"));
+	
+	var undoButton = $sb("ScoreBoard.ClockUndo").$sbControl("<button>")
+		.html("<span class=\"Label\">Undo</span>").val("true")
+		.attr("id", "ClockUndo").addClass("KeyControl ShowUndo").button();
+	$sb("ScoreBoard.Settings.Setting(ScoreBoard.Button.UndoLabel)").$sbBindAndRun("sbchange", function(event, val) {
+		undoButton.find("span.Label").html(val);
+		});
+	controlsTr.children("td:eq(3)").addClass("SingleUndoControl");
+	undoButton.appendTo(controlsTr.children("td:eq(3)"));
 	
 	return table;
 }
@@ -740,7 +772,7 @@ function createTeamTable() {
 		sbTeam.$sb("Score").$sbBindAndRun("sbchange", jamScoreUpdate);
 		sbTeam.$sb("LastScore").$sbBindAndRun("sbchange", jamScoreUpdate);
 
-		var timeout = sbTeam.$sb("Timeout");
+		var timeout = sbTeam.$sb("Team TO");
 		var timeoutButton = timeout.$sbControl("<button>").text("Timeout").val("true")
 			.attr("id", "Team"+team+"Timeout").addClass("KeyControl").button();
 		var timeoutHighlight = function() {

--- a/html/controls/operator.js
+++ b/html/controls/operator.js
@@ -431,7 +431,13 @@ var operatorSettings = [
 	}},
 	{ id: "ShowStartStop", display: "Show Start/Stop Buttons", type: "boolean", defaultValue: "False", func: function(value) {
 		$("#TeamTime").find("tr.Control").toggleClass("Show", isTrue(value));
-	}}
+	}},
+	{ id: "AutoStart", display: "Auto start Jam or Timeout after lineup time is up", type: "select", values: [
+			{ text: "Neither", value: "Off"},
+			{ text: "Jam", value: "Jam"},
+			{ text: "Timeout", value: "Timeout"}
+		], defaultValue: "Off", func: function(value) {}},
+	{ id: "AutoStartBuffer", display: "Delay auto start by (and adjust clocks afterwards)", type: "time", defaultValue: "0", func: function(value) {}}
 ];
 
 function setOperatorSettingsToDefault() {

--- a/src/com/carolinarollergirls/scoreboard/Ruleset.java
+++ b/src/com/carolinarollergirls/scoreboard/Ruleset.java
@@ -60,10 +60,6 @@ public class Ruleset {
 
 			newRule(new BooleanRule(false, "ScoreBoard", Clock.ID_JAM, "ResetNumberEachPeriod",   "How to handle Jam Numbers", true, "Reset each period", "Continue counting"));
 
-			newRule(new BooleanRule(false, "ScoreBoard", Clock.ID_LINEUP, "AutoStart",   "Start a Jam or Timeout when the Linup time is over its maximum by BufferTime start a Jam or Timeout as defined below. Jam/Timeout/Period Clocks will be adjusted by the buffer time. This only works if the lineup clock is counting up.", false, "Enabled", "Disabled"));
-			newRule(   new TimeRule(false, "ScoreBoard", Clock.ID_LINEUP, "AutoStartBuffer",   "How long to wait after end of lineup before auto start is triggered.", "0:02"));
-			newRule(new BooleanRule(false, "ScoreBoard", Clock.ID_LINEUP, "AutoStartType",   "What to start after lineup is up", false, "Jam", "Timeout"));
-			
 			newRule( new StringRule(false, "ScoreBoard", null, "PenaltyDefinitionFile", "", "/config/penalties/wftda2018.json"));
 			newRule(new BooleanRule(false, "ScoreBoard", null, "HideJamTotals",   "Should the score for the current Jam be displayed?", false, "Hide Jam Totals", "Show Jam Totals"));
 			newRule( new StringRule(false, "ScoreBoard", null, "BackgroundStyle", "Background style to be used. Possible values: bg_blacktowhite, bg_whitetoblack, bg_black", "bg_black"));

--- a/src/com/carolinarollergirls/scoreboard/defaults/DefaultScoreBoardModel.java
+++ b/src/com/carolinarollergirls/scoreboard/defaults/DefaultScoreBoardModel.java
@@ -46,9 +46,6 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 		Ruleset.registerRule(settings, "ScoreBoard." + Clock.ID_INTERMISSION + ".Official");
 		Ruleset.registerRule(settings, "ScoreBoard.Clock.Sync");
 		Ruleset.registerRule(settings, "ScoreBoard." + Clock.ID_JAM + ".ResetNumberEachPeriod");
-		Ruleset.registerRule(settings, "ScoreBoard." + Clock.ID_LINEUP + ".AutoStart");
-		Ruleset.registerRule(settings, "ScoreBoard." + Clock.ID_LINEUP + ".AutoStartBuffer");
-		Ruleset.registerRule(settings, "ScoreBoard." + Clock.ID_LINEUP + ".AutoStartType");
 		Ruleset.registerRule(settings, "Clock." + Clock.ID_INTERMISSION + ".Time");
 		Ruleset.registerRule(settings, "Clock." + Clock.ID_LINEUP + ".Time");
 		Ruleset.registerRule(settings, "Clock." + Clock.ID_LINEUP + ".OvertimeTime");
@@ -384,17 +381,17 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 		ClockModel lc = getClockModel(Clock.ID_LINEUP);
 		ClockModel tc = getClockModel(Clock.ID_TIMEOUT);
 		
-		long bufferTime = settings.getLong("ScoreBoard." + Clock.ID_LINEUP + ".AutoStartBuffer"); 
+		long bufferTime = settings.getLong(SETTING_AUTO_START_BUFFER); 
 		long triggerTime = bufferTime + (isInOvertime() ? 
 					settings.getLong("Clock." + Clock.ID_LINEUP + ".OvertimeTime") :
 					settings.getLong("Clock." + Clock.ID_LINEUP + ".Time"));
 
 		requestBatchStart();
 		if (lc.getTimeElapsed() >= triggerTime) {
-			if (Boolean.parseBoolean(settings.get("ScoreBoard." + Clock.ID_LINEUP + ".AutoStartType"))) {
+			if (settings.get(SETTING_AUTO_START).equals(AUTO_START_JAM)) {
 				startJam();
 				jc.elapseTime(bufferTime);
-			} else {
+			} else if (settings.get(SETTING_AUTO_START).equals(AUTO_START_TIMEOUT)) {
 				timeout();
 				pc.elapseTime(-bufferTime);
 				tc.elapseTime(bufferTime);
@@ -613,7 +610,7 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 	};
 	protected ScoreBoardListener lineupClockListener = new ScoreBoardListener() {
 		public void scoreBoardChange(ScoreBoardEvent event) {
-			if (settings.getBoolean("ScoreBoard." + Clock.ID_LINEUP + ".AutoStart")) {
+			if (!settings.get(SETTING_AUTO_START).equals(AUTO_START_DISABLED)) {
 				_possiblyAutostart();
 			}
 		}
@@ -665,7 +662,8 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 	public static final String TIMEOUT_OWNER_NONE = "";
 	public static final String DEFAULT_TIMEOUT_OWNER = TIMEOUT_OWNER_NONE;
 
-	public static final String POLICY_KEY = DefaultScoreBoardModel.class.getName() + ".policy";
+	public static final String SETTING_AUTO_START = "Operator.AutoStart";
+	public static final String SETTING_AUTO_START_BUFFER = "Operator.AutoStartBuffer";
 	
 	public static final String ACTION_START_JAM = "Start Jam";
 	public static final String ACTION_STOP_JAM = "Stop Jam";
@@ -673,5 +671,9 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 	public static final String ACTION_LINEUP = "Lineup";
 	public static final String ACTION_TIMEOUT = "Timeout";
 	public static final String ACTION_OVERTIME = "Overtime";
+
+	public static final String AUTO_START_DISABLED = "Off";
+	public static final String AUTO_START_JAM = "Jam";
+	public static final String AUTO_START_TIMEOUT = "Timeout";
 }
 

--- a/src/com/carolinarollergirls/scoreboard/defaults/DefaultScoreBoardModel.java
+++ b/src/com/carolinarollergirls/scoreboard/defaults/DefaultScoreBoardModel.java
@@ -101,9 +101,18 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 		setInPeriod(false);
 		setInOvertime(false);
 		restartPcAfterTimeout = false;
+		snapshot = null;
 		
 		settings.reset();
 		stats.reset();
+		
+		setLabel(BUTTON_START, ACTION_START_JAM);
+		setLabel(BUTTON_UNSTART, ACTION_NONE);
+		setLabel(BUTTON_STOP, ACTION_LINEUP);
+		setLabel(BUTTON_UNSTOP, ACTION_NONE);
+		setLabel(BUTTON_TIMEOUT, ACTION_TIMEOUT);
+		setLabel(BUTTON_UNTIMEOUT, ACTION_NONE);
+		setLabel(BUTTON_UNDO, ACTION_NONE);
 	}
 
 	public boolean isInPeriod() { return inPeriod; }
@@ -148,6 +157,7 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 			if (!pc.isTimeAtEnd())
 				return;
 			createSnapshot(ACTION_OVERTIME);
+			setLabels(ACTION_START_JAM, ACTION_NONE, ACTION_TIMEOUT);
 			
 			requestBatchStart();
 			setInOvertime(true);
@@ -174,6 +184,7 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 		synchronized (runLock) {
 			if (!getClock(Clock.ID_JAM).isRunning()) {
 				createSnapshot(ACTION_START_JAM);
+				setLabels(ACTION_NONE, ACTION_STOP_JAM, ACTION_TIMEOUT);
 				_startJam();
 				ScoreBoardManager.gameSnapshot();
 			}
@@ -188,12 +199,15 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 			if (jc.isRunning()) {
 				ScoreBoardManager.gameSnapshot(true);
 				createSnapshot(ACTION_STOP_JAM);
+				setLabels(ACTION_START_JAM, ACTION_NONE, ACTION_TIMEOUT);
 				_endJam(false);
 			} else if (tc.isRunning()) {
 				createSnapshot(ACTION_STOP_TO);
+				setLabels(ACTION_START_JAM, ACTION_NONE, ACTION_TIMEOUT);
 				_endTimeout();
 			} else if (!lc.isRunning()) {
 				createSnapshot(ACTION_LINEUP);
+				setLabels(ACTION_START_JAM, ACTION_NONE, ACTION_TIMEOUT);
 				_startLineup();
 			}
 		}
@@ -201,6 +215,7 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 	public void timeout() { 
 		synchronized (runLock) {
 			createSnapshot(ACTION_TIMEOUT);
+			setLabels(ACTION_START_JAM, ACTION_STOP_TO, ACTION_NONE);
 			_startTimeout();
 			ScoreBoardManager.gameSnapshot();
 		}
@@ -402,6 +417,25 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 
 
 	protected void createSnapshot(String type) {
+		setLabel(BUTTON_UNDO, UNDO_PREFIX + type);
+		if (type == ACTION_START_JAM) {
+			setLabel(BUTTON_UNSTART, UNDO_PREFIX + type);
+		} else {
+			setLabel(BUTTON_UNSTART, ACTION_NONE);
+		}
+		if (type == ACTION_STOP_JAM ||
+				type == ACTION_STOP_TO ||
+				type == ACTION_LINEUP ||
+				type == ACTION_OVERTIME) {
+			setLabel(BUTTON_UNSTOP, UNDO_PREFIX + type);
+		} else {
+			setLabel(BUTTON_UNSTOP, ACTION_NONE);
+		}
+		if (type == ACTION_TIMEOUT) {
+			setLabel(BUTTON_UNTIMEOUT, UNDO_PREFIX + type);
+		} else {
+			setLabel(BUTTON_UNTIMEOUT, ACTION_NONE);
+		}
 		snapshot = new ScoreBoardSnapshot(this, DefaultClockModel.updateClockTimerTask.getCurrentTime(), type);
 	}
 	protected long restoreSnapshot() {
@@ -417,7 +451,12 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 		setInOvertime(snapshot.inOvertime());
 		setInPeriod(snapshot.inPeriod());
 		restartPcAfterTimeout = snapshot.restartPcAfterTo();
+		setLabels(snapshot.getStartLabel(), snapshot.getStopLabel(), snapshot.getTimeoutLabel());
 		snapshot = null;
+		setLabel(BUTTON_UNDO, ACTION_NONE);
+		setLabel(BUTTON_UNSTART, ACTION_NONE);
+		setLabel(BUTTON_UNSTOP, ACTION_NONE);
+		setLabel(BUTTON_UNTIMEOUT, ACTION_NONE);
 		return relapseTime;
 	}
 	protected void relapseTime(long time) {
@@ -447,7 +486,8 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 		if (snapshot != null && 
 				(snapshot.getType() == ACTION_STOP_JAM ||
 				 snapshot.getType() == ACTION_STOP_TO ||
-				 snapshot.getType() == ACTION_LINEUP)) {
+				 snapshot.getType() == ACTION_LINEUP ||
+				 snapshot.getType() == ACTION_OVERTIME)) {
 			clockUndo();
 		}
 	}
@@ -458,6 +498,15 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 		}
 	}
 
+	protected void setLabel(String id, String value) {
+		settings.set(id, value);
+	}
+	protected void setLabels(String startLabel, String stopLabel, String timeoutLabel) {
+		setLabel(BUTTON_START, startLabel);
+		setLabel(BUTTON_STOP, stopLabel);
+		setLabel(BUTTON_TIMEOUT, timeoutLabel);
+	}
+	
 	public Ruleset _getRuleset() {
 		synchronized (rulesetLock) {
 			if (ruleset == null) {
@@ -625,6 +674,9 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 			inOvertime = sbm.isInOvertime();
 			inPeriod = sbm.isInPeriod();
 			restartPcAfterTo = sbm.restartPcAfterTimeout;
+			startLabel = sbm.getSettings().get(BUTTON_START);
+			stopLabel = sbm.getSettings().get(BUTTON_STOP);
+			timeoutLabel = sbm.getSettings().get(BUTTON_TIMEOUT);
 			clockSnapshots = new HashMap<String, DefaultClockModel.ClockSnapshotModel>();
 			for (ClockModel clock : sbm.getClockModels()) {
 				clockSnapshots.put(clock.getId(), clock.snapshot());
@@ -642,6 +694,9 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 		public boolean inOvertime() { return inOvertime; }
 		public boolean inPeriod() { return inPeriod; }
 		public boolean restartPcAfterTo() { return restartPcAfterTo; }
+		public String getStartLabel() { return startLabel; }
+		public String getStopLabel() { return stopLabel; }
+		public String getTimeoutLabel() { return timeoutLabel; }
 		public Map<String, ClockModel.ClockSnapshotModel> getClockSnapshots() { return clockSnapshots; }
 		public Map<String, TeamModel.TeamSnapshotModel> getTeamSnapshots() { return teamSnapshots; }
 		public DefaultClockModel.ClockSnapshotModel getClockSnapshot(String clock) { return clockSnapshots.get(clock); }
@@ -654,6 +709,9 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 		protected boolean inOvertime;
 		protected boolean inPeriod;
 		protected boolean restartPcAfterTo;
+		protected String startLabel;
+		protected String stopLabel;
+		protected String timeoutLabel;
 		protected Map<String, ClockModel.ClockSnapshotModel> clockSnapshots;
 		protected Map<String, TeamModel.TeamSnapshotModel> teamSnapshots;
 	}
@@ -664,6 +722,14 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 
 	public static final String SETTING_AUTO_START = "Operator.AutoStart";
 	public static final String SETTING_AUTO_START_BUFFER = "Operator.AutoStartBuffer";
+
+	public static final String BUTTON_START = "ScoreBoard.Button.StartLabel";
+	public static final String BUTTON_UNSTART = "ScoreBoard.Button.UnStartLabel";
+	public static final String BUTTON_STOP = "ScoreBoard.Button.StopLabel";
+	public static final String BUTTON_UNSTOP = "ScoreBoard.Button.UnStopLabel";
+	public static final String BUTTON_TIMEOUT = "ScoreBoard.Button.TimeoutLabel";
+	public static final String BUTTON_UNTIMEOUT = "ScoreBoard.Button.UnTimeoutLabel";
+	public static final String BUTTON_UNDO = "ScoreBoard.Button.UndoLabel";
 	
 	public static final String ACTION_START_JAM = "Start Jam";
 	public static final String ACTION_STOP_JAM = "Stop Jam";
@@ -671,6 +737,8 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 	public static final String ACTION_LINEUP = "Lineup";
 	public static final String ACTION_TIMEOUT = "Timeout";
 	public static final String ACTION_OVERTIME = "Overtime";
+	public static final String ACTION_NONE = "";
+	public static final String UNDO_PREFIX = "Un-";
 
 	public static final String AUTO_START_DISABLED = "Off";
 	public static final String AUTO_START_JAM = "Jam";


### PR DESCRIPTION
Also move them from individual buttons into a popup dialog, in order to
allow more settings to be added without cluttering the interface.

Add frontend elements for single button undo and add it as default
option for undo.