### PR TITLE
Remove session-related code.

### DIFF
--- a/config/crg.scoreboard.properties
+++ b/config/crg.scoreboard.properties
@@ -29,16 +29,6 @@ com.carolinarollergirls.scoreboard.xml.AbstractScoreBoardStream.dir = html/strea
 # Unless you know what you are doing, you should leave this as "html".
 com.carolinarollergirls.scoreboard.jetty.JettyServletScoreBoardController.html.dir = html
 
-# This selects whether to use java.security.SecureRandom or java.util.Random to
-# generate session IDs.  Using SecureRandom may cause a delay during startup (on systems
-# with low entropy), while using Random may result in predictable session ids.
-# However since the scoreboard uses no security at all (currently) it should
-# not matter if the session ids are predictable.
-# See http://docs.codehaus.org/display/JETTY/Connectors+slow+to+startup
-# The default is false.
-# You should not need to change this.
-#com.carolinarollergirls.scoreboard.jetty.JettyServletScoreBoardController.secure.session.ids = false
-
 # These are the servlets that are started.
 # Unless you know what you are doing, you should not modify this.
 com.carolinarollergirls.scoreboard.jetty.JettyServletScoreBoardController.servlet.1 = com.carolinarollergirls.scoreboard.jetty.XmlScoreBoardServlet


### PR DESCRIPTION
We don't use sessions, and I've verified that we're not reading
anything from /dev/random (though we do open it 3 times).
This also removes an unneeded message at startup, and one more
bit of the properties file.