### PR TITLE
Overhaul jam & timeout controls

### DIFF
--- a/html/controls/mobile.css
+++ b/html/controls/mobile.css
@@ -30,6 +30,7 @@
 	#JamControlPage div.Period div.Number { font-size: 200% }
 	#JamControlPage div.Period div.PeriodTime { font-size: 500%; }
 	#JamControlPage div.Time a.Time { font-size: 150%; }
+	#JamControlPage span.Label { display:block; min-height: 1.4em; }
 /* END JamControlPage */
 
 /* PeriodTimePage */

--- a/html/controls/mobile.html
+++ b/html/controls/mobile.html
@@ -120,6 +120,7 @@
 			</div>
 		</div>
 		<button class="Timeout" data-role="button">Timeout</button>
+		<button class="Undo" data-role="button">Undo</button>
 		<div class="ui-grid-b Timeout">
 			<div class="ui-block-a"><button class="Team1">
 				TO 

--- a/html/controls/mobile.html
+++ b/html/controls/mobile.html
@@ -113,14 +113,14 @@
 		<div class="TimeoutTime Time"><h2>TIMEOUT Time</h2><a class="Time"></a></div>
 		<div class="ui-grid-a">
 			<div class="ui-block-a">
-				<button class="StartJam" data-role="button" data-icon="check" data-iconpos="right">Start Jam</button>
+				<button class="StartJam" data-role="button" data-icon="check" data-iconpos="right"><span class="StartLabel Label">Start Jam</span></button>
 			</div>
 			<div class="ui-block-b">
-				<button class="StopJam" data-role="button" data-icon="delete" data-iconpos="left">Stop Jam/TO</button>
+				<button class="StopJam" data-role="button" data-icon="delete" data-iconpos="left"><span class="StopLabel Label">Stop Jam/TO</span></button>
 			</div>
 		</div>
-		<button class="Timeout" data-role="button">Timeout</button>
-		<button class="Undo" data-role="button">Undo</button>
+		<button class="Timeout" data-role="button"><span class="TimeoutLabel Label">Timeout</span></button>
+		<button class="Undo" data-role="button"><span class="UndoLabel Label">Undo</span></button>
 		<div class="ui-grid-b Timeout">
 			<div class="ui-block-a"><button class="Team1">
 				TO 

--- a/html/controls/mobile.js
+++ b/html/controls/mobile.js
@@ -38,7 +38,7 @@ function setupJamControlPage() {
 	$sb("ScoreBoard.Team(1).AlternateName(mobile).Name").$sbElement("#JamControlPage div.Timeout button.Team1>span.AlternateName");
 	$sb("ScoreBoard.Team(1).Name").$sbElement("#JamControlPage div.OfficialReview button.Team1>span.Name");
 	$sb("ScoreBoard.Team(1).AlternateName(mobile).Name").$sbElement("#JamControlPage div.OfficialReview button.Team1>span.AlternateName");
-	$sb("ScoreBoard.Timeout").$sbControl("#JamControlPage div.Timeout button.Official").val(true);
+	$sb("ScoreBoard.OfficialTimeout").$sbControl("#JamControlPage div.Timeout button.Official").val(true);
 	$sb("ScoreBoard.Team(2).Timeout").$sbControl("#JamControlPage div.Timeout button.Team2").val(true);
 	$sb("ScoreBoard.Team(2).OfficialReview").$sbControl("#JamControlPage div.OfficialReview button.Team2").val(true);
 	$sb("ScoreBoard.Team(2).Name").$sbElement("#JamControlPage div.Timeout button.Team2>span.Name");

--- a/html/controls/mobile.js
+++ b/html/controls/mobile.js
@@ -52,6 +52,11 @@ function setupJamControlPage() {
 			$("#JamControlPage span.ClockBubble."+clock).toggleClass("Running", isTrue(value));
 		});
 	});
+	$.each( [ "Start", "Stop", "Timeout", "Undo" ], function(i, button) {
+		$sb("ScoreBoard.Settings.Setting(ScoreBoard.Button."+button+"Label)").$sbBindAndRun("sbchange", function(event, val) {
+			$("#JamControlPage span."+button+"Label").html(val);
+		});
+	});
 	
 	// Period number
 	$sb("ScoreBoard.Clock(Period).Number").$sbElement("#JamControlPage div.PeriodNumber a.Number");

