### PR TITLE
Remove almost all the log noise at startup.

### DIFF
--- a/scoreboard-Linux.sh
+++ b/scoreboard-Linux.sh
@@ -7,4 +7,4 @@ GUI="--gui"
 # If fd 0 (stdin) exists, this is an interactive shell, so don't use the gui
 test -t "0" && GUI=""
 
-java -Done-jar.verbose=false -Done-jar.info=false -jar lib/crg-scoreboard.jar "$GUI" "$@"
+java -Done-jar.silent=true -Dorg.eclipse.jetty.server.LEVEL=WARN -jar lib/crg-scoreboard.jar "$GUI" "$@"

--- a/src/com/carolinarollergirls/scoreboard/xml/AutoSaveScoreBoard.java
+++ b/src/com/carolinarollergirls/scoreboard/xml/AutoSaveScoreBoard.java
@@ -96,7 +96,6 @@ public class AutoSaveScoreBoard implements Runnable
 				if (from.exists()) {
 					try {
 						FileUtils.copyFileToDirectory(from, backupDir, true);
-						ScoreBoardManager.printMessage("Copied auto-save file "+from.getName()+" to "+backupDir.getPath());
 					} catch ( Exception e ) {
 						ScoreBoardManager.printMessage("Could not back up auto-save file '"+from.getName()+"' : "+e.getMessage());
 					}


### PR DESCRIPTION
This is not relevant even to developers, and likely
confuses users.