### PR TITLE
remove advance(0) from tests

### DIFF
--- a/tests/com/carolinarollergirls/scoreboard/defaults/DefaultClockModelTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/defaults/DefaultClockModelTests.java
@@ -204,7 +204,6 @@ public class DefaultClockModelTests {
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_NAME, listener));
 		
 		clock.setName("Test Clock");
-		advance(0);
 		
 		assertEquals("Test Clock", clock.getName());
 		assertEquals(1, collectedEvents.size());
@@ -218,7 +217,6 @@ public class DefaultClockModelTests {
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_DIRECTION, listener));
 		
 		clock.setCountDirectionDown(true);
-		advance(0);
 		assertTrue(clock.isCountDirectionDown());
 		assertEquals(1, collectedEvents.size());
 		ScoreBoardEvent event = collectedEvents.poll();
@@ -227,12 +225,10 @@ public class DefaultClockModelTests {
 
 		//check idempotency
 		clock.setCountDirectionDown(true);
-		advance(0);
 		assertTrue(clock.isCountDirectionDown());
 		assertEquals(1, collectedEvents.size());
 		
 		clock.setCountDirectionDown(false);
-		advance(0);
 		assertFalse(clock.isCountDirectionDown());
 	}
 	
@@ -241,7 +237,6 @@ public class DefaultClockModelTests {
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MINIMUM_NUMBER, listener));
 		
 		clock.setMinimumNumber(1);
-		advance(0);
 		
 		// validate constraint: max >= number >= min
 		assertEquals(1, clock.getMinimumNumber());
@@ -262,11 +257,9 @@ public class DefaultClockModelTests {
 
 		
 		clock.setMinimumNumber(10);
-		advance(0);
 		collectedEvents.clear();
 
 		clock.setMinimumNumber(5);
-		advance(0);
 		
 		// validate constraint: number is automatically set to max
 		assertEquals(5, clock.getMinimumNumber());
@@ -281,7 +274,6 @@ public class DefaultClockModelTests {
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MAXIMUM_NUMBER, listener));
 		
 		clock.setMaximumNumber(5);
-		advance(0);
 		
 		assertEquals(0, clock.getMinimumNumber());
 		assertEquals(5, clock.getMaximumNumber());
@@ -301,11 +293,9 @@ public class DefaultClockModelTests {
 
 		
 		clock.setMinimumNumber(10);
-		advance(0);
 		collectedEvents.clear();
 
 		clock.setMaximumNumber(5);
-		advance(0);
 		
 		// validate constraint: cannot set a max that is < min
 		assertEquals(10, clock.getMinimumNumber());
@@ -320,11 +310,9 @@ public class DefaultClockModelTests {
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MAXIMUM_NUMBER, listener));
 		
 		clock.setMaximumNumber(5);
-		advance(0);
 		collectedEvents.clear();
 
 		clock.changeMaximumNumber(2);
-		advance(0);
 		
 		assertEquals(0, clock.getMinimumNumber());
 		assertEquals(7, clock.getMaximumNumber());
@@ -341,11 +329,9 @@ public class DefaultClockModelTests {
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MINIMUM_NUMBER, listener));
 		
 		clock.setMinimumNumber(5);
-		advance(0);
 		collectedEvents.clear();
 
 		clock.changeMinimumNumber(2);
-		advance(0);
 		
 		assertEquals(7, clock.getMinimumNumber());
 		assertEquals(7, clock.getMaximumNumber());
@@ -363,11 +349,9 @@ public class DefaultClockModelTests {
 		
 		clock.setMaximumNumber(12);
 		clock.setMinimumNumber(3);
-		advance(0);
 		collectedEvents.clear();
 		
 		clock.setNumber(5);
-		advance(0);
 		assertEquals(5, clock.getNumber());
 		assertEquals(1, collectedEvents.size());
 		ScoreBoardEvent event = collectedEvents.poll();
@@ -375,41 +359,35 @@ public class DefaultClockModelTests {
 		assertEquals(3, event.getPreviousValue());
 		
 		clock.changeNumber(3);
-		advance(0);
 		assertEquals(8, clock.getNumber());
 		assertEquals(1, collectedEvents.size());
 		collectedEvents.clear();
 	
 		// validate constraint: cannot set number above maximum
 		clock.setNumber(23);
-		advance(0);
 		assertEquals(12, clock.getNumber());
 		assertEquals(1, collectedEvents.size());
 		collectedEvents.clear();
 		
 		// validate constraint: cannot set number below minimum
 		clock.setNumber(-2);
-		advance(0);
 		assertEquals(3, clock.getNumber());
 		assertEquals(1, collectedEvents.size());
 		collectedEvents.clear();
 		
 		// ...and check that constraint is not a >0 type constraint
 		clock.setNumber(1);
-		advance(0);
 		assertEquals(3, clock.getNumber());
 		assertEquals(1, collectedEvents.size());
 		collectedEvents.clear();
 		
 		clock.changeNumber(6);
-		advance(0);
 		assertEquals(9, clock.getNumber());
 		assertEquals(1, collectedEvents.size());
 		collectedEvents.clear();
 		
 		// validate constraint: cannot changeNumber above maximum
 		clock.changeNumber(6);
-		advance(0);
 		assertEquals(12, clock.getNumber());
 		assertEquals(1, collectedEvents.size());
 		collectedEvents.clear();
@@ -417,14 +395,12 @@ public class DefaultClockModelTests {
 		
 		clock.setNumber(5);
 		clock.changeNumber(-1);
-		advance(0);
 		assertEquals(4, clock.getNumber());
 		assertEquals(2, collectedEvents.size());
 		collectedEvents.clear();
 		
 		// validate constraint: cannot changeNumber below minimum
 		clock.changeNumber(-4);
-		advance(0);
 		assertEquals(3, clock.getNumber());
 		assertEquals(1, collectedEvents.size());
 	}
@@ -436,7 +412,6 @@ public class DefaultClockModelTests {
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_TIME, listener));
 		
 		clock.setMinimumTime(1000);
-		advance(0);
 		
 		// validate constraint: max > min
 		assertEquals(1000, clock.getMinimumTime());
@@ -456,7 +431,6 @@ public class DefaultClockModelTests {
 		
 		clock.setMinimumTime(2000);
 		clock.setMinimumTime(1000);
-		advance(0);
 		
 		// validate constraint: reducing min time doesn't reset max or current time
 		assertEquals(1000, clock.getMinimumTime());
@@ -481,7 +455,6 @@ public class DefaultClockModelTests {
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MAXIMUM_TIME, listener));
 		
 		clock.setMaximumTime(5000);
-		advance(0);
 		
 		// validate constraint: increase max time doesn't reset min or current time
 		assertEquals(0, clock.getMinimumTime());
@@ -510,11 +483,9 @@ public class DefaultClockModelTests {
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MAXIMUM_TIME, listener));
 		
 		clock.setMaximumTime(1000);