--- a/html/controls/mobile.js
+++ b/html/controls/mobile.js
@@ -32,6 +32,7 @@ function setupJamControlPage() {
 	$sb("ScoreBoard.StartJam").$sbControl("#JamControlPage button.StartJam").val(true);
 	$sb("ScoreBoard.StopJam").$sbControl("#JamControlPage button.StopJam").val(true);
 	$sb("ScoreBoard.Timeout").$sbControl("#JamControlPage button.Timeout").val(true);
+	$sb("ScoreBoard.ClockUndo").$sbControl("#JamControlPage button.Undo").val(true);
 	$sb("ScoreBoard.Team(1).Timeout").$sbControl("#JamControlPage div.Timeout button.Team1").val(true);
 	$sb("ScoreBoard.Team(1).OfficialReview").$sbControl("#JamControlPage div.OfficialReview button.Team1").val(true);
 	$sb("ScoreBoard.Team(1).Name").$sbElement("#JamControlPage div.Timeout button.Team1>span.Name");

--- a/html/controls/operator.css
+++ b/html/controls/operator.css
@@ -44,14 +44,14 @@ table.RowTable { border-spacing: 0px; }
 	#TeamTime table.TabTable>tbody>tr:last-of-type>td { border-radius: 0px 0px 12px 12px; }
 	#TeamTime table.TabTable>tbody>tr:only-of-type>td { border-radius: 12px; }
 	#TeamTime table.TabTable>tbody>tr.Hidden>td { display: none; }
-
+	
 	#TeamTime table.MetaControl>tbody>tr>td { width: 100%; }
 	#TeamTime table.MetaControl { font-size: 65%; }
 	#TeamTime table.MetaControl>tbody>tr>td { background: #eee; }
 
 	#TeamTime table.JamControl>tbody>tr>td { width: 100%; }
 	#TeamTime table.JamControl>tbody>tr:first-of-type>td { border-radius: 12px; }
-	#TeamTime .UndoControls:not(.ShowUndo) { display: none; }
+	#TeamTime table.JamControl .Label { display: inline-block; min-width:50px; }
 
 	#TeamTime table.Team>tbody>tr>td { width: 50%; }
 	#TeamTime table.Team tr.Name td.Name div { max-height: 100px; max-width: 300px; overflow: hidden; font-size: 150%; }

--- a/html/controls/operator.css
+++ b/html/controls/operator.css
@@ -65,6 +65,10 @@ table.RowTable { border-spacing: 0px; }
 	#TeamTime table.Team tr.Timeout td.OfficialReview button.Active { color: #000; background: #3f3; }
 	#TeamTime table.Team tr.Timeout td.OfficialReviews a { font-size: 200%; }
 	#TeamTime table.Team tr.Timeout td.RetainedOfficialReview button.Active { color: #000; background: #F33; }
+	#TeamTime table.Team tr.Timeout td.OfficialTimeout { position: relative; }
+	#TeamTime table.Team tr.Timeout td.OfficialTimeout>div { position: absolute; left: 50%; width: 100%; }
+	#TeamTime table.Team tr.Timeout td.OfficialTimeout button { transform: translateY(-50%); }
+	#TeamTime table.Team tr.Timeout td.OfficialTimeout button.Active { color: #000; background: #3f3; }
 	#TeamTime table.Team tr.Jammer td.ui-buttonset label.Lead.ui-state-active { background: #3f3; }
 	#TeamTime table.Team tr.Jammer td.ui-buttonset label.StarPass.ui-state-active { background: #3f3; }
 

--- a/html/controls/operator.js
+++ b/html/controls/operator.js
@@ -469,7 +469,7 @@ function createTeamTable() {
 		var nameTr = createRowTable(2).appendTo($("<td>").appendTo(nameRow)).find("tr");
 		var scoreTr = createRowTable(3).appendTo($("<td>").appendTo(scoreRow)).find("tr");
 		var speedScoreTr = createRowTable(4).appendTo($("<td>").appendTo(speedScoreRow)).find("tr");
-		var timeoutTr = createRowTable(5).appendTo($("<td>").appendTo(timeoutRow)).find("tr");
+		var timeoutTr = createRowTable(6).appendTo($("<td>").appendTo(timeoutRow)).find("tr");
 		var jammer1Tr = createRowTable(2).appendTo($("<td>").appendTo(jammer1Row)).find("tr");
 		var jammer2Tr = createRowTable(2).appendTo($("<td>").appendTo(jammer2Row)).find("tr");
 
@@ -653,7 +653,7 @@ function createTeamTable() {
 		sbTeam.$sb("LastScore").$sbBindAndRun("sbchange", jamScoreUpdate);
 
 		var timeout = sbTeam.$sb("Timeout");
-		var timeoutButton = timeout.$sbControl("<button>").text("Timeout").val("true")
+		var timeoutButton = timeout.$sbControl("<button>").text("Team TO").val("true")
 			.attr("id", "Team"+team+"Timeout").addClass("KeyControl").button();
 		var timeoutHighlight = function() {
 			var to = $sb("ScoreBoard.TimeoutOwner").$sbGet() == team;
@@ -662,11 +662,11 @@ function createTeamTable() {
 		};
 		$sb("ScoreBoard.TimeoutOwner").$sbBindAndRun("sbchange", timeoutHighlight);
 		$sb("ScoreBoard.OfficialReview").$sbBindAndRun("sbchange", timeoutHighlight);
-		timeoutButton.appendTo(timeoutTr.children("td:eq("+(first?"0":"4")+")").addClass("Timeout"));
+		timeoutButton.appendTo(timeoutTr.children("td:eq("+(first?"0":"5")+")").addClass("Timeout"));
 		sbTeam.$sb("Timeouts").$sbControl("<a/><input type='text' size='2'/>", { sbcontrol: {
 				editOnClick: true,
-				bindClickTo: timeoutTr.children("td:eq("+(first?"1":"3")+")")
-			} }).appendTo(timeoutTr.children("td:eq("+(first?"1":"3")+")").addClass("Timeouts"));
+				bindClickTo: timeoutTr.children("td:eq("+(first?"1":"4")+")")
+			} }).appendTo(timeoutTr.children("td:eq("+(first?"1":"4")+")").addClass("Timeouts"));
 		var review = sbTeam.$sb("OfficialReview");
 		var reviewButton = review.$sbControl("<button>").text("Off Review").val("true")
 			.attr("id", "Team"+team+"OfficialReview").addClass("KeyControl").button();
@@ -677,11 +677,11 @@ function createTeamTable() {
 		};
 		$sb("ScoreBoard.TimeoutOwner").$sbBindAndRun("sbchange", reviewHighlight);
 		$sb("ScoreBoard.OfficialReview").$sbBindAndRun("sbchange", reviewHighlight);
-		reviewButton.appendTo(timeoutTr.children("td:eq("+(first?"2":"2")+")").addClass("OfficialReview"));
+		reviewButton.appendTo(timeoutTr.children("td:eq("+(first?"2":"3")+")").addClass("OfficialReview"));
 		sbTeam.$sb("OfficialReviews").$sbControl("<a/><input type='text' size='2'/>", { sbcontrol: {
 				editOnClick: true,
-				bindClickTo: timeoutTr.children("td:eq("+(first?"3":"1")+")")
-			} }).appendTo(timeoutTr.children("td:eq("+(first?"3":"1")+")").addClass("OfficialReviews"));
+				bindClickTo: timeoutTr.children("td:eq("+(first?"3":"2")+")")
+			} }).appendTo(timeoutTr.children("td:eq("+(first?"3":"2")+")").addClass("OfficialReviews"));
 		var retainedOR = sbTeam.$sb("RetainedOfficialReview");
 		var retainedORButton = retainedOR.$sbControl("<button>").text("Retained").val("true")
 			.attr("id", "Team"+team+"RetainedOfficialReview").addClass("KeyControl Box").button();
