### PR TITLE
Sendq fix

### DIFF
--- a/src/com/carolinarollergirls/scoreboard/json/ScoreBoardJSONListener.java
+++ b/src/com/carolinarollergirls/scoreboard/json/ScoreBoardJSONListener.java
@@ -12,7 +12,6 @@ import java.util.LinkedList;
 import java.util.List;
 
 import com.carolinarollergirls.scoreboard.ScoreBoardManager;
-import com.carolinarollergirls.scoreboard.event.AsyncScoreBoardListener;
 import com.carolinarollergirls.scoreboard.event.ScoreBoardEvent;
 import com.carolinarollergirls.scoreboard.event.ScoreBoardEventProvider;
 import com.carolinarollergirls.scoreboard.event.ScoreBoardListener;
@@ -36,7 +35,7 @@ public class ScoreBoardJSONListener implements ScoreBoardListener
 	public ScoreBoardJSONListener(ScoreBoard sb, JSONStateManager jsm) {
 		this.jsm = jsm;
 		initialize(sb);
-		sb.addScoreBoardListener(new AsyncScoreBoardListener(this));
+		sb.addScoreBoardListener(this);
 	}
 
 	public void scoreBoardChange(ScoreBoardEvent event) {

--- a/tests/com/carolinarollergirls/scoreboard/defaults/DefaultClockModelTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/defaults/DefaultClockModelTests.java
@@ -15,7 +15,6 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import com.carolinarollergirls.scoreboard.Ruleset;
-import com.carolinarollergirls.scoreboard.event.AsyncScoreBoardListener;
 import com.carolinarollergirls.scoreboard.event.ConditionalScoreBoardListener;
 import com.carolinarollergirls.scoreboard.event.ScoreBoardEvent;
 import com.carolinarollergirls.scoreboard.event.ScoreBoardListener;
@@ -50,7 +49,6 @@ public class DefaultClockModelTests {
 	
 	private void advance(long time_ms) {
 		ScoreBoardClock.getInstance().advance(time_ms);
-	    AsyncScoreBoardListener.waitForEvents();
 	}
 	
 	@Before

--- a/tests/com/carolinarollergirls/scoreboard/defaults/DefaultScoreboardModelTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/defaults/DefaultScoreboardModelTests.java
@@ -13,7 +13,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.carolinarollergirls.scoreboard.ScoreBoardManager;
-import com.carolinarollergirls.scoreboard.event.AsyncScoreBoardListener;
 import com.carolinarollergirls.scoreboard.event.ConditionalScoreBoardListener;
 import com.carolinarollergirls.scoreboard.event.ScoreBoardEvent;
 import com.carolinarollergirls.scoreboard.event.ScoreBoardListener;
@@ -81,9 +80,7 @@ public class DefaultScoreboardModelTests {
 	}
 
 	private void advance(long time_ms) {
-		AsyncScoreBoardListener.waitForEvents();
 		ScoreBoardClock.getInstance().advance(time_ms);
-		AsyncScoreBoardListener.waitForEvents();
 	}
 	
 	@Test

--- a/tests/com/carolinarollergirls/scoreboard/defaults/DefaultStatsModelTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/defaults/DefaultStatsModelTests.java
@@ -8,7 +8,6 @@ import org.junit.Test;
 import java.util.Arrays;
 
 import com.carolinarollergirls.scoreboard.ScoreBoardManager;
-import com.carolinarollergirls.scoreboard.event.AsyncScoreBoardListener;
 import com.carolinarollergirls.scoreboard.jetty.JettyServletScoreBoardController;
 import com.carolinarollergirls.scoreboard.model.ClockModel;
 import com.carolinarollergirls.scoreboard.model.ScoreBoardModel;
@@ -55,9 +54,7 @@ public class DefaultStatsModelTests {
 	}
 
 	private void advance(long time_ms) {
-		AsyncScoreBoardListener.waitForEvents();
 		ScoreBoardClock.getInstance().advance(time_ms);
-		AsyncScoreBoardListener.waitForEvents();
 	}
 
 	@Test

--- a/tests/com/carolinarollergirls/scoreboard/json/JSONStateManagerTest.java
+++ b/tests/com/carolinarollergirls/scoreboard/json/JSONStateManagerTest.java
@@ -41,6 +41,7 @@ public class JSONStateManagerTest {
     HashMap<String, Object> hm = new HashMap<String, Object>();
     hm.put("foo", "bar");
 
+    jsm.waitForSent();
     assertEquals(1, listener.num_updates);
     assertEquals(hm, listener.state);
   }
@@ -50,8 +51,10 @@ public class JSONStateManagerTest {
     jsm.register(listener);
     assertEquals(1, listener.num_updates);
     jsm.updateState("foo", "bar");
+    jsm.waitForSent();
     assertEquals(2, listener.num_updates);
     jsm.updateState("foo", "bar");
+    jsm.waitForSent();
     assertEquals(2, listener.num_updates);
   }
 
@@ -64,6 +67,7 @@ public class JSONStateManagerTest {
     assertEquals(3, listener.state.size());
 
     jsm.updateState("foo.12", null);
+    jsm.waitForSent();
     assertEquals(1, listener.state.size());
   }
 
@@ -76,6 +80,7 @@ public class JSONStateManagerTest {
     assertEquals(3, listener.state.size());
 
     jsm.updateState("foo.1", null);
+    jsm.waitForSent();
     assertEquals(3, listener.state.size());
   }
 
@@ -84,6 +89,7 @@ public class JSONStateManagerTest {
     jsm.register(listener);
     assertEquals(1, listener.num_updates);
     jsm.updateState("foo", null);
+    jsm.waitForSent();
     assertEquals(1, listener.num_updates);
   }
 
@@ -98,6 +104,7 @@ public class JSONStateManagerTest {
 
     HashMap<String, Object> hm = new HashMap<String, Object>();
     hm.put("foo.1", "baz");
+    jsm.waitForSent();
     assertEquals(hm, listener.state);
   }
 

--- a/tests/com/carolinarollergirls/scoreboard/json/ScoreBoardJSONListenerTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/json/ScoreBoardJSONListenerTests.java
@@ -12,7 +12,6 @@ import org.junit.Test;
 import com.carolinarollergirls.scoreboard.ScoreBoardManager;
 import com.carolinarollergirls.scoreboard.utils.ScoreBoardClock;
 import com.carolinarollergirls.scoreboard.defaults.DefaultScoreBoardModel;
-import com.carolinarollergirls.scoreboard.event.AsyncScoreBoardListener;
 import com.carolinarollergirls.scoreboard.jetty.JettyServletScoreBoardController;
 import com.carolinarollergirls.scoreboard.view.Clock;
 import com.carolinarollergirls.scoreboard.view.Position;
@@ -37,9 +36,6 @@ public class ScoreBoardJSONListenerTests {
 		ScoreBoardManager.setPropertyOverride(JettyServletScoreBoardController.class.getName() + ".html.dir", "html");
 		sbm = new DefaultScoreBoardModel();
 
-		//Clock Sync can cause clocks to be changed when started, breaking tests.
-		sbm.getSettingsModel().set("ScoreBoard.Clock.Sync", "False");
-
 		jsm = new JSONStateManager();
 		new ScoreBoardJSONListener(sbm, jsm);
 		jsm.register(jsonListener);
@@ -55,9 +51,8 @@ public class ScoreBoardJSONListenerTests {
 	}
 
 	private void advance(long time_ms) {
-		AsyncScoreBoardListener.waitForEvents();
 		ScoreBoardClock.getInstance().advance(time_ms);
-		AsyncScoreBoardListener.waitForEvents();
+		jsm.waitForSent();
 	}
 
 	@Test


### PR DESCRIPTION
This should fix the WS lockup seen at British Champs, and also makes the results of the ScoreBoardJSONListener deterministic.