### PR TITLE
Use git tag as version, and include build info.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -9,11 +9,8 @@
 	<property name="test.src.dir" value="tests" />
 	<property name="test.build.dir" value="test-bin" />
 	<property name="jdoc.dir" value="jdoc"/>
-	<property name="version.src.dir" value="${src.dir}/com/carolinarollergirls/scoreboard/version"/>
 	<property name="version.dest.dir" value="${dest.dir}/com/carolinarollergirls/scoreboard/version"/>
 	<property name="version.release.file" value="release.properties"/>
-	<property name="version.build.file" value="build.properties"/>
-	<property file="${version.src.dir}/release.properties" prefix="version"/>
 
 	<property name="compile.deprecation" value="true"/>
 	<property name="compile.debug" value="true"/>
@@ -59,29 +56,30 @@
 		<echo message="	manifest				 (Re)create the manifest file"/>
 		<echo message="	help						 Show this help"/>
 		<echo message="	jdoc						 Create JavaDOC"/>
-		<echo message="	release					Create release zip file"/>
+		<echo message="	release					Create release zip file based on a git tag"/>
 		<echo message="	zip							Create non-release zip file"/>
 		<echo message=""/>
 	</target>
 
-	<!-- Add build timestamp to version -->
-	<target name="-buildversion" unless="isRelease" >
-		<tstamp>
-			<format property="version.build" pattern="yyyyMMddHHmmss" />
-		</tstamp>
-		<mkdir dir="${version.dest.dir}"/>
-		<propertyfile file="${version.dest.dir}/${version.build.file}">
-			<entry key="build" value="${version.build}"/>
-		</propertyfile>
-	</target>
-
 	<!-- Determine version -->
-	<target name="-version" depends="-buildversion" >
-		<mkdir dir="${version.dest.dir}"/>
-		<copy file="${version.src.dir}/${version.release.file}" todir="${version.dest.dir}"/>
-		<condition property="version" value="${version.release}-${version.build}" else="${version.release}">
-			<isset property="version.build"/>
+	<target name="-version">
+		<exec executable="git" outputproperty="version.git">
+			<arg line="describe --tags --always --dirty"/>
+		</exec>
+		<tstamp>
+			<format property="version.time" pattern="yyyyMMddHHmmss" />
+		</tstamp>
+		<hostinfo prefix="host"/>
+		<condition property="version" value="${version.git}-${version.time}" else="${version.git}">
+			<isfalse value="${isRelease}"/>
 		</condition>
+		<mkdir dir="${version.dest.dir}"/>
+		<propertyfile file="${version.dest.dir}/${version.release.file}">
+			<entry key="release" value="${version}"/>
+			<entry key="release.user" value="${user.name}"/>
+			<entry key="release.time" value="${version.time}"/>
+			<entry key="release.host" value="${host.NAME}"/>
+		</propertyfile>
 	</target>
 
 	<!-- Compile source files -->
@@ -238,6 +236,9 @@
 				<include name="config/crg.scoreboard.properties" />
 				<include name="config/penalties/**" />
 				<include name="config/default/**" />
+			</zipfileset>
+			<zipfileset dir="${version.dest.dir}" prefix="${zip.prefix}/html/" filemode="755" >
+				<include name="${version.release.file}" />
 			</zipfileset>
 		</zip>
 	</target>

--- a/src/com/carolinarollergirls/scoreboard/ScoreBoardManager.java
+++ b/src/com/carolinarollergirls/scoreboard/ScoreBoardManager.java
@@ -60,10 +60,7 @@ public class ScoreBoardManager {
 	}
 
 	public static String getVersion() {
-		if ("".equals(versionBuild))
-			return versionRelease;
-		else
-			return versionRelease+"-"+versionBuild;
+		return versionRelease;
 	}
 
 	public static void printMessage(String msg) {
@@ -110,7 +107,6 @@ public class ScoreBoardManager {
 		Properties versionProperties = new Properties();
 		ClassLoader cL = ScoreBoardManager.class.getClassLoader();
 		InputStream releaseIs = cL.getResourceAsStream(VERSION_RELEASE_PROPERTIES_NAME);
-		InputStream buildIs = cL.getResourceAsStream(VERSION_BUILD_PROPERTIES_NAME);
 		try {
 			versionProperties.load(releaseIs);
 		} catch ( NullPointerException npE ) {
@@ -118,16 +114,8 @@ public class ScoreBoardManager {
 		} catch ( IOException ioE ) {
 			doExit("Could not load version release properties file '"+VERSION_RELEASE_PROPERTIES_NAME+"'", ioE);
 		}
-		try {
-			versionProperties.load(buildIs);
-		} catch ( Exception e ) {
-			/* Ignore missing build properties */
-			versionProperties.setProperty(VERSION_BUILD_KEY, "");
-		}
 		try { releaseIs.close(); } catch ( Exception e ) { }
-		try { buildIs.close(); } catch ( Exception e ) { }
 		versionRelease = versionProperties.getProperty(VERSION_RELEASE_KEY);
-		versionBuild = versionProperties.getProperty(VERSION_BUILD_KEY);
 		printMessage("Carolina Rollergirls Scoreboard version "+getVersion());
 	}
 
@@ -181,16 +169,13 @@ public class ScoreBoardManager {
 	private static ScoreBoardModel scoreBoardModel;
 	private static Logger logger = null;
 
-	private static String versionRelease;
-	private static String versionBuild;
+	private static String versionRelease = "";
 
 	private static File defaultPath = new File(".");
 
 	public static final String VERSION_PATH = "com/carolinarollergirls/scoreboard/version";
 	public static final String VERSION_RELEASE_PROPERTIES_NAME = VERSION_PATH+"/release.properties";
-	public static final String VERSION_BUILD_PROPERTIES_NAME = VERSION_PATH+"/build.properties";
 	public static final String VERSION_RELEASE_KEY = "release";
-	public static final String VERSION_BUILD_KEY = "build";
 
 	public static final String PROPERTIES_DIR_NAME = "config";
 	public static final String PROPERTIES_FILE_NAME = "crg.scoreboard.properties";

--- a/src/com/carolinarollergirls/scoreboard/version/release.properties
+++ b/src/com/carolinarollergirls/scoreboard/version/release.properties
@@ -1,1 +1,0 @@
-release=3.9.1-beta


### PR DESCRIPTION
This avoids having to remember to update a file on every release, and
when ad-hoc builds are made not at a tag they'll include the most recent
tag, how many commits since then, and the commit hash.

Also always include the build username, host, and time so we
can figure out where a build came from if needed.

Fixes #120 