@@ -689,8 +689,19 @@ function createTeamTable() {
 			retainedORButton.val(!isTrue(value));
 			retainedORButton.toggleClass("Active", isTrue(value));
 		});
-		retainedORButton.appendTo(timeoutTr.children("td:eq("+(first?"4":"0")+")").addClass("RetainedOfficialReview"));
-
+		retainedORButton.appendTo(timeoutTr.children("td:eq("+(first?"4":"1")+")").addClass("RetainedOfficialReview"));
+		if (first) {
+			var oto = $sb("ScoreBoard.OfficialTimeout");
+			var otoButton = oto.$sbControl("<button>").text("Official TO").val("true")
+				.attr("id", "OfficialTimeout").addClass("KeyControl").button();
+			var otoHighlight = function() {
+				var to = $sb("ScoreBoard.TimeoutOwner").$sbGet() == "O";
+				otoButton.toggleClass("Active", to);
+			};
+			$sb("ScoreBoard.TimeoutOwner").$sbBindAndRun("sbchange", otoHighlight);
+			otoButton.appendTo(timeoutTr.children("td:eq(5)").addClass("OfficialTimeout"));
+			otoButton.wrap("<div></div>");
+		}
 		var leadJammerTd = jammer1Tr.children("td:eq("+(first?"0":"1")+")")
 			.append("<label id='Team"+team+"Lead' class='Lead'>Lead</label><input type='radio' value='Lead'/>")
 			[first?"append":"prepend"]("<label id='Team"+team+"NoLead' class='NoLead'>No</label><input type='radio' value='NoLead'/>")

--- a/html/controls/operator.js
+++ b/html/controls/operator.js
@@ -147,15 +147,6 @@ function createMetaControlTable() {
 	$("<a>").text("Key Control Edit mode enabled.	 Buttons do not operate in this mode.	 Move the mouse over a button, then press a normal key (not ESC, Enter, F1, etc.) to assign.")
 		.appendTo(helpTd);
 
-	$("<label>").text("Show UNDO Controls").attr("for", "ShowUndoControlsButton")
-		.appendTo(buttonsTd);
-	$("<input type='checkbox' checked='true'>").attr("id", "ShowUndoControlsButton")
-		.appendTo(buttonsTd)
-		.button()
-		.click(function() {
-			$("#TeamTime").find(".UndoControls").toggleClass("ShowUndo", this.checked);
-		});
-
 	$("<label>").text("Show Speed Score Controls").attr("for", "ShowSpeedScoreControlsButton")
 		.appendTo(buttonsTd);
 	$("<input type='checkbox'>").attr("id", "ShowSpeedScoreControlsButton")
@@ -425,28 +416,23 @@ function createOvertimeDialog() {
 
 function createJamControlTable() {
 	var table = $("<table><tr><td/></tr></table>").addClass("JamControl");
-	var controlsTr = createRowTable(3,1).appendTo(table.find("td")).find("tr:eq(0)").addClass("Controls");
+	var controlsTr = createRowTable(4,1).appendTo(table.find("td")).find("tr:eq(0)").addClass("Controls");
 
 	$sb("ScoreBoard.StartJam").$sbControl("<button>").text("Start Jam").val("true")
 		.attr("id", "StartJam").addClass("KeyControl").button()
-		.appendTo(controlsTr.children("td:eq(0)"));
-	$sb("ScoreBoard.UnStartJam").$sbControl("<button>").text("UN-Start Jam").val("true")
-		.attr("id", "UnStartJam").addClass("KeyControl UndoControls ShowUndo").button()
 		.appendTo(controlsTr.children("td:eq(0)"));
 
 	$sb("ScoreBoard.StopJam").$sbControl("<button>").text("Stop Jam/TO").val("true")
 		.attr("id", "StopJam").addClass("KeyControl").button()
 		.appendTo(controlsTr.children("td:eq(1)"));
-	$sb("ScoreBoard.UnStopJam").$sbControl("<button>").text("UN-Stop Jam/TO").val("true")
-		.attr("id", "UnStopJam").addClass("KeyControl UndoControls ShowUndo").button()
-		.appendTo(controlsTr.children("td:eq(1)"));
 
 	$sb("ScoreBoard.Timeout").$sbControl("<button>").text("Timeout").val("true")
 		.attr("id", "Timeout").addClass("KeyControl").button()
 		.appendTo(controlsTr.children("td:eq(2)"));
-	$sb("ScoreBoard.UnTimeout").$sbControl("<button>").text("UN-Timeout").val("true")
-		.attr("id", "UnTimeout").addClass("KeyControl UndoControls ShowUndo").button()
-		.appendTo(controlsTr.children("td:eq(2)"));
+
+	$sb("ScoreBoard.ClockUndo").$sbControl("<button>").text("Undo").val("true")
+	.attr("id", "Undo").addClass("KeyControl").button()
+	.appendTo(controlsTr.children("td:eq(3)"));
 
 	return table;
 }

--- a/html/controls/operator.js
+++ b/html/controls/operator.js
@@ -398,7 +398,7 @@ function createPeriodEndTimeoutDialog(td) {
 
 function createOvertimeDialog() {
 	var dialog = $("<div>");
-	$("<span>").text("Overtime can only be started at the end of Period ").appendTo(dialog);
+	$("<span>").text("Note: Overtime can only be started at the end of Period ").appendTo(dialog);
 	$sb("ScoreBoard.Clock(Period).MaximumNumber").$sbElement("<span>").appendTo(dialog);
 	$("<button>").addClass("StartOvertime").text("Start Overtime Lineup clock").appendTo(dialog)
 		.click(function() {
@@ -418,22 +418,39 @@ function createJamControlTable() {
 	var table = $("<table><tr><td/></tr></table>").addClass("JamControl");
 	var controlsTr = createRowTable(4,1).appendTo(table.find("td")).find("tr:eq(0)").addClass("Controls");
 
-	$sb("ScoreBoard.StartJam").$sbControl("<button>").text("Start Jam").val("true")
-		.attr("id", "StartJam").addClass("KeyControl").button()
-		.appendTo(controlsTr.children("td:eq(0)"));
+	var jamStartButton = $sb("ScoreBoard.StartJam").$sbControl("<button>")
+		.html("<span class=\"Label\">Start Jam</span>").val("true")
+		.attr("id", "StartJam").addClass("KeyControl").button();
+	$sb("ScoreBoard.Settings.Setting(ScoreBoard.Button.StartLabel)").$sbBindAndRun("sbchange", function(event, val) {
+		jamStartButton.find("span.Label").html(val);
+	});
+	jamStartButton.appendTo(controlsTr.children("td:eq(0)"));
 
-	$sb("ScoreBoard.StopJam").$sbControl("<button>").text("Stop Jam/TO").val("true")
-		.attr("id", "StopJam").addClass("KeyControl").button()
-		.appendTo(controlsTr.children("td:eq(1)"));
+	var stopButton = $sb("ScoreBoard.StopJam").$sbControl("<button>")
+		.html("<span class=\"Label\">Stop Jam/TO</span>").val("true")
+		.attr("id", "StopJam").addClass("KeyControl").button();
+	$sb("ScoreBoard.Settings.Setting(ScoreBoard.Button.StopLabel)").$sbBindAndRun("sbchange", function(event, val) {
+		stopButton.find("span.Label").html(val);
+	});
+	stopButton.appendTo(controlsTr.children("td:eq(1)"));
 
-	$sb("ScoreBoard.Timeout").$sbControl("<button>").text("Timeout").val("true")
-		.attr("id", "Timeout").addClass("KeyControl").button()
-		.appendTo(controlsTr.children("td:eq(2)"));
 
-	$sb("ScoreBoard.ClockUndo").$sbControl("<button>").text("Undo").val("true")
-	.attr("id", "Undo").addClass("KeyControl").button()
-	.appendTo(controlsTr.children("td:eq(3)"));
-
+	var timeoutButton = $sb("ScoreBoard.Timeout").$sbControl("<button>")
+		.html("<span class=\"Label\">Timeout</span>").val("true")
+		.attr("id", "Timeout").addClass("KeyControl").button();
+	$sb("ScoreBoard.Settings.Setting(ScoreBoard.Button.TimeoutLabel)").$sbBindAndRun("sbchange", function(event, val) {
+		timeoutButton.find("span.Label").html(val);
+		});
+	timeoutButton.appendTo(controlsTr.children("td:eq(2)"));
+	
+	var undoButton = $sb("ScoreBoard.ClockUndo").$sbControl("<button>")
+		.html("<span class=\"Label\">Undo</span>").val("true")
+		.attr("id", "ClockUndo").addClass("KeyControl").button();
+	$sb("ScoreBoard.Settings.Setting(ScoreBoard.Button.UndoLabel)").$sbBindAndRun("sbchange", function(event, val) {
+		undoButton.find("span.Label").html(val);
+		});
+	undoButton.appendTo(controlsTr.children("td:eq(3)"));
+	
 	return table;
 }
 

--- a/src/com/carolinarollergirls/scoreboard/defaults/DefaultScoreBoardModel.java
+++ b/src/com/carolinarollergirls/scoreboard/defaults/DefaultScoreBoardModel.java
@@ -124,7 +124,8 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 			setLabel(BUTTON_START, ACTION_START_JAM);
 			setLabel(BUTTON_STOP, ACTION_LINEUP);
 			setLabel(BUTTON_TIMEOUT, ACTION_TIMEOUT);
-			setLabel(BUTTON_UNDO, ACTION_NONE);		}
+			setLabel(BUTTON_UNDO, ACTION_NONE);
+		}
 	}
 
 	public boolean isInPeriod() { return inPeriod; }
@@ -703,7 +704,7 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 	public static final String BUTTON_TIMEOUT = "ScoreBoard.Button.TimeoutLabel";
 	public static final String BUTTON_UNDO = "ScoreBoard.Button.UndoLabel";
 	
-	public static final String ACTION_NONE = "";
+	public static final String ACTION_NONE = "---";
 	public static final String ACTION_START_JAM = "Start Jam";
 	public static final String ACTION_STOP_JAM = "Stop Jam";
 	public static final String ACTION_STOP_TO = "End Timeout";

--- a/src/com/carolinarollergirls/scoreboard/defaults/DefaultScoreBoardModel.java
+++ b/src/com/carolinarollergirls/scoreboard/defaults/DefaultScoreBoardModel.java
@@ -85,6 +85,8 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 		reset();
 		addInPeriodListeners();
 		xmlScoreBoard = new XmlScoreBoard(this);
+		//Button may have a label from autosave but undo will not work after restart
+		setLabel(BUTTON_UNDO, ACTION_NONE);
 	}
 
 	public String getProviderName() { return "ScoreBoard"; }

--- a/src/com/carolinarollergirls/scoreboard/defaults/DefaultScoreBoardModel.java
+++ b/src/com/carolinarollergirls/scoreboard/defaults/DefaultScoreBoardModel.java
@@ -114,12 +114,17 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 			setInOvertime(false);
 			setOfficialScore(false);
 			restartPcAfterTimeout = false;
+			snapshot = null;
 			
 			settings.reset();
 			stats.reset();
 			// Custom settings are not reset, as broadcast overlays settings etc.
 			// shouldn't be lost just because the next game is starting.
-		}
+			
+			setLabel(BUTTON_START, ACTION_START_JAM);
+			setLabel(BUTTON_STOP, ACTION_LINEUP);
+			setLabel(BUTTON_TIMEOUT, ACTION_TIMEOUT);
+			setLabel(BUTTON_UNDO, ACTION_NONE);		}
 	}
 
 	public boolean isInPeriod() { return inPeriod; }
@@ -164,6 +169,7 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 			if (!pc.isTimeAtEnd())
 				return;
 			createSnapshot(ACTION_OVERTIME);
+			setLabels(ACTION_START_JAM, ACTION_NONE, ACTION_TIMEOUT);
 			
 			requestBatchStart();
 			setInOvertime(true);
@@ -190,6 +196,7 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 		synchronized (coreLock) {
 			if (!getClock(Clock.ID_JAM).isRunning()) {
 				createSnapshot(ACTION_START_JAM);
+				setLabels(ACTION_NONE, ACTION_STOP_JAM, ACTION_TIMEOUT);
 				_startJam();
 			}
 		}
@@ -202,12 +209,15 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 
 			if (jc.isRunning()) {
 				createSnapshot(ACTION_STOP_JAM);
+				setLabels(ACTION_START_JAM, ACTION_NONE, ACTION_TIMEOUT);
 				_endJam(false);
 			} else if (tc.isRunning()) {
 				createSnapshot(ACTION_STOP_TO);
+				setLabels(ACTION_START_JAM, ACTION_NONE, ACTION_TIMEOUT);
 				_endTimeout(false);
 			} else if (!lc.isRunning()) {
 				createSnapshot(ACTION_LINEUP);
+				setLabels(ACTION_START_JAM, ACTION_NONE, ACTION_TIMEOUT);
 				_startLineup();
 			}
 		}
@@ -219,6 +229,7 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 			} else {
 				createSnapshot(ACTION_TIMEOUT);
 			}
+			setLabels(ACTION_START_JAM, ACTION_STOP_TO, ACTION_RE_TIMEOUT);
 			_startTimeout();
 		}
 	}
@@ -269,6 +280,7 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 
 		if (pc.isTimeAtEnd() && !pc.isRunning() && !jc.isRunning() && !tc.isRunning()) {
 			requestBatchStart();
+			setLabels(ACTION_START_JAM, ACTION_LINEUP, ACTION_TIMEOUT);
 			setInPeriod(false);
 			setOfficialScore(false);
 			_endLineup();
@@ -428,6 +440,7 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 
 	protected void createSnapshot(String type) {
 		snapshot = new ScoreBoardSnapshot(this, type);
+		setLabel(BUTTON_UNDO, UNDO_PREFIX + type);
 	}
 	protected void restoreSnapshot() {
 		ScoreBoardClock.getInstance().rewindTo(snapshot.getSnapshotTime());
@@ -442,6 +455,8 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 		setInOvertime(snapshot.inOvertime());
 		setInPeriod(snapshot.inPeriod());
 		restartPcAfterTimeout = snapshot.restartPcAfterTo();
+		setLabels(snapshot.getStartLabel(), snapshot.getStopLabel(), snapshot.getTimeoutLabel());
+		setLabel(BUTTON_UNDO, ACTION_NONE);
 		snapshot = null;
 	}
 	public void clockUndo() {
@@ -453,6 +468,15 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 			ScoreBoardClock.getInstance().start(true);
 			requestBatchEnd();
 		}
+	}
+	
+	protected void setLabel(String id, String value) {
+		settings.set(id, value);
+	}
+	protected void setLabels(String startLabel, String stopLabel, String timeoutLabel) {
+		setLabel(BUTTON_START, startLabel);
+		setLabel(BUTTON_STOP, stopLabel);
+		setLabel(BUTTON_TIMEOUT, timeoutLabel);
 	}
 
 	public Ruleset _getRuleset() {
@@ -594,7 +618,10 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 			ClockModel jc = getClockModel(Clock.ID_JAM);
 			if (jc.isTimeAtEnd()) {
 				//clock has run down naturally
+				requestBatchStart();
+				setLabels(ACTION_NONE, ACTION_STOP_JAM, ACTION_TIMEOUT);
 				_endJam(true);
+				requestBatchEnd();
 			}
 		}
 	};