-		advance(0);
 		collectedEvents.clear();
 		
 		clock.changeMaximumTime(2000);
-		advance(0);
 		
 		assertEquals(0, clock.getMinimumTime());
 		assertEquals(3000, clock.getMaximumTime());
@@ -530,11 +501,9 @@ public class DefaultClockModelTests {
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MINIMUM_TIME, listener));
 		
 		clock.setMinimumTime(5000);
-		advance(0);
 		collectedEvents.clear();
 
 		clock.changeMinimumTime(2000);
-		advance(0);
 		
 		assertEquals(7000, clock.getMinimumTime());
 		assertEquals(7000, clock.getMaximumTime());
@@ -552,11 +521,9 @@ public class DefaultClockModelTests {
 		
 		clock.setMaximumTime(5000);
 		clock.setMinimumTime(1000);
-		advance(0);
 		collectedEvents.clear();
 		
 		clock.setTime(2000);
-		advance(0);
 		assertEquals(2000, clock.getTime());
 		assertEquals(3000, clock.getInvertedTime());
 		assertEquals(1, collectedEvents.size());
@@ -565,39 +532,33 @@ public class DefaultClockModelTests {
 		assertEquals(1000, (long)event.getPreviousValue());
 		
 		clock.setTime(6000);
-		advance(0);
 		assertEquals(5000, clock.getTime());
 		assertEquals(0, clock.getInvertedTime());
 		assertEquals(1, collectedEvents.size());
 		assertEquals(5000, (long)collectedEvents.poll().getValue());
 		
 		clock.setTime(400);
-		advance(0);
 		assertEquals(1000, clock.getTime());
 		assertEquals(4000, clock.getInvertedTime());
 		assertEquals(1, collectedEvents.size());
 		collectedEvents.clear();
 		
 		clock.setTime(1200);
-		advance(0);
 		assertEquals(1200, clock.getTime());
 		assertEquals(3800, clock.getInvertedTime());
 		assertEquals(0, collectedEvents.size());
 		
 		clock.changeTime(-201);
-		advance(0);
 		assertEquals(999, clock.getTime());
 		assertEquals(1, collectedEvents.size());
 		collectedEvents.clear();
 
 		clock.setCountDirectionDown(true);
 		clock.changeTime(1);
-		advance(0);
 		assertEquals(0, collectedEvents.size());
 
 		clock.setTime(2000);
 		clock.changeTime(1200);
-		advance(0);
 		assertEquals(3200, clock.getTime());
 		assertEquals(1800, clock.getInvertedTime());
 		assertEquals(2, collectedEvents.size());
@@ -605,7 +566,6 @@ public class DefaultClockModelTests {
 		
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_INVERTED_TIME, listener));
 		clock.changeTime(-5000);
-		advance(0);
 		assertEquals(1000, clock.getTime());
 		assertEquals(4000, clock.getInvertedTime());
 		assertEquals(2, collectedEvents.size());
@@ -630,7 +590,6 @@ public class DefaultClockModelTests {
 		}
 		
 		clock.changeTime(4100);
-		advance(0);
 		assertEquals(5100, clock.getTime());
 		assertEquals(-100, clock.getInvertedTime());
 	}