@@ -623,6 +650,9 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 			inOvertime = sbm.isInOvertime();
 			inPeriod = sbm.isInPeriod();
 			restartPcAfterTo = sbm.restartPcAfterTimeout;
+			startLabel = sbm.getSettings().get(BUTTON_START);
+			stopLabel = sbm.getSettings().get(BUTTON_STOP);
+			timeoutLabel = sbm.getSettings().get(BUTTON_TIMEOUT);
 			clockSnapshots = new HashMap<String, DefaultClockModel.ClockSnapshotModel>();
 			for (ClockModel clock : sbm.getClockModels()) {
 				clockSnapshots.put(clock.getId(), clock.snapshot());
@@ -640,6 +670,9 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 		public boolean inOvertime() { return inOvertime; }
 		public boolean inPeriod() { return inPeriod; }
 		public boolean restartPcAfterTo() { return restartPcAfterTo; }
+		public String getStartLabel() { return startLabel; }
+		public String getStopLabel() { return stopLabel; }
+		public String getTimeoutLabel() { return timeoutLabel; }
 		public Map<String, ClockModel.ClockSnapshotModel> getClockSnapshots() { return clockSnapshots; }
 		public Map<String, TeamModel.TeamSnapshotModel> getTeamSnapshots() { return teamSnapshots; }
 		public DefaultClockModel.ClockSnapshotModel getClockSnapshot(String clock) { return clockSnapshots.get(clock); }
@@ -652,6 +685,9 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 		protected boolean inOvertime;
 		protected boolean inPeriod;
 		protected boolean restartPcAfterTo;
+		protected String startLabel;
+		protected String stopLabel;
+		protected String timeoutLabel;
 		protected Map<String, ClockModel.ClockSnapshotModel> clockSnapshots;
 		protected Map<String, TeamModel.TeamSnapshotModel> teamSnapshots;
 	}
@@ -662,6 +698,12 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 
 	public static final String POLICY_KEY = DefaultScoreBoardModel.class.getName() + ".policy";
 	
+	public static final String BUTTON_START = "ScoreBoard.Button.StartLabel";
+	public static final String BUTTON_STOP = "ScoreBoard.Button.StopLabel";
+	public static final String BUTTON_TIMEOUT = "ScoreBoard.Button.TimeoutLabel";
+	public static final String BUTTON_UNDO = "ScoreBoard.Button.UndoLabel";
+	
+	public static final String ACTION_NONE = "";
 	public static final String ACTION_START_JAM = "Start Jam";
 	public static final String ACTION_STOP_JAM = "Stop Jam";
 	public static final String ACTION_STOP_TO = "End Timeout";
@@ -669,5 +711,6 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 	public static final String ACTION_TIMEOUT = "Timeout";
 	public static final String ACTION_RE_TIMEOUT = "New Timeout";
 	public static final String ACTION_OVERTIME = "Overtime";
+	public static final String UNDO_PREFIX = "Un-";
 }
 

--- a/src/com/carolinarollergirls/scoreboard/defaults/DefaultScoreBoardModel.java
+++ b/src/com/carolinarollergirls/scoreboard/defaults/DefaultScoreBoardModel.java
@@ -454,32 +454,6 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 			requestBatchEnd();
 		}
 	}
-	public void unStartJam() {
-		synchronized (coreLock) {
-			if (snapshot != null && 
-					snapshot.getType() == ACTION_START_JAM) {
-				clockUndo();
-			}
-		}
-	}
-	public void unStopJam() {
-		synchronized (coreLock) {
-			if (snapshot != null && 
-					(snapshot.getType() == ACTION_STOP_JAM ||
-					snapshot.getType() == ACTION_STOP_TO ||
-					snapshot.getType() == ACTION_LINEUP)) {
-				clockUndo();
-			}
-		}
-	}
-	public void unTimeout() {
-		synchronized (coreLock) {
-			if (snapshot != null && 
-					snapshot.getType() == ACTION_TIMEOUT) {
-				clockUndo();
-			}
-		}
-	}
 
 	public Ruleset _getRuleset() {
 		synchronized (coreLock) {

--- a/src/com/carolinarollergirls/scoreboard/defaults/DefaultTeamModel.java
+++ b/src/com/carolinarollergirls/scoreboard/defaults/DefaultTeamModel.java
@@ -254,16 +254,16 @@ public class DefaultTeamModel extends DefaultScoreBoardEventProvider implements 
 	public void timeout() {
 		synchronized (coreLock) {
 			if (getTimeouts() > 0) {
-				changeTimeouts(-1);
 				getScoreBoardModel().setTimeoutType(getId(), false);
+				changeTimeouts(-1);
 			}
 		}
 	}
 	public void officialReview() {
 		synchronized (coreLock) {
 			if (getOfficialReviews() > 0) {
-				changeOfficialReviews(-1);
 				getScoreBoardModel().setTimeoutType(getId(), true);
+				changeOfficialReviews(-1);
 			}
 		}
 	}

--- a/src/com/carolinarollergirls/scoreboard/defaults/DefaultTeamModel.java
+++ b/src/com/carolinarollergirls/scoreboard/defaults/DefaultTeamModel.java
@@ -255,7 +255,7 @@ public class DefaultTeamModel extends DefaultScoreBoardEventProvider implements 
 		synchronized (coreLock) {
 			if (getTimeouts() > 0) {
 				changeTimeouts(-1);
-				getScoreBoardModel().startTimeoutType(getId(), false);
+				getScoreBoardModel().setTimeoutType(getId(), false);
 			}
 		}
 	}
@@ -263,7 +263,7 @@ public class DefaultTeamModel extends DefaultScoreBoardEventProvider implements 
 		synchronized (coreLock) {
 			if (getOfficialReviews() > 0) {
 				changeOfficialReviews(-1);
-				getScoreBoardModel().startTimeoutType(getId(), true);
+				getScoreBoardModel().setTimeoutType(getId(), true);
 			}
 		}
 	}

--- a/src/com/carolinarollergirls/scoreboard/model/ScoreBoardModel.java
+++ b/src/com/carolinarollergirls/scoreboard/model/ScoreBoardModel.java
@@ -36,9 +36,6 @@ public interface ScoreBoardModel extends ScoreBoard
 	public void setTimeoutType(String team, boolean review);
 
 	public void clockUndo();
-	public void unStartJam();
-	public void unStopJam();
-	public void unTimeout();
 
 	public void penalty(String teamId, String skaterId, String penaltyId, boolean fo_exp, int period, int jam, String code);
 

--- a/src/com/carolinarollergirls/scoreboard/model/ScoreBoardModel.java
+++ b/src/com/carolinarollergirls/scoreboard/model/ScoreBoardModel.java
@@ -33,7 +33,7 @@ public interface ScoreBoardModel extends ScoreBoard
 	public void stopJamTO();
 
 	public void timeout();
-	public void startTimeoutType(String team, boolean review);
+	public void setTimeoutType(String team, boolean review);
 
 	public void clockUndo();
 	public void unStartJam();

--- a/src/com/carolinarollergirls/scoreboard/xml/ScoreBoardXmlConverter.java
+++ b/src/com/carolinarollergirls/scoreboard/xml/ScoreBoardXmlConverter.java
@@ -54,6 +54,7 @@ public class ScoreBoardXmlConverter
 		editor.setElement(sb, "UnTimeout", null, "");
 		editor.setElement(sb, "ClockUndo", null, "");
 		editor.setElement(sb, "StartOvertime", null, "");
+		editor.setElement(sb, "OfficialTimeout", null, "");
 
 		editor.setElement(sb, ScoreBoard.EVENT_TIMEOUT_OWNER, null, scoreBoard.getTimeoutOwner());
 		editor.setElement(sb, ScoreBoard.EVENT_OFFICIAL_REVIEW, null, String.valueOf(scoreBoard.isOfficialReview()));
@@ -333,6 +334,8 @@ public class ScoreBoardXmlConverter
 						scoreBoardModel.clockUndo();
 					else if (name.equals("StartOvertime"))
 						scoreBoardModel.startOvertime();
+					else if (name.equals("OfficialTimeout"))
+						scoreBoardModel.setTimeoutType("O", false);
 				}
 			} catch ( Exception e ) {
 			}

--- a/src/com/carolinarollergirls/scoreboard/xml/ScoreBoardXmlConverter.java
+++ b/src/com/carolinarollergirls/scoreboard/xml/ScoreBoardXmlConverter.java
@@ -47,11 +47,8 @@ public class ScoreBoardXmlConverter
 
 		editor.setElement(sb, "Reset", null, "");
 		editor.setElement(sb, "StartJam", null, "");
-		editor.setElement(sb, "UnStartJam", null, "");
 		editor.setElement(sb, "StopJam", null, "");
-		editor.setElement(sb, "UnStopJam", null, "");
 		editor.setElement(sb, "Timeout", null, "");
-		editor.setElement(sb, "UnTimeout", null, "");
 		editor.setElement(sb, "ClockUndo", null, "");
 		editor.setElement(sb, "StartOvertime", null, "");
 		editor.setElement(sb, "OfficialTimeout", null, "");
@@ -324,12 +321,6 @@ public class ScoreBoardXmlConverter
 						scoreBoardModel.stopJamTO();
 					else if (name.equals("Timeout"))
 						scoreBoardModel.timeout();
-					else if (name.equals("UnStartJam"))
-						scoreBoardModel.unStartJam();
-					else if (name.equals("UnStopJam"))
-						scoreBoardModel.unStopJam();
-					else if (name.equals("UnTimeout"))
-						scoreBoardModel.unTimeout();
 					else if (name.equals("ClockUndo"))
 						scoreBoardModel.clockUndo();
 					else if (name.equals("StartOvertime"))