@@ -646,7 +605,6 @@ public class DefaultClockModelTests {
 		assertEquals(3000, clock.getTimeRemaining());
 
 		clock.elapseTime(1000);
-		advance(0);
 		assertEquals(3000, clock.getTime());
 		assertEquals(3000, clock.getTimeElapsed());
 		assertEquals(2000, clock.getTimeRemaining());
@@ -719,7 +677,6 @@ public class DefaultClockModelTests {
 		clock.setTime(3000);
 		
 		clock.resetTime();
-		advance(0);
 		
 		assertEquals(1000, clock.getTime());
 		assertEquals(3, collectedEvents.size());
@@ -740,7 +697,6 @@ public class DefaultClockModelTests {
 		assertTrue(clock.isTimeAtStart());
 
 		clock.start();
-		advance(0);
 		assertEquals(1, collectedEvents.size());
 		ScoreBoardEvent event = collectedEvents.poll();
 		assertEquals(Clock.EVENT_RUNNING, event.getProperty());
@@ -761,7 +717,6 @@ public class DefaultClockModelTests {
 		assertEquals(Clock.EVENT_TIME, collectedEvents.poll().getProperty());
 
 		clock.stop();
-		advance(0);
 		assertEquals(1, collectedEvents.size());
 		event = collectedEvents.poll();
 		assertEquals(Clock.EVENT_RUNNING, event.getProperty());
@@ -800,10 +755,8 @@ public class DefaultClockModelTests {
 		clock.setMaximumTime(60000);
 		clock.setTime(45000);
 		assertFalse(clock.isRunning());
-		advance(0);
 		
 		clock.startNext();
-		advance(0);
 		assertTrue(clock.isRunning());
 		assertEquals(3, clock.getNumber());
 		assertTrue(clock.isTimeAtStart());
@@ -814,7 +767,6 @@ public class DefaultClockModelTests {
 	{
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_NAME, listener));
 		clock.applyRule("Clock." + ID + ".Name", "New Name");
-		advance(0);
 		assertEquals("New Name", clock.getName());
 		assertEquals(1, collectedEvents.size());
 		
@@ -827,7 +779,6 @@ public class DefaultClockModelTests {
 	{
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_DIRECTION, listener));
 		clock.applyRule("Clock." + ID + ".Direction", true);
-		advance(0);
 		assertTrue(clock.isCountDirectionDown());
 		assertEquals(1, collectedEvents.size());
 		
@@ -840,7 +791,6 @@ public class DefaultClockModelTests {
 	{
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MINIMUM_NUMBER, listener));
 		clock.applyRule("Clock." + ID + ".MinimumNumber", 10);
-		advance(0);
 		assertEquals(10, clock.getMinimumNumber());
 		assertEquals(10, clock.getMaximumNumber());
 		assertEquals(10, clock.getNumber());
@@ -858,7 +808,6 @@ public class DefaultClockModelTests {
 	{
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MAXIMUM_NUMBER, listener));
 		clock.applyRule("Clock." + ID + ".MaximumNumber", 10);
-		advance(0);
 		assertEquals(0, clock.getMinimumNumber());
 		assertEquals(10, clock.getMaximumNumber());
 		assertEquals(0, clock.getNumber());
@@ -876,7 +825,6 @@ public class DefaultClockModelTests {
 	{
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MINIMUM_TIME, listener));
 		clock.applyRule("Clock." + ID + ".MinimumTime", (long)10000);
-		advance(0);
 		assertEquals(10000, clock.getMinimumTime());
 		assertEquals(10000, clock.getMaximumTime());
 		assertEquals(10000, clock.getTime());
@@ -894,7 +842,6 @@ public class DefaultClockModelTests {
 	{
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MAXIMUM_TIME, listener));
 		clock.applyRule("Clock." + ID + ".MaximumTime", (long)10000);
-		advance(0);
 		assertEquals(0, clock.getMinimumTime());
 		assertEquals(10000, clock.getMaximumTime());
 		assertEquals(0, clock.getTime());

--- a/tests/com/carolinarollergirls/scoreboard/defaults/DefaultScoreboardModelTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/defaults/DefaultScoreboardModelTests.java
@@ -76,7 +76,6 @@ public class DefaultScoreboardModelTests {
 	public void tearDown() throws Exception {
 		ScoreBoardClock.getInstance().start(false);
 		// Check all started batches were ended.
-		advance(0);
 		assertEquals(0, batchLevel);
 	}
 
@@ -92,7 +91,6 @@ public class DefaultScoreboardModelTests {
 		sbm.addScoreBoardListener(new ConditionalScoreBoardListener(sbm, ScoreBoard.EVENT_IN_PERIOD, listener));
 		
 		sbm.setInPeriod(true);
-		advance(0);
 		assertTrue(sbm.isInPeriod());
 		assertEquals(1, collectedEvents.size());
 		ScoreBoardEvent event = collectedEvents.poll();
@@ -101,12 +99,10 @@ public class DefaultScoreboardModelTests {
 		
 		//check idempotency
 		sbm.setInPeriod(true);
-		advance(0);
 		assertTrue(sbm.isInPeriod());
 		assertEquals(0, collectedEvents.size());
 		
 		sbm.setInPeriod(false);
-		advance(0);
 		assertFalse(sbm.isInPeriod());
 	}
 
@@ -120,7 +116,6 @@ public class DefaultScoreboardModelTests {
 		sbm.addScoreBoardListener(new ConditionalScoreBoardListener(sbm, ScoreBoard.EVENT_IN_OVERTIME, listener));
 		
 		sbm.setInOvertime(true);
-		advance(0);
 		assertTrue(sbm.isInOvertime());
 		assertEquals(999999999, lc.getMaximumTime());
 		assertEquals(1, collectedEvents.size());
@@ -130,25 +125,20 @@ public class DefaultScoreboardModelTests {
 		
 		//check idempotency
 		sbm.setInOvertime(true);
-		advance(0);
 		assertTrue(sbm.isInOvertime());
 		assertEquals(0, collectedEvents.size());
 
 		sbm.setInOvertime(true);
-		advance(0);
 		assertTrue(sbm.isInOvertime());
 
 		sbm.setInOvertime(false);
-		advance(0);
 		assertFalse(sbm.isInOvertime());
 		assertEquals(999999999, lc.getMaximumTime());
 
 		//check that lineup clock maximum time is reset for countdown lineup clock
 		sbm.setInOvertime(true);
-		advance(0);
 		lc.setCountDirectionDown(true);
 		sbm.setInOvertime(false);
-		advance(0);
 		assertEquals(30000, lc.getMaximumTime());
 	}
 
@@ -158,7 +148,6 @@ public class DefaultScoreboardModelTests {
 		sbm.addScoreBoardListener(new ConditionalScoreBoardListener(sbm, ScoreBoard.EVENT_OFFICIAL_SCORE, listener));
 		
 		sbm.setOfficialScore(true);
-		advance(0);
 		assertTrue(sbm.isOfficialScore());
 		assertEquals(1, collectedEvents.size());
 		ScoreBoardEvent event = collectedEvents.poll();
@@ -167,12 +156,10 @@ public class DefaultScoreboardModelTests {
 		
 		//check idempotency
 		sbm.setOfficialScore(true);
-		advance(0);
 		assertTrue(sbm.isOfficialScore());
 		assertEquals(1, collectedEvents.size());
 		
 		sbm.setOfficialScore(false);
-		advance(0);
 		assertFalse(sbm.isOfficialScore());
 	}
 
@@ -182,7 +169,6 @@ public class DefaultScoreboardModelTests {
 		sbm.addScoreBoardListener(new ConditionalScoreBoardListener(sbm, ScoreBoard.EVENT_OFFICIAL_REVIEW, listener));
 		
 		sbm.setOfficialReview(true);
-		advance(0);
 		assertTrue(sbm.isOfficialReview());
 		assertEquals(1, collectedEvents.size());
 		ScoreBoardEvent event = collectedEvents.poll();
@@ -191,12 +177,10 @@ public class DefaultScoreboardModelTests {
 		
 		//check idempotency
 		sbm.setOfficialReview(true);
-		advance(0);
 		assertTrue(sbm.isOfficialReview());
 		assertEquals(1, collectedEvents.size());
 		
 		sbm.setOfficialReview(false);
-		advance(0);
 		assertFalse(sbm.isOfficialReview());
 	}
 
@@ -207,14 +191,12 @@ public class DefaultScoreboardModelTests {
 		
 		sbm.setTimeoutOwner("testOwner");
 		assertEquals("testOwner", sbm.getTimeoutOwner());
-		advance(0);
 		assertEquals(1, collectedEvents.size());
 		ScoreBoardEvent event = collectedEvents.poll();
 		assertEquals("testOwner", event.getValue());
 		assertEquals("", event.getPreviousValue());
 		
 		sbm.setTimeoutOwner("");
-		advance(0);
 		assertEquals("", sbm.getTimeoutOwner());
 		assertEquals(1, collectedEvents.size());
 		event = collectedEvents.poll();
@@ -239,7 +221,6 @@ public class DefaultScoreboardModelTests {
 		ic.start();
 		
 		sbm.startOvertime();
-		advance(0);
 
 		assertEquals(DefaultScoreBoardModel.ACTION_OVERTIME, sbm.snapshot.getType());
 		assertTrue(sbm.isInOvertime());
@@ -266,7 +247,6 @@ public class DefaultScoreboardModelTests {
 		ic.start();
 		
 		sbm.startOvertime();
-		advance(0);
 		
 		assertEquals(DefaultScoreBoardModel.ACTION_OVERTIME, sbm.snapshot.getType());
 		assertTrue(sbm.isInOvertime());
@@ -320,7 +300,6 @@ public class DefaultScoreboardModelTests {
 		assertFalse(ic.isRunning());
 		
 		sbm.startJam();
-		advance(0);
 		
 		assertEquals(DefaultScoreBoardModel.ACTION_START_JAM, sbm.snapshot.getType());
 		assertTrue(pc.isRunning());
@@ -350,7 +329,6 @@ public class DefaultScoreboardModelTests {
 		sbm.getTeamModel("2").setInOfficialReview(true);
 		
 		sbm.startJam();
-		advance(0);
 		
 		assertEquals(DefaultScoreBoardModel.ACTION_START_JAM, sbm.snapshot.getType());
 		assertTrue(pc.isRunning());
@@ -380,7 +358,6 @@ public class DefaultScoreboardModelTests {
 		assertFalse(ic.isRunning());
 		
 		sbm.startJam();
-		advance(0);
 		
 		assertEquals(DefaultScoreBoardModel.ACTION_START_JAM, sbm.snapshot.getType());
 		assertTrue(pc.isRunning());
@@ -406,7 +383,6 @@ public class DefaultScoreboardModelTests {
 		assertFalse(ic.isRunning());
 		
 		sbm.startJam();
-		advance(0);
 		
 		assertEquals(DefaultScoreBoardModel.ACTION_START_JAM, sbm.snapshot.getType());
 		assertTrue(pc.isRunning());
@@ -437,7 +413,6 @@ public class DefaultScoreboardModelTests {
 		assertFalse(sbm.isInPeriod());
 
 		sbm.startJam();
-		advance(0);
 		
 		assertEquals(DefaultScoreBoardModel.ACTION_START_JAM, sbm.snapshot.getType());
 		assertTrue(pc.isRunning());
@@ -491,7 +466,6 @@ public class DefaultScoreboardModelTests {
 		jc.start();
 
 		sbm.startJam();
-		advance(0);
 
 		assertEquals(null, sbm.snapshot);
 		assertTrue(jc.isRunning());
@@ -511,7 +485,6 @@ public class DefaultScoreboardModelTests {
 		sbm.getTeamModel("2").setLeadJammer(Team.LEAD_NO_LEAD);
 		
 		sbm.stopJamTO();
-		advance(0);
 		
 		assertEquals(DefaultScoreBoardModel.ACTION_STOP_JAM, sbm.snapshot.getType());
 		assertTrue(pc.isRunning());
@@ -541,7 +514,6 @@ public class DefaultScoreboardModelTests {
 		sbm.setOfficialScore(true);
 		
 		sbm.stopJamTO();
-		advance(0);
 		
 		assertEquals(DefaultScoreBoardModel.ACTION_STOP_JAM, sbm.snapshot.getType());
 		assertFalse(pc.isRunning());
@@ -571,7 +543,6 @@ public class DefaultScoreboardModelTests {
 		sbm.setOfficialReview(true);
 		
 		sbm.stopJamTO();
-		advance(0);
 		
 		assertEquals(DefaultScoreBoardModel.ACTION_STOP_TO, sbm.snapshot.getType());
 		assertFalse(pc.isRunning());
@@ -597,7 +568,6 @@ public class DefaultScoreboardModelTests {
 		assertFalse(ic.isRunning());
 		
 		sbm.stopJamTO();
-		advance(0);
 		
 		assertEquals(DefaultScoreBoardModel.ACTION_STOP_TO, sbm.snapshot.getType());
 		assertFalse(pc.isRunning());
@@ -623,7 +593,6 @@ public class DefaultScoreboardModelTests {
 		ic.start();
 		
 		sbm.stopJamTO();
-		advance(0);
 		
 		assertEquals(DefaultScoreBoardModel.ACTION_LINEUP, sbm.snapshot.getType());
 		assertFalse(pc.isRunning());
@@ -653,7 +622,6 @@ public class DefaultScoreboardModelTests {
 		ic.start();
 		
 		sbm.stopJamTO();
-		advance(0);
 		
 		assertEquals(DefaultScoreBoardModel.ACTION_LINEUP, sbm.snapshot.getType());
 		assertFalse(pc.isRunning());
@@ -673,7 +641,6 @@ public class DefaultScoreboardModelTests {
 		lc.start();
 		
 		sbm.stopJamTO();
-		advance(0);
 		
 		assertEquals(null, sbm.snapshot);
 		assertTrue(lc.isRunning());
@@ -690,10 +657,8 @@ public class DefaultScoreboardModelTests {
 		tc.setTime(23000);
 		tc.setNumber(2);
 		assertFalse(ic.isRunning());
-		advance(0);
 		
 		sbm.timeout();
-		advance(0);
 		
 		assertEquals(DefaultScoreBoardModel.ACTION_TIMEOUT, sbm.snapshot.getType());
 		assertFalse(pc.isRunning());
@@ -714,10 +679,8 @@ public class DefaultScoreboardModelTests {
 		assertFalse(lc.isRunning());
 		assertFalse(tc.isRunning());
 		assertFalse(ic.isRunning());
-		advance(0);
 		
 		sbm.timeout();
-		advance(0);
 		
 		assertEquals(DefaultScoreBoardModel.ACTION_TIMEOUT, sbm.snapshot.getType());
 		assertFalse(pc.isRunning());
@@ -735,10 +698,8 @@ public class DefaultScoreboardModelTests {
 		assertFalse(lc.isRunning());
 		assertFalse(tc.isRunning());
 		ic.start();
-		advance(0);
 		
 		sbm.timeout();
-		advance(0);
 		
 		assertEquals(DefaultScoreBoardModel.ACTION_TIMEOUT, sbm.snapshot.getType());
 		assertFalse(pc.isRunning());
@@ -756,10 +717,8 @@ public class DefaultScoreboardModelTests {
 		assertFalse(lc.isRunning());
 		assertFalse(tc.isRunning());
 		assertFalse(ic.isRunning());
-		advance(0);
 		
 		sbm.timeout();
-		advance(0);
 		
 		assertEquals(DefaultScoreBoardModel.ACTION_TIMEOUT, sbm.snapshot.getType());
 		assertFalse(pc.isRunning());
@@ -780,10 +739,8 @@ public class DefaultScoreboardModelTests {
 		tc.setNumber(7);
 		assertFalse(ic.isRunning());
 		sbm.setTimeoutOwner("");
-		advance(0);
 		
 		sbm.timeout();
-		advance(0);
 		
 		assertEquals(DefaultScoreBoardModel.ACTION_TIMEOUT, sbm.snapshot.getType());
 		assertFalse(pc.isRunning());
@@ -796,7 +753,6 @@ public class DefaultScoreboardModelTests {
 		assertEquals("O", sbm.getTimeoutOwner());
 		
 		sbm.timeout();
-		advance(0);
 		
 		assertEquals("", sbm.getTimeoutOwner());
 	}
@@ -804,10 +760,8 @@ public class DefaultScoreboardModelTests {
 	@Test
 	public void testSetTimeoutType() {
 		sbm.setTimeoutOwner("");
-		advance(0);
 		
 		sbm.startTimeoutType("2", false);
-		advance(0);
 
 		assertEquals(DefaultScoreBoardModel.ACTION_TIMEOUT, sbm.snapshot.getType());
 		assertFalse(pc.isRunning());
@@ -819,7 +773,6 @@ public class DefaultScoreboardModelTests {
 		assertFalse(sbm.isOfficialReview());
 
 		sbm.startTimeoutType("1", true);
-		advance(0);
 		assertEquals("1", sbm.getTimeoutOwner());
 		assertTrue(sbm.isOfficialReview());
 	}
@@ -829,7 +782,6 @@ public class DefaultScoreboardModelTests {
 		pc.start();
 		jc.start();
 		sbm.setInPeriod(true);
-		advance(0);
 		assertFalse(lc.isRunning());
 		assertFalse(tc.isRunning());
 		assertFalse(ic.isRunning());
@@ -853,7 +805,6 @@ public class DefaultScoreboardModelTests {
 		advance(2000);
 		
 		sbm.clockUndo();
-		advance(0);
 		//need to manually advance as the stopped clock will not catch up to system time
 		advance(ScoreBoardClock.getInstance().getLastRewind());
 		assertTrue(pc.isRunning());
@@ -884,7 +835,6 @@ public class DefaultScoreboardModelTests {
 		assertFalse(ic.isRunning());
 		ic.setNumber(0);
 		ic.setTime(3000);
-		advance(0);
 		
 		advance(2000);
 		
@@ -910,7 +860,6 @@ public class DefaultScoreboardModelTests {
 		assertFalse(lc.isRunning());
 		assertFalse(tc.isRunning());
 		assertFalse(ic.isRunning());
-		advance(0);
 		
 		advance(2000);
 		
@@ -959,7 +908,6 @@ public class DefaultScoreboardModelTests {
 		assertTrue(ic.isCountDirectionDown());
 		ic.setNumber(1);
 		ic.setTime(3000);
-		advance(0);
 		
 		advance(3000);
 		
@@ -990,7 +938,6 @@ public class DefaultScoreboardModelTests {
 		assertTrue(ic.isCountDirectionDown());
 		ic.setNumber(pc.getMaximumNumber());
 		ic.setTime(3000);
-		advance(0);
 		
 		advance(3000);
 		
@@ -1018,12 +965,10 @@ public class DefaultScoreboardModelTests {
 		sbm.timeout();
 		advance(20000);
 		sbm.stopJamTO();
-		advance(0);
 		assertFalse(pc.isRunning());
 
 		//jam ended after 30s mark, official timeout
 		sbm.startJam();
-		advance(0);
 		sbm.stopJamTO();
 		assertEquals(25000, pc.getTime());
 		assertTrue(pc.isRunning());
@@ -1031,7 +976,6 @@ public class DefaultScoreboardModelTests {
 		sbm.timeout();
 		advance(35000);
 		sbm.stopJamTO();
-		advance(0);
 		assertTrue(pc.isRunning());
 		
 		//follow up with team timeout
@@ -1039,7 +983,6 @@ public class DefaultScoreboardModelTests {
 		sbm.startTimeoutType("1", false);
 		advance(60000);
 		sbm.stopJamTO();
-		advance(0);
 		assertFalse(pc.isRunning());
 		assertEquals(22000, pc.getTimeRemaining());
 	}

--- a/tests/com/carolinarollergirls/scoreboard/defaults/DefaultStatsModelTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/defaults/DefaultStatsModelTests.java
@@ -73,7 +73,6 @@ public class DefaultStatsModelTests {
 
 		// Start the second jam and confirm it's there.
 		sbm.stopJamTO();
-		advance(0);
 		sbm.startJam();
 		advance(1000);
 		assertEquals(2, psm.getJamStats().size());
@@ -89,7 +88,6 @@ public class DefaultStatsModelTests {
 			sbm.startJam();
 			advance(1000);
 			sbm.stopJamTO();
-			advance(0);
 		}
 		assertEquals(2, sm.getPeriodStats().size());
 		StatsModel.PeriodStatsModel psm = sm.getPeriodStatsModel(2);
@@ -97,7 +95,6 @@ public class DefaultStatsModelTests {
 
 		// Truncate jams.
 		jc.setNumber(1);
-		advance(0);
 		assertEquals(1, psm.getJamStats().size());
 	}
 
@@ -105,7 +102,6 @@ public class DefaultStatsModelTests {
 	public void testJamStartListener() {
 		team1.getSkaterModel(ID_PREFIX + "100").setPosition(Position.ID_JAMMER);
 		team1.getSkaterModel(ID_PREFIX + "101").setPosition(Position.ID_PIVOT);
-		advance(0);
 
 		sbm.startJam();
 		advance(1000);
@@ -128,7 +124,6 @@ public class DefaultStatsModelTests {
 		// Team 1 gets lead and scores.
 		team1.setLeadJammer(Team.LEAD_LEAD);
 		team1.changeScore(5);
-		advance(0);
 
 		sbm.stopJamTO();
 		advance(1000);
@@ -183,18 +178,15 @@ public class DefaultStatsModelTests {
 
 		// Change the score during the jam.
 		team1.changeScore(5);
-		advance(0);
 		assertEquals(5, tsm1.getTotalScore());
 		assertEquals(5, tsm1.getJamScore());
 
 		// Star pass during the jam.
 		team1.setStarPass(true);
-		advance(0);
 		assertEquals(true, tsm1.getStarPass());
 
 		// Lead during the jam.
 		team1.setLeadJammer(Team.LEAD_LEAD);
-		advance(0);
 		assertEquals(Team.LEAD_LEAD, tsm1.getLeadJammer());
 
 		sbm.stopJamTO();
@@ -205,7 +197,6 @@ public class DefaultStatsModelTests {
 
 		// Some points arrive after end of jam.
 		team1.changeScore(4);
-		advance(0);
 		assertEquals(9, tsm1.getTotalScore());
 		assertEquals(9, tsm1.getJamScore());
 
@@ -229,7 +220,6 @@ public class DefaultStatsModelTests {
 
 		// Add points during the jam, jam score is correct.
 		team1.changeScore(3);
-		advance(0);
 		assertEquals(12, tsm1.getTotalScore());
 		assertEquals(3, tsm1.getJamScore());
 	}
@@ -239,7 +229,6 @@ public class DefaultStatsModelTests {
 		// Some skater positions set before jam.
 		team1.getSkaterModel(ID_PREFIX + "100").setPosition(Position.ID_JAMMER);
 		team1.getSkaterModel(ID_PREFIX + "101").setPosition(Position.ID_PIVOT);
-		advance(0);
 
 		sbm.startJam();
 		advance(1000);
@@ -250,24 +239,20 @@ public class DefaultStatsModelTests {
 
 		// Blocker is added after the jam stats. All positions in place.
 		team1.getSkaterModel(ID_PREFIX + "102").setPosition(Position.ID_BLOCKER1);
-		advance(0);
 		assertEquals(Position.ID_JAMMER, tsm1.getSkaterStatsModel(ID_PREFIX + "100").getPosition());
 		assertEquals(Position.ID_PIVOT, tsm1.getSkaterStatsModel(ID_PREFIX + "101").getPosition());
 		assertEquals(Position.ID_BLOCKER1, tsm1.getSkaterStatsModel(ID_PREFIX + "102").getPosition());
 
 		// Skater was actually on bench.
 		team1.getSkaterModel(ID_PREFIX + "102").setPosition(Position.ID_BENCH);
-		advance(0);
 		assertEquals(null, tsm1.getSkaterStatsModel(ID_PREFIX + "102"));
 
 		// Skater goes to the box.
 		team1.getSkaterModel(ID_PREFIX + "100").setPenaltyBox(true);
-		advance(0);
 		assertEquals(true, tsm1.getSkaterStatsModel(ID_PREFIX + "100").getPenaltyBox());
 
 		// Skater exits the box.
 		team1.getSkaterModel(ID_PREFIX + "100").setPenaltyBox(false);
-		advance(0);
 		assertEquals(false, tsm1.getSkaterStatsModel(ID_PREFIX + "100").getPenaltyBox());
 
 		// Jam ends.
@@ -275,7 +260,6 @@ public class DefaultStatsModelTests {
 		advance(1000);
 		// New jammer does not replace jammer from previous jam.
 		team1.getSkaterModel(ID_PREFIX + "103").setPosition(Position.ID_JAMMER);
-		advance(0);
 		assertEquals(Position.ID_JAMMER, tsm1.getSkaterStatsModel(ID_PREFIX + "100").getPosition());
 	}
 

--- a/tests/com/carolinarollergirls/scoreboard/defaults/DefaultTeamModelTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/defaults/DefaultTeamModelTests.java
@@ -12,7 +12,6 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import com.carolinarollergirls.scoreboard.Ruleset;
-import com.carolinarollergirls.scoreboard.event.AsyncScoreBoardListener;
 import com.carolinarollergirls.scoreboard.event.ConditionalScoreBoardListener;
 import com.carolinarollergirls.scoreboard.event.ScoreBoardEvent;
 import com.carolinarollergirls.scoreboard.event.ScoreBoardListener;
@@ -43,11 +42,6 @@ public class DefaultTeamModelTests {
 	
 	private DefaultTeamModel team;
 	private static String ID = "TEST";
-	
-	private void advance(long time_ms) {
-		ScoreBoardClock.getInstance().advance(time_ms);
-	    AsyncScoreBoardListener.waitForEvents();
-	}
 	
 	@Before
 	public void setUp() throws Exception {
@@ -85,7 +79,6 @@ public class DefaultTeamModelTests {
 		team.addScoreBoardListener(new ConditionalScoreBoardListener(team, Team.EVENT_LAST_SCORE, listener));
 		
 		team.startJam();
-		advance(0);
 		
 		assertEquals(34, team.getLastScore());
 		assertEquals(1, collectedEvents.size());
@@ -99,7 +92,6 @@ public class DefaultTeamModelTests {
 		team.addScoreBoardListener(new ConditionalScoreBoardListener(team, Team.EVENT_STAR_PASS, listener));
 		
 		team.stopJam();
-		advance(0);
 		
 		assertEquals(Team.LEAD_NO_LEAD, team.getLeadJammer());
 		assertEquals(false, team.isStarPass());
@@ -134,12 +126,10 @@ public class DefaultTeamModelTests {
 		team.setInOfficialReview(true);
 		team.setTimeouts(1);
 		team.setOfficialReviews(0);
-		advance(0);
 		
 		//snapshot should not be applied when id doesn't match
 		team.id = "OTHER";
 		team.restoreSnapshot(snapshot);
-		advance(0);
 		assertEquals(Team.LEAD_LOST_LEAD, team.getLeadJammer());
 		assertTrue(team.isStarPass());
 		assertEquals(5, team.getScore());
@@ -151,7 +141,6 @@ public class DefaultTeamModelTests {
 		
 		team.id = "TEST";
 		team.restoreSnapshot(snapshot);
-		advance(0);
 		assertEquals(Team.LEAD_NO_LEAD, team.getLeadJammer());
 		assertFalse(team.isStarPass());
 		assertEquals(5, team.getScore()); //score is not reset
@@ -189,7 +178,6 @@ public class DefaultTeamModelTests {
 		team.addScoreBoardListener(new ConditionalScoreBoardListener(team, Team.EVENT_SCORE, listener));
 		
 		team.setScore(5);
-		advance(0);
 		assertEquals(5, team.getScore());
 		assertEquals(1, collectedEvents.size());
 		ScoreBoardEvent event = collectedEvents.poll();
@@ -200,13 +188,11 @@ public class DefaultTeamModelTests {
 		//setting a value below lastScore changes lastScore
 		team.setLastScore(4);
 		team.setScore(3);
-		advance(0);
 		assertEquals(3, team.getLastScore());
 		
 		//negative values are clamped
 		collectedEvents.clear();
 		team.setScore(-1);
-		advance(0);
 		assertEquals(0,team.getScore());
 		assertEquals(1, collectedEvents.size());
 		assertEquals(0, collectedEvents.poll().getValue());
@@ -218,7 +204,6 @@ public class DefaultTeamModelTests {
 
 		team.setScore(5);
 		team.changeScore(3);
-		advance(0);
 		assertEquals(8, team.getScore());
 		assertEquals(2, collectedEvents.size());
 		
@@ -232,7 +217,6 @@ public class DefaultTeamModelTests {
 		team.setScore(10);
 		
 		team.setLastScore(5);
-		advance(0);
 		assertEquals(5, team.getLastScore());
 		assertEquals(1, collectedEvents.size());
 		ScoreBoardEvent event = collectedEvents.poll();
@@ -241,7 +225,6 @@ public class DefaultTeamModelTests {
 
 		//values higher than score are clamped
 		team.setLastScore(12);
-		advance(0);
 		assertEquals(10, team.getLastScore());
 		assertEquals(1, collectedEvents.size());
 		assertEquals(10, collectedEvents.poll().getValue());
@@ -258,7 +241,6 @@ public class DefaultTeamModelTests {
 		team.setScore(10);
 		team.setLastScore(5);
 		team.changeLastScore(3);
-		advance(0);
 		assertEquals(8, team.getLastScore());
 		assertEquals(2, collectedEvents.size());
 		
@@ -272,7 +254,6 @@ public class DefaultTeamModelTests {
 		team.addScoreBoardListener(new ConditionalScoreBoardListener(team, Team.EVENT_IN_TIMEOUT, listener));
 		
 		team.setInTimeout(true);
-		advance(0);
 		assertTrue(team.inTimeout());
 		assertEquals(1, collectedEvents.size());
 		ScoreBoardEvent event = collectedEvents.poll();
@@ -281,12 +262,10 @@ public class DefaultTeamModelTests {
 
 		//check idempotency
 		team.setInTimeout(true);
-		advance(0);
 		assertTrue(team.inTimeout());
 		assertEquals(0, collectedEvents.size());
 		
 		team.setInTimeout(false);
-		advance(0);
 		assertFalse(team.inTimeout());
 	}
 
@@ -296,7 +275,6 @@ public class DefaultTeamModelTests {
 		team.addScoreBoardListener(new ConditionalScoreBoardListener(team, Team.EVENT_IN_OFFICIAL_REVIEW, listener));
 		
 		team.setInOfficialReview(true);
-		advance(0);
 		assertTrue(team.inOfficialReview());
 		assertEquals(1, collectedEvents.size());
 		ScoreBoardEvent event = collectedEvents.poll();
@@ -305,12 +283,10 @@ public class DefaultTeamModelTests {
 
 		//check idempotency
 		team.setInOfficialReview(true);
-		advance(0);
 		assertTrue(team.inOfficialReview());
 		assertEquals(0, collectedEvents.size());
 		
 		team.setInOfficialReview(false);
-		advance(0);
 		assertFalse(team.inOfficialReview());
 	}
 
@@ -322,7 +298,6 @@ public class DefaultTeamModelTests {
 		team.addScoreBoardListener(new ConditionalScoreBoardListener(team, Team.EVENT_OFFICIAL_REVIEWS, listener));
 		
 		team.setRetainedOfficialReview(true);
-		advance(0);
 		assertTrue(team.retainedOfficialReview());
 		assertEquals(1, team.getOfficialReviews());
 		assertEquals(1, collectedEvents.size());
@@ -332,19 +307,15 @@ public class DefaultTeamModelTests {
 
 		//check idempotency
 		team.setRetainedOfficialReview(true);
-		advance(0);
 		assertTrue(team.retainedOfficialReview());
 		assertEquals(0, collectedEvents.size());
 		
 		team.setRetainedOfficialReview(false);
-		advance(0);
 		assertFalse(team.retainedOfficialReview());
 	
 		team.setOfficialReviews(0);
-		advance(0);
 		collectedEvents.clear();
 		team.setRetainedOfficialReview(true);
-		advance(0);
 		assertEquals(1, team.getOfficialReviews());
 		assertEquals(2, collectedEvents.size());
 	}
@@ -355,7 +326,6 @@ public class DefaultTeamModelTests {
 		team.maximumTimeouts = 5;
 		
 		team.setTimeouts(4);
-		advance(0);
 		assertEquals(4, team.getTimeouts());
 		assertEquals(1, collectedEvents.size());
 		ScoreBoardEvent event = collectedEvents.poll();
@@ -364,7 +334,6 @@ public class DefaultTeamModelTests {
 
 		//values higher than maximum are clamped
 		team.setTimeouts(12);
-		advance(0);
 		assertEquals(5, team.getTimeouts());
 		assertEquals(1, collectedEvents.size());
 		assertEquals(5, collectedEvents.poll().getValue());
@@ -380,7 +349,6 @@ public class DefaultTeamModelTests {
 		assertEquals(3, team.getTimeouts());
 
 		team.changeTimeouts(-2);
-		advance(0);
 		assertEquals(1, team.getTimeouts());
 		assertEquals(1, collectedEvents.size());
 		
@@ -394,7 +362,6 @@ public class DefaultTeamModelTests {
 		team.maximumOfficialReviews = 5;
 		
 		team.setOfficialReviews(4);
-		advance(0);
 		assertEquals(4, team.getOfficialReviews());
 		assertEquals(1, collectedEvents.size());
 		ScoreBoardEvent event = collectedEvents.poll();
@@ -403,7 +370,6 @@ public class DefaultTeamModelTests {
 
 		//values higher than maximum are clamped
 		team.setOfficialReviews(12);
-		advance(0);
 		assertEquals(5, team.getOfficialReviews());
 		assertEquals(1, collectedEvents.size());
 		assertEquals(5, collectedEvents.poll().getValue());
@@ -420,7 +386,6 @@ public class DefaultTeamModelTests {
 		assertEquals(1, team.getOfficialReviews());
 
 		team.changeOfficialReviews(2);
-		advance(0);
 		assertEquals(3, team.getOfficialReviews());
 		assertEquals(1, collectedEvents.size());
 		
@@ -440,11 +405,9 @@ public class DefaultTeamModelTests {
 		team.setRetainedOfficialReview(true);
 		team.setTimeouts(1);
 		team.setOfficialReviews(0);
-		advance(0);
 		collectedEvents.clear();
 		
 		team.resetTimeouts(false);
-		advance(0);
 		assertFalse(team.inTimeout());
 		assertFalse(team.inOfficialReview());
 		assertEquals(1, team.getTimeouts());
@@ -466,10 +429,8 @@ public class DefaultTeamModelTests {
 		team.setRetainedOfficialReview(true);
 		team.setTimeouts(1);
 		team.setOfficialReviews(0);
-		advance(0);
 		collectedEvents.clear();
 		team.resetTimeouts(true);
-		advance(0);
 		assertFalse(team.inTimeout());
 		assertFalse(team.inOfficialReview());
 		assertEquals(3, team.getTimeouts());
@@ -492,10 +453,8 @@ public class DefaultTeamModelTests {
 		team.setRetainedOfficialReview(true);
 		team.setTimeouts(1);
 		team.setOfficialReviews(0);
-		advance(0);
 		collectedEvents.clear();
 		team.resetTimeouts(false);
-		advance(0);
 		assertEquals(4, team.getTimeouts());
 		assertEquals(0, team.getOfficialReviews());
 		assertTrue(team.retainedOfficialReview());
@@ -509,7 +468,6 @@ public class DefaultTeamModelTests {
 		team.addScoreBoardListener(new ConditionalScoreBoardListener(team, Team.EVENT_LEAD_JAMMER, listener));
 		
 		team.setLeadJammer(Team.LEAD_LEAD);
-		advance(0);
 		assertEquals(Team.LEAD_LEAD, team.getLeadJammer());
 		assertEquals(1, collectedEvents.size());
 		ScoreBoardEvent event = collectedEvents.poll();
@@ -518,16 +476,13 @@ public class DefaultTeamModelTests {
 
 		//check idempotency
 		team.setLeadJammer(Team.LEAD_LEAD);
-		advance(0);
 		assertEquals(Team.LEAD_LEAD, team.getLeadJammer());
 		assertEquals(1, collectedEvents.size());
 		
 		team.setLeadJammer(Team.LEAD_LOST_LEAD);
-		advance(0);
 		assertEquals(Team.LEAD_LOST_LEAD, team.getLeadJammer());
 		
 		team.setLeadJammer(Team.LEAD_NO_LEAD);
-		advance(0);
 		assertEquals(Team.LEAD_NO_LEAD, team.getLeadJammer());
 	}
 
@@ -537,7 +492,6 @@ public class DefaultTeamModelTests {
 		team.addScoreBoardListener(new ConditionalScoreBoardListener(team, Team.EVENT_STAR_PASS, listener));
 		
 		team.setStarPass(true);
-		advance(0);
 		assertTrue(team.isStarPass());
 		assertEquals(1, collectedEvents.size());
 		ScoreBoardEvent event = collectedEvents.poll();
@@ -546,12 +500,10 @@ public class DefaultTeamModelTests {
 
 		//check idempotency
 		team.setStarPass(true);
-		advance(0);
 		assertTrue(team.isStarPass());
 		assertEquals(1, collectedEvents.size());
 		
 		team.setStarPass(false);
-		advance(0);
 		assertFalse(team.isStarPass());
 	}
 }


### PR DESCRIPTION
They served to wait for events, which we don't need anymore with
synchronous events.