--- a/tests/com/carolinarollergirls/scoreboard/defaults/DefaultScoreboardModelTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/defaults/DefaultScoreboardModelTests.java
@@ -779,21 +779,21 @@ public class DefaultScoreboardModelTests {
 		tc.setTime(24000);
 		tc.setNumber(7);
 		assertFalse(ic.isRunning());
-		sbm.setTimeoutOwner("");
+		sbm.setTimeoutOwner(DefaultScoreBoardModel.TIMEOUT_OWNER_NONE);
 		advance(0);
 		
 		sbm.timeout();
 		advance(0);
 		
-		assertEquals(DefaultScoreBoardModel.ACTION_TIMEOUT, sbm.snapshot.getType());
+		assertEquals(DefaultScoreBoardModel.ACTION_RE_TIMEOUT, sbm.snapshot.getType());
 		assertFalse(pc.isRunning());
 		assertFalse(jc.isRunning());
 		assertFalse(lc.isRunning());
 		assertTrue(tc.isRunning());
-		assertEquals(24000, tc.getTime());
-		assertEquals(7, tc.getNumber());
+		assertTrue(tc.isTimeAtStart());
+		assertEquals(8, tc.getNumber());
 		assertFalse(ic.isRunning());
-		assertEquals("O", sbm.getTimeoutOwner());
+		assertEquals(DefaultScoreBoardModel.TIMEOUT_OWNER_NONE, sbm.getTimeoutOwner());
 		
 		sbm.timeout();
 		advance(0);
@@ -806,7 +806,8 @@ public class DefaultScoreboardModelTests {
 		sbm.setTimeoutOwner("");
 		advance(0);
 		
-		sbm.startTimeoutType("2", false);
+		sbm.setTimeoutType("2", false);
+		sbm.getTeamModel("2").setTimeouts(2);
 		advance(0);
 
 		assertEquals(DefaultScoreBoardModel.ACTION_TIMEOUT, sbm.snapshot.getType());
@@ -817,11 +818,13 @@ public class DefaultScoreboardModelTests {
 		assertFalse(ic.isRunning());
 		assertEquals("2", sbm.getTimeoutOwner());
 		assertFalse(sbm.isOfficialReview());
+		assertEquals(2, sbm.getTeam("2").getTimeouts());
 
-		sbm.startTimeoutType("1", true);
+		sbm.setTimeoutType("1", true);
 		advance(0);
 		assertEquals("1", sbm.getTimeoutOwner());
 		assertTrue(sbm.isOfficialReview());
+		assertEquals(3, sbm.getTeam("2").getTimeouts());
 	}
 	
 	@Test
@@ -1036,7 +1039,7 @@ public class DefaultScoreboardModelTests {
 		
 		//follow up with team timeout
 		advance(2000);
-		sbm.startTimeoutType("1", false);
+		sbm.setTimeoutType("1", false);
 		advance(60000);
 		sbm.stopJamTO();
 		advance(0);

--- a/tests/com/carolinarollergirls/scoreboard/defaults/DefaultScoreboardModelTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/defaults/DefaultScoreboardModelTests.java
@@ -876,6 +876,23 @@ public class DefaultScoreboardModelTests {
 	}
 	
 	@Test
+	public void testTimeoutCountOnUndo() {
+		assertEquals(3, sbm.getTeam("1").getTimeouts());
+		assertEquals(1, sbm.getTeam("2").getOfficialReviews());
+		pc.start();
+		lc.start();
+		sbm.timeout();
+		sbm.getTeamModel("1").timeout();
+		assertEquals(2, sbm.getTeam("1").getTimeouts());
+		sbm.clockUndo();
+		assertEquals(3, sbm.getTeam("1").getTimeouts());
+		sbm.getTeamModel("2").officialReview();
+		assertEquals(0, sbm.getTeam("2").getOfficialReviews());
+		sbm.clockUndo();
+		assertEquals(1, sbm.getTeam("2").getOfficialReviews());
+	}
+	
+	@Test
 	public void testPeriodClockEnd_duringLineup() {
 		pc.start();
 		assertTrue(pc.isCountDirectionDown());

--- a/tests/com/carolinarollergirls/scoreboard/defaults/DefaultTeamModelTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/defaults/DefaultTeamModelTests.java
@@ -168,20 +168,20 @@ public class DefaultTeamModelTests {
 		
 		team.timeout();
 		assertEquals(0, team.getTimeouts());
-		Mockito.verify(sbModelMock).startTimeoutType("TEST", false);
+		Mockito.verify(sbModelMock).setTimeoutType("TEST", false);
 		
 		team.timeout();
-		Mockito.verify(sbModelMock, Mockito.times(1)).startTimeoutType("TEST", false);
+		Mockito.verify(sbModelMock, Mockito.times(1)).setTimeoutType("TEST", false);
 	}
 
 	@Test
 	public void testOfficialReview() {
 		team.officialReview();
 		assertEquals(0, team.getOfficialReviews());
-		Mockito.verify(sbModelMock).startTimeoutType("TEST", true);
+		Mockito.verify(sbModelMock).setTimeoutType("TEST", true);
 		
 		team.officialReview();
-		Mockito.verify(sbModelMock, Mockito.times(1)).startTimeoutType("TEST", true);
+		Mockito.verify(sbModelMock, Mockito.times(1)).setTimeoutType("TEST", true);
 	}
 
 	@Test


### PR DESCRIPTION
- Make jam control buttons display their current function
- Use a single undo button (and remove the option to hide it)
- Move setting timeout type to Official timeout to a new button instead of reusing the start timeout button
- Selecting a timeout type during a running timeout will change the type (and credit back the timout to the previous owner, if applicable)
- Pressing the "Timeout" button again will start a new timeout (e.g. if a TTO is followed by an OTO)
- Team Timeout buttons are labelled "Team TO" instead of "Timeout"