### PR TITLE
Extend ruleset to support more game types

### DIFF
--- a/html/controls/operator.css
+++ b/html/controls/operator.css
@@ -89,15 +89,6 @@ table.RowTable { border-spacing: 0px; }
 	#TeamTime tr.Control:not(.Show) { display: none; }
 /* End Team/Time Tab */
 
-/* Policies */
-	#Policies tr.ExpandCollapseAll>td { background: #eee; border-radius: 12px; text-align: center; }
-	#Policies tr.Name>td { background: #ccc; border-radius: 12px 12px 0px 0px; text-align: center; }
-	#Policies tr.Name>td.Hide { border-radius: 12px; }
-	#Policies tr.Content>td { background: #eee; }
-	#Policies tr.Content>td.Description { border-radius: 0px 0px 0px 12px; width: 60%; text-align: left; }
-	#Policies tr.Content>td.Controls { border-radius: 0px 0px 12px 0px; width: 40%; text-align: center; }
-/* End Policies */
-
 /* ScoreBoard View */
 	#ScoreBoardView.UsePreview>tbody>tr.View { display: none; }
 	#ScoreBoardView:not(.UsePreview)>tbody>tr.Preview { display: none; }

--- a/html/controls/pt/index.js
+++ b/html/controls/pt/index.js
@@ -35,7 +35,8 @@
 		WS.Register(['ScoreBoard.Clock(Period).MinimumNumber', 'ScoreBoard.Clock(Period).MaximumNumber'], function (k, v) { setupSelect('Period'); });
 		WS.Register(['ScoreBoard.Clock(Jam).MinimumNumber', 'ScoreBoard.Clock(Jam).MaximumNumber'], function (k, v) { setupSelect('Jam'); });
 
-
+		WS.Register(['ScoreBoard.Setting(Rule.Penalties.NumberToFoulout)']);
+		
 
 		if (_windowFunctions.checkParam("autoFit", "true")) {
 			$('.Team').addClass('auto-fit');
@@ -188,14 +189,15 @@
 			jamBox.html("&nbsp;");
 		}
 
-		var cnt = 0; // Change row colors for skaters on 5 or more penalties, or explusion.
+		var cnt = 0; // Change row colors for skaters on 5 or more penalties, or expulsion.
+		var limit = WS.state["ScoreBoard.Setting(Rule.Penalties.NumberToFoulout)"];
 		var fo_exp = ($($('.Team' + t + ' .Skater.Penalty[id=' + s + '] .BoxFO_EXP')[0]).data("id") != null);
 
 		$('.Team' + t + ' .Skater.Penalty[id=' + s + '] .Box').each(function (idx, elem) { cnt += ($(elem).data("id") != null ? 1 : 0); });
 		totalBox.text(cnt);
-		$('.Team' + t + ' .Skater[id=' + s + ']').toggleClass("Warn1", cnt == 5 && !fo_exp);
-		$('.Team' + t + ' .Skater[id=' + s + ']').toggleClass("Warn2", cnt == 6 && !fo_exp);
-		$('.Team' + t + ' .Skater[id=' + s + ']').toggleClass("Warn3", cnt > 6 || fo_exp);
+		$('.Team' + t + ' .Skater[id=' + s + ']').toggleClass("Warn1", cnt == limit-2 && !fo_exp);
+		$('.Team' + t + ' .Skater[id=' + s + ']').toggleClass("Warn2", cnt == limit-1 && !fo_exp);
+		$('.Team' + t + ' .Skater[id=' + s + ']').toggleClass("Warn3", cnt >= limit || fo_exp);
 	}
 
 	function teamNameUpdate(t) {

--- a/html/controls/rulesets.js
+++ b/html/controls/rulesets.js
@@ -53,7 +53,7 @@ function loadDefinitions() {
 					.addClass("section folded")
 					.attr("group", def.group)
 				if (def.subgroup != null) {
-					name = name + " - " + def.subgroup;
+					name = def.subgroup;
 					section.attr("subgroup", def.subgroup);
 				}
 

--- a/html/views/wb/tcdg2016wb.js
+++ b/html/views/wb/tcdg2016wb.js
@@ -44,6 +44,7 @@ function initialize() {
 	WS.Register( [ 'ScoreBoard.Team(1).Skater' ], function(k, v) { skaterUpdate(1, k, v); } ); 
 	WS.Register( [ 'ScoreBoard.Team(2).Skater' ], function(k, v) { skaterUpdate(2, k, v); } ); 
 
+	WS.Register( [ 'ScoreBoard.Setting(Rule.Penalties.NumberToFoulout)' ]);
 }
 
 
@@ -97,12 +98,13 @@ function displayPenalty(t, s, p) {
 
 	// Change row colors for skaters on 5 or more penalties, or who have been expelled.
 	var cnt = 0; 
+	var limit = WS.state['ScoreBoard.Setting(Rule.Penalties.NumberToFoulout)'];
 	var fo_exp = ($($('.Team' + t + ' .Skater.Penalty[id=' + s + '] .BoxFO_EXP')[0]).data("id") != null);
 	$('.Team' + t + ' .Skater.Penalty[id=' + s + '] .Box').each(function(idx, elem) { cnt += ($(elem).data("id") != null ? 1 : 0); });
 	totalBox.text(cnt);
-	$('.Team' + t + ' .Skater[id=' + s + ']').toggleClass("Warn1", cnt == 5 && !fo_exp);
-	$('.Team' + t + ' .Skater[id=' + s + ']').toggleClass("Warn2", cnt == 6 && !fo_exp);
-	$('.Team' + t + ' .Skater[id=' + s + ']').toggleClass("Warn3", cnt > 6 || fo_exp);
+	$('.Team' + t + ' .Skater[id=' + s + ']').toggleClass("Warn1", cnt == limit-2 && !fo_exp);
+	$('.Team' + t + ' .Skater[id=' + s + ']').toggleClass("Warn2", cnt == limit-1 && !fo_exp);
+	$('.Team' + t + ' .Skater[id=' + s + ']').toggleClass("Warn3", cnt >= limit || fo_exp);
 }
 
 function makeSkaterRows(t, id, number) { //team, id, number

--- a/html/views/wb/whiteboard.js
+++ b/html/views/wb/whiteboard.js
@@ -30,6 +30,7 @@ function initialize() {
 	WS.Register( [ 'ScoreBoard.Team(1).Skater' ], function(k, v) { skaterUpdate(1, k, v); } ); 
 	WS.Register( [ 'ScoreBoard.Team(2).Skater' ], function(k, v) { skaterUpdate(2, k, v); } ); 
 
+	WS.Register( [ 'ScoreBoard.Setting(Rule.Penalties.NumberToFoulout)' ]);
 }
 
 function adjust(which, inc) {
@@ -103,12 +104,13 @@ function displayPenalty(t, s, p) {
 	}
 	// Change row colors for skaters on 5 or more penalties, or explusion.			  
 	var cnt = 0; 
+	var limit = WS.state['ScoreBoard.Setting(Rule.Penalties.NumberToFoulout)'];
 	var fo_exp = ($($('.Team' + t + ' .Skater.Penalty[id=' + s + '] .BoxFO_EXP')[0]).data("id") != null);
 	$('.Team' + t + ' .Skater.Penalty[id=' + s + '] .Box').each(function(idx, elem) { cnt += ($(elem).data("id") != null ? 1 : 0); });
 	totalBox.text(cnt);
-	$('.Team' + t + ' .Skater[id=' + s + ']').toggleClass("Warn1", cnt == 5 && !fo_exp);
-	$('.Team' + t + ' .Skater[id=' + s + ']').toggleClass("Warn2", cnt == 6 && !fo_exp);
-	$('.Team' + t + ' .Skater[id=' + s + ']').toggleClass("Warn3", cnt > 6 || fo_exp);
+	$('.Team' + t + ' .Skater[id=' + s + ']').toggleClass("Warn1", cnt == limit-2 && !fo_exp);
+	$('.Team' + t + ' .Skater[id=' + s + ']').toggleClass("Warn2", cnt == limit-1 && !fo_exp);
+	$('.Team' + t + ' .Skater[id=' + s + ']').toggleClass("Warn3", cnt >= limit || fo_exp);
 }
 
 function makeSkaterRows(t, id, number) { //team, id, number

--- a/src/com/carolinarollergirls/scoreboard/Ruleset.java
+++ b/src/com/carolinarollergirls/scoreboard/Ruleset.java
@@ -74,14 +74,9 @@ public class Ruleset {
 			newRule(new BooleanRule(false, ScoreBoard.SETTING_STOP_PC_ON_OTO, "Stop the period clock on official timeouts?", false, "True", "False"));
 			newRule(new BooleanRule(false, ScoreBoard.SETTING_STOP_PC_ON_TTO, "Stop the period clock on team timeouts?", false, "True", "False"));
 			newRule(new BooleanRule(false, ScoreBoard.SETTING_STOP_PC_ON_OR, "Stop the period clock on official reviews?", false, "True", "False"));
-			newRule(   new TimeRule(false, ScoreBoard.SETTING_STOP_PC_AFTER, "Stop the period clock, if a timeout lasts longer than this time. Set to a high value to disable.", "60:00"));
+			newRule(   new TimeRule(false, ScoreBoard.SETTING_STOP_PC_AFTER_TO_DURATION, "Stop the period clock, if a timeout lasts longer than this time. Set to a high value to disable.", "60:00"));
 			
-			newRule( new StringRule(false, ScoreBoard.SETTING_INTERMISSION_TYPE_SEQUENCE, "List of the types of intermissions as they appear in the game, separated by commas.", "1,2"));
-			newRule(   new TimeRule(false, ScoreBoard.SETTING_INTERMISSION_DURATION + "1", "Duration of the first type of intermission", "15:00"));
-			newRule(   new TimeRule(false, ScoreBoard.SETTING_INTERMISSION_DURATION + "2", "Duration of the second type of intermission", "60:00"));
-			newRule(   new TimeRule(false, ScoreBoard.SETTING_INTERMISSION_DURATION + "3", "Duration of the third type of intermission", "5:00"));
-			newRule(   new TimeRule(false, ScoreBoard.SETTING_INTERMISSION_DURATION + "4", "Duration of the fourth type of intermission", "15:00"));
-			newRule(   new TimeRule(false, ScoreBoard.SETTING_INTERMISSION_DURATION + "5", "Duration of the fifth type of intermission", "15:00"));
+			newRule( new StringRule(false, ScoreBoard.SETTING_INTERMISSION_DURATIONS, "List of the duration of intermissions as they appear in the game, separated by commas.", "15:00,60:00"));
 			newRule(new BooleanRule(false, ScoreBoard.SETTING_INTERMISSION_DIRECTION, "Which way should the intermission clock count?", true, "Count Down", "Count Up"));
 			
 			newRule(new BooleanRule(false, ScoreBoard.SETTING_AUTO_START,   "Start a Jam or Timeout when the Linup time is over its maximum by BufferTime start a Jam or Timeout as defined below. Jam/Timeout/Period Clocks will be adjusted by the buffer time. This only works if the lineup clock is counting up.", false, "Enabled", "Disabled"));

--- a/src/com/carolinarollergirls/scoreboard/Ruleset.java
+++ b/src/com/carolinarollergirls/scoreboard/Ruleset.java
@@ -16,12 +16,15 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.JSONTokener;
 
+import com.carolinarollergirls.scoreboard.penalties.PenaltyCodesManager;
 import com.carolinarollergirls.scoreboard.rules.BooleanRule;
 import com.carolinarollergirls.scoreboard.rules.IntegerRule;
 import com.carolinarollergirls.scoreboard.rules.Rule;
 import com.carolinarollergirls.scoreboard.rules.StringRule;
 import com.carolinarollergirls.scoreboard.rules.TimeRule;
-import com.carolinarollergirls.scoreboard.view.Clock;
+import com.carolinarollergirls.scoreboard.view.ScoreBoard;
+import com.carolinarollergirls.scoreboard.view.Skater.Penalty;
+import com.carolinarollergirls.scoreboard.view.Team;
 
 public class Ruleset {
 	public interface RulesetReceiver {
@@ -52,58 +55,48 @@ public class Ruleset {
 				return base;
 			}
 
-			newRule(new BooleanRule(false, "ScoreBoard", Clock.ID_JAM, "ResetNumberEachPeriod",   "How to handle Jam Numbers", true, "Reset each period", "Continue counting"));
+			newRule(new IntegerRule(false, ScoreBoard.SETTING_NUMBER_PERIODS, "Number of periods", 2));
+			newRule(   new TimeRule(false, ScoreBoard.SETTING_PERIOD_DURATION, "Duration of a period", "30:00"));
+			newRule(new BooleanRule(false, ScoreBoard.SETTING_PERIOD_DIRECTION, "Which way should the period clock count?", true, "Count Down", "Count Up"));
+			newRule(new BooleanRule(false, ScoreBoard.SETTING_PERIOD_END_BETWEEN_JAMS, "When can a period end?", true, "Anytime outside a jam", "Only on jam end"));
 
-			newRule(new BooleanRule(false, "ScoreBoard", Clock.ID_LINEUP, "AutoStart",   "Start a Jam or Timeout when the Linup time is over its maximum by BufferTime start a Jam or Timeout as defined below. Jam/Timeout/Period Clocks will be adjusted by the buffer time. This only works if the lineup clock is counting up.", false, "Enabled", "Disabled"));
-			newRule(   new TimeRule(false, "ScoreBoard", Clock.ID_LINEUP, "AutoStartBuffer",   "How long to wait after end of lineup before auto start is triggered.", "0:02"));
-			newRule(new BooleanRule(false, "ScoreBoard", Clock.ID_LINEUP, "AutoStartType",   "What to start after lineup is up", false, "Jam", "Timeout"));
+			newRule(new BooleanRule(false, ScoreBoard.SETTING_JAM_NUMBER_PER_PERIOD,   "How to handle Jam Numbers", true, "Reset each period", "Continue counting"));
+			newRule(   new TimeRule(false, ScoreBoard.SETTING_JAM_DURATION, "Maximum duration of a jam", "2:00"));
+			newRule(new BooleanRule(false, ScoreBoard.SETTING_JAM_DIRECTION, "Which way should the jam clock count?", true, "Count Down", "Count Up"));
+
+			newRule(   new TimeRule(false, ScoreBoard.SETTING_LINEUP_DURATION, "Duration of lineup", "0:30"));
+			newRule(   new TimeRule(false, ScoreBoard.SETTING_OVERTIME_LINEUP_DURATION, "Duration of lineup before an overtime jam", "1:00"));
+			newRule(new BooleanRule(false, ScoreBoard.SETTING_LINEUP_DIRECTION, "Which way should the lineup clock count?", false, "Count Down", "Count Up"));
 			
-			newRule( new StringRule(false, "ScoreBoard", null, "PenaltyDefinitionFile", "", "/config/penalties/wftda2018.json"));
+			newRule(   new TimeRule(false, ScoreBoard.SETTING_TTO_DURATION, "Duration of a team timeout", "1:00"));
+			newRule(new BooleanRule(false, ScoreBoard.SETTING_TIMEOUT_DIRECTION, "Which way should the timeout clock count?", false, "Count Down", "Count Up"));
+			newRule(new BooleanRule(false, ScoreBoard.SETTING_STOP_PC_ON_TO, "Stop the period clock on every timeout? If false, the options below control the behaviour per type of timeout.", true, "True", "False"));
+			newRule(new BooleanRule(false, ScoreBoard.SETTING_STOP_PC_ON_OTO, "Stop the period clock on official timeouts?", false, "True", "False"));
+			newRule(new BooleanRule(false, ScoreBoard.SETTING_STOP_PC_ON_TTO, "Stop the period clock on team timeouts?", false, "True", "False"));
+			newRule(new BooleanRule(false, ScoreBoard.SETTING_STOP_PC_ON_OR, "Stop the period clock on official reviews?", false, "True", "False"));
+			newRule(   new TimeRule(false, ScoreBoard.SETTING_STOP_PC_AFTER, "Stop the period clock, if a timeout lasts longer than this time. Set to a high value to disable.", "60:00"));
+			
+			newRule( new StringRule(false, ScoreBoard.SETTING_INTERMISSION_TYPE_SEQUENCE, "List of the types of intermissions as they appear in the game, separated by commas.", "1,2"));
+			newRule(   new TimeRule(false, ScoreBoard.SETTING_INTERMISSION_DURATION + "1", "Duration of the first type of intermission", "15:00"));
+			newRule(   new TimeRule(false, ScoreBoard.SETTING_INTERMISSION_DURATION + "2", "Duration of the second type of intermission", "60:00"));
+			newRule(   new TimeRule(false, ScoreBoard.SETTING_INTERMISSION_DURATION + "3", "Duration of the third type of intermission", "5:00"));
+			newRule(   new TimeRule(false, ScoreBoard.SETTING_INTERMISSION_DURATION + "4", "Duration of the fourth type of intermission", "15:00"));
+			newRule(   new TimeRule(false, ScoreBoard.SETTING_INTERMISSION_DURATION + "5", "Duration of the fifth type of intermission", "15:00"));
+			newRule(new BooleanRule(false, ScoreBoard.SETTING_INTERMISSION_DIRECTION, "Which way should the intermission clock count?", true, "Count Down", "Count Up"));
+			
+			newRule(new BooleanRule(false, ScoreBoard.SETTING_AUTO_START,   "Start a Jam or Timeout when the Linup time is over its maximum by BufferTime start a Jam or Timeout as defined below. Jam/Timeout/Period Clocks will be adjusted by the buffer time. This only works if the lineup clock is counting up.", false, "Enabled", "Disabled"));
+			newRule(   new TimeRule(false, ScoreBoard.SETTING_AUTO_START_BUFFER,   "How long to wait after end of lineup before auto start is triggered.", "0:02"));
+			newRule(new BooleanRule(false, ScoreBoard.SETTING_AUTO_START_JAM,   "What to start after lineup is up", false, "Jam", "Timeout"));
+			newRule(new BooleanRule(false, ScoreBoard.SETTING_AUTO_END_JAM,   "End a jam, when the jam clock has run down", true, "Enabled", "Disabled"));
+			newRule(new BooleanRule(false, ScoreBoard.SETTING_AUTO_END_TTO,   "End a team timeout, after it's defined duration has elapsed", false, "Enabled", "Disabled"));
 
-			newRule( new StringRule(false, "Clock", Clock.ID_PERIOD,       "Name",          "", Clock.ID_PERIOD));
-			newRule(new IntegerRule(false, "Clock", Clock.ID_PERIOD,       "MinimumNumber", "", 1));
-			newRule(new IntegerRule(false, "Clock", Clock.ID_PERIOD,       "MaximumNumber", "Number of periods", 2));
-			newRule(new BooleanRule(false, "Clock", Clock.ID_PERIOD,       "Direction",     "Which way should this clock count?", true, "Count Down", "Count Up"));
-			newRule(   new TimeRule(false, "Clock", Clock.ID_PERIOD,       "MinimumTime",   "", "0:00"));
-			newRule(   new TimeRule(false, "Clock", Clock.ID_PERIOD,       "MaximumTime",   "Duration of a period", "30:00"));
-
-			newRule( new StringRule(false, "Clock", Clock.ID_JAM,          "Name",          "", Clock.ID_JAM));
-			newRule(new IntegerRule(false, "Clock", Clock.ID_JAM,          "MinimumNumber", "", 0));
-			newRule(new IntegerRule(false, "Clock", Clock.ID_JAM,          "MaximumNumber", "", 999));
-			newRule(new BooleanRule(false, "Clock", Clock.ID_JAM,          "Direction",     "Which way should this clock count?", true, "Count Down", "Count Up"));
-			newRule(   new TimeRule(false, "Clock", Clock.ID_JAM,          "MinimumTime",   "", "0:00"));
-			newRule(   new TimeRule(false, "Clock", Clock.ID_JAM,          "MaximumTime",   "Maximum duration of a Jam", "2:00"));
-
-			newRule( new StringRule(false, "Clock", Clock.ID_LINEUP,       "Name",          "", Clock.ID_LINEUP));
-			newRule(new IntegerRule(false, "Clock", Clock.ID_LINEUP,       "MinimumNumber", "", 1));
-			newRule(new IntegerRule(false, "Clock", Clock.ID_LINEUP,       "MaximumNumber", "", 999));
-			newRule(new BooleanRule(false, "Clock", Clock.ID_LINEUP,       "Direction",     "Which way should this clock count?", false, "Count Down", "Count Up"));
-			newRule(   new TimeRule(false, "Clock", Clock.ID_LINEUP,       "MinimumTime",   "", "0:00"));
-			newRule(   new TimeRule(false, "Clock", Clock.ID_LINEUP,       "MaximumTime",   "Must be length of lineup if counting down (will be automatically adjusted for overtime, if necessary). Must be larger than lineup time + buffer time if auto start is used", "60:00"));
-			newRule(   new TimeRule(false, "Clock", Clock.ID_LINEUP,       "Time",          "Duration of Lineup before a regular jam", "00:30"));
-			newRule(   new TimeRule(false, "Clock", Clock.ID_LINEUP,       "OvertimeTime",  "Duration of Lineup before an overtime jam", "01:00"));
-
-			newRule( new StringRule(false, "Clock", Clock.ID_TIMEOUT,      "Name",          "", Clock.ID_TIMEOUT));
-			newRule(new IntegerRule(false, "Clock", Clock.ID_TIMEOUT,      "MinimumNumber", "", 1));
-			newRule(new IntegerRule(false, "Clock", Clock.ID_TIMEOUT,      "MaximumNumber", "", 999));
-			newRule(new BooleanRule(false, "Clock", Clock.ID_TIMEOUT,      "Direction",     "Which way should this clock count?", false, "Count Down", "Count Up"));
-			newRule(   new TimeRule(false, "Clock", Clock.ID_TIMEOUT,      "MinimumTime",   "", "0:00"));
-			newRule(   new TimeRule(false, "Clock", Clock.ID_TIMEOUT,      "MaximumTime",   "", "60:00"));
-
-			newRule( new StringRule(false, "Clock", Clock.ID_INTERMISSION, "Name",          "", Clock.ID_INTERMISSION));
-			newRule(new IntegerRule(false, "Clock", Clock.ID_INTERMISSION, "MinimumNumber", "", 0));
-			newRule(new IntegerRule(false, "Clock", Clock.ID_INTERMISSION, "MaximumNumber", "", 2));
-			newRule(new BooleanRule(false, "Clock", Clock.ID_INTERMISSION, "Direction",     "Which way should this clock count?", true, "Count Down", "Count Up"));
-			newRule(   new TimeRule(false, "Clock", Clock.ID_INTERMISSION, "MinimumTime",   "", "0:00"));
-			newRule(   new TimeRule(false, "Clock", Clock.ID_INTERMISSION, "MaximumTime",   "", "60:00"));
-			newRule(   new TimeRule(false, "Clock", Clock.ID_INTERMISSION, "Time",          "Duration of Intermissions", "15:00"));
-
-			newRule(new IntegerRule(false, "Team", null, "Timeouts", "How many timeouts each team is granted per game or period", 3));
-			newRule(new BooleanRule(false, "Team", null, "TimeoutsPer", "Are timeouts granted per period or per game?", false, "Period", "Game"));
-			newRule(new IntegerRule(false, "Team", null, "OfficialReviews", "How many official reviews each team is granted per game or period", 1));
-			newRule(new BooleanRule(false, "Team", null, "OfficialReviewsPer", "Are official reviews granted per period or per game?", true, "Period", "Game"));
-			newRule( new StringRule( true, "Team", "1", "Name", "Team name to display on scoreboard reset", "Team 1"));
-			newRule( new StringRule( true, "Team", "2", "Name", "Team name to display on scoreboard reset", "Team 2"));
+			newRule(new IntegerRule(false, Team.SETTING_NUMBER_TIMEOUTS, "How many timeouts each team is granted per game or period", 3));
+			newRule(new BooleanRule(false, Team.SETTING_TIMEOUTS_PER_PERIOD, "Are timeouts granted per period or per game?", false, "Period", "Game"));
+			newRule(new IntegerRule(false, Team.SETTING_NUMBER_REVIEWS, "How many official reviews each team is granted per game or period", 1));
+			newRule(new BooleanRule(false, Team.SETTING_REVIEWS_PER_PERIOD, "Are official reviews granted per period or per game?", true, "Period", "Game"));
+			
+			newRule( new StringRule(false, PenaltyCodesManager.SETTING_PENALTIES_FILE, "File that contains the penalty code definitions to be used", "/config/penalties/wftda2018.json"));
+			newRule(new IntegerRule(false, Penalty.SETTING_FO_LIMIT, "After how many penalties a skater has fouled out of the game. Note that the software currently does not suppert more than 9 penalties per skater.", 7));
 
 			base = new Ruleset();
 			base.name = "WFTDA Sanctioned";

--- a/src/com/carolinarollergirls/scoreboard/defaults/DefaultClockModel.java
+++ b/src/com/carolinarollergirls/scoreboard/defaults/DefaultClockModel.java
@@ -377,7 +377,7 @@ public class DefaultClockModel extends DefaultScoreBoardEventProvider implements
 	public static final int DEFAULT_MINIMUM_NUMBER = 1;
 	public static final int DEFAULT_MAXIMUM_NUMBER = 999;
 	public static final long DEFAULT_MINIMUM_TIME = 0;
-	public static final long DEFAULT_MAXIMUM_TIME = 3600000; // 60 minutes
+	public static final long DEFAULT_MAXIMUM_TIME = 24 * 60 * 60 * 1000; // 1 day for long time to derby
 	public static final boolean DEFAULT_DIRECTION = false;   // up
 
 	public static class DefaultClockSnapshotModel implements ClockSnapshotModel {

--- a/src/com/carolinarollergirls/scoreboard/defaults/DefaultScoreBoardModel.java
+++ b/src/com/carolinarollergirls/scoreboard/defaults/DefaultScoreBoardModel.java
@@ -26,6 +26,7 @@ import com.carolinarollergirls.scoreboard.model.SettingsModel;
 import com.carolinarollergirls.scoreboard.model.StatsModel;
 import com.carolinarollergirls.scoreboard.model.TeamModel;
 import com.carolinarollergirls.scoreboard.penalties.PenaltyCodesManager;
+import com.carolinarollergirls.scoreboard.utils.ClockConversion;
 import com.carolinarollergirls.scoreboard.utils.ScoreBoardClock;
 import com.carolinarollergirls.scoreboard.view.Clock;
 import com.carolinarollergirls.scoreboard.view.FrontendSettings;
@@ -65,13 +66,8 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 		Ruleset.registerRule(settings, SETTING_STOP_PC_ON_OTO);
 		Ruleset.registerRule(settings, SETTING_STOP_PC_ON_TTO);
 		Ruleset.registerRule(settings, SETTING_STOP_PC_ON_OR);
-		Ruleset.registerRule(settings, SETTING_STOP_PC_AFTER);
-		Ruleset.registerRule(settings, SETTING_INTERMISSION_DURATION + "1");
-		Ruleset.registerRule(settings, SETTING_INTERMISSION_DURATION + "2");
-		Ruleset.registerRule(settings, SETTING_INTERMISSION_DURATION + "3");
-		Ruleset.registerRule(settings, SETTING_INTERMISSION_DURATION + "4");
-		Ruleset.registerRule(settings, SETTING_INTERMISSION_DURATION + "5");
-		Ruleset.registerRule(settings, SETTING_INTERMISSION_TYPE_SEQUENCE);
+		Ruleset.registerRule(settings, SETTING_STOP_PC_AFTER_TO_DURATION);
+		Ruleset.registerRule(settings, SETTING_INTERMISSION_DURATIONS);
 		Ruleset.registerRule(settings, SETTING_INTERMISSION_DIRECTION);
 		Ruleset.registerRule(settings, SETTING_AUTO_START);
 		Ruleset.registerRule(settings, SETTING_AUTO_START_BUFFER);
@@ -435,15 +431,11 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 
 		requestBatchStart();
 		ic.setNumber(pc.getNumber());
-		long duration = settings.getLong(SETTING_INTERMISSION_DURATION + "1");
-		if (!settings.get(SETTING_INTERMISSION_TYPE_SEQUENCE).equals("")) {
-			String[] sequence = settings.get(SETTING_INTERMISSION_TYPE_SEQUENCE).split(",");
-			if (sequence.length >= ic.getNumber()) {
-				int index = Integer.parseInt(sequence[ic.getNumber()-1]);
-				if (index > 0 && index < 6) {
-					duration = settings.getLong(SETTING_INTERMISSION_DURATION + index);
-				}
-			}
+		long duration = 0;
+		String[] sequence = settings.get(SETTING_INTERMISSION_DURATIONS).split(",");
+		int number = Math.min(ic.getNumber(), sequence.length);
+		if (number > 0) {
+			duration = ClockConversion.fromHumanReadable(sequence[number-1]);
 		}
 		ic.setMaximumTime(duration);
 		ic.resetTime();
@@ -703,7 +695,7 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 					(long)event.getValue() == settings.getLong(SETTING_TTO_DURATION)) {
 				stopJamTO();
 			}
-			if ((long)event.getValue() == settings.getLong(SETTING_STOP_PC_AFTER) &&
+			if ((long)event.getValue() == settings.getLong(SETTING_STOP_PC_AFTER_TO_DURATION) &&
 					getClock(Clock.ID_PERIOD).isRunning()) {
 				getClockModel(Clock.ID_PERIOD).stop();
 			}

--- a/src/com/carolinarollergirls/scoreboard/defaults/DefaultSettingsModel.java
+++ b/src/com/carolinarollergirls/scoreboard/defaults/DefaultSettingsModel.java
@@ -82,6 +82,11 @@ public class DefaultSettingsModel extends DefaultScoreBoardEventProvider impleme
 			return Boolean.parseBoolean(get(k));
 		}
 	}
+	public int getInt(String k) {
+		synchronized (coreLock) {
+			return Integer.parseInt(get(k));
+		}
+	}
 	public long getLong(String k) {
 		synchronized (coreLock) {
 			return Long.parseLong(get(k));

--- a/src/com/carolinarollergirls/scoreboard/json/ScoreBoardJSONListener.java
+++ b/src/com/carolinarollergirls/scoreboard/json/ScoreBoardJSONListener.java
@@ -97,7 +97,7 @@ public class ScoreBoardJSONListener implements ScoreBoardListener
 					String prefix = null;
 					if (s.getParent() instanceof ScoreBoard)
 						prefix = "ScoreBoard";
-					if(prop.equals(PenaltyCodesManager.PenaltiesFileSetting)) {
+					if(prop.equals(PenaltyCodesManager.SETTING_PENALTIES_FILE)) {
 						update(prefix, "Setting(" + prop + ")", v);
 						processPenaltyCodes(s);
 					}
@@ -326,7 +326,7 @@ public class ScoreBoardJSONListener implements ScoreBoardListener
 	
 	private void processPenaltyCodes(Settings s) {
 		updates.add(new WSUpdate("ScoreBoard.PenaltyCode", null));
-		String file = s.get(PenaltyCodesManager.PenaltiesFileSetting);
+		String file = s.get(PenaltyCodesManager.SETTING_PENALTIES_FILE);
 		if(file != null && !file.isEmpty()) {
 			PenaltyCodesDefinition penalties = pm.loadFromJSON(file);
 			for(PenaltyCode p : penalties.getPenalties()) {

--- a/src/com/carolinarollergirls/scoreboard/penalties/PenaltyCodesManager.java
+++ b/src/com/carolinarollergirls/scoreboard/penalties/PenaltyCodesManager.java
@@ -31,5 +31,5 @@ public class PenaltyCodesManager {
 		}
 	}
 	
-	public static final String PenaltiesFileSetting = "ScoreBoard.PenaltyDefinitionFile";
+	public static final String SETTING_PENALTIES_FILE = "Rule.Penalties.DefinitionFile";
 }

--- a/src/com/carolinarollergirls/scoreboard/rules/BooleanRule.java
+++ b/src/com/carolinarollergirls/scoreboard/rules/BooleanRule.java
@@ -4,8 +4,8 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 public class BooleanRule extends Rule {
-	public BooleanRule(boolean onResetOnly, String group, String subgroup, String name, String description, boolean defaultValue, String trueValue, String falseValue) {
-		super(onResetOnly, "Boolean", group, subgroup, name, description, new Boolean(defaultValue));
+	public BooleanRule(boolean onResetOnly, String fullname, String description, boolean defaultValue, String trueValue, String falseValue) {
+		super(onResetOnly, "Boolean", fullname, description, new Boolean(defaultValue));
 
 		this.trueValue = trueValue;
 		this.falseValue = falseValue;

--- a/src/com/carolinarollergirls/scoreboard/rules/IntegerRule.java
+++ b/src/com/carolinarollergirls/scoreboard/rules/IntegerRule.java
@@ -2,8 +2,8 @@ package com.carolinarollergirls.scoreboard.rules;
 
 
 public class IntegerRule extends Rule {
-	public IntegerRule(boolean onResetOnly, String group, String subgroup, String name, String description, int defaultValue) {
-		super(onResetOnly, "Integer", group, subgroup, name, description, new Integer(defaultValue));
+	public IntegerRule(boolean onResetOnly, String fullname, String description, int defaultValue) {
+		super(onResetOnly, "Integer", fullname, description, new Integer(defaultValue));
 	}
 
 	public Object convertValue(String v) {

--- a/src/com/carolinarollergirls/scoreboard/rules/LongRule.java
+++ b/src/com/carolinarollergirls/scoreboard/rules/LongRule.java
@@ -2,8 +2,8 @@ package com.carolinarollergirls.scoreboard.rules;
 
 
 public class LongRule extends Rule {
-	public LongRule(boolean onResetOnly, String group, String subgroup, String name, String description, int defaultValue) {
-		super(onResetOnly, "Long", group, subgroup, name, description, new Long(defaultValue));
+	public LongRule(boolean onResetOnly, String fullname, String description, int defaultValue) {
+		super(onResetOnly, "Long", fullname, description, new Long(defaultValue));
 	}
 
 	public Object convertValue(String v) {

--- a/src/com/carolinarollergirls/scoreboard/rules/Rule.java
+++ b/src/com/carolinarollergirls/scoreboard/rules/Rule.java
@@ -4,26 +4,26 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 public class Rule {
-	public Rule(boolean onResetOnly, String type, String group, String subgroup, String name, String description, Object defaultValue) {
+	public Rule(boolean onResetOnly, String type, String fullname, String description, Object defaultValue) {
 		this.onResetOnly = onResetOnly;
 		this.type = type;
-		this.group = group;
-		this.subgroup = subgroup;
-		this.name = name;
+		this.fullname = fullname;
 		this.defaultValue = defaultValue;
 		this.description = description;
 
-		StringBuilder sb = new StringBuilder();
-		if (group != null) {
-			sb.append(group);
-			sb.append(".");
+		name = "";
+		group = "";
+		subgroup = "";
+		String[] parts = fullname.split("[.]");
+		if (parts.length > 0) {
+			name = parts[parts.length - 1];
 		}
-		if (subgroup != null) {
-			sb.append(subgroup);
-			sb.append(".");
+		if (parts.length > 1) {
+			group = parts[0];
 		}
-		sb.append(name);
-		fullname = sb.toString();
+		if (parts.length > 2) {
+			subgroup = fullname.substring(fullname.indexOf(".")+1, fullname.lastIndexOf("."));
+		}
 	}
 
 	public boolean isResetOnly() { return onResetOnly; }

--- a/src/com/carolinarollergirls/scoreboard/rules/StringRule.java
+++ b/src/com/carolinarollergirls/scoreboard/rules/StringRule.java
@@ -2,8 +2,8 @@ package com.carolinarollergirls.scoreboard.rules;
 
 
 public class StringRule extends Rule {
-	public StringRule(boolean onResetOnly, String group, String subgroup, String name, String description, String defaultValue) {
-		super(onResetOnly, "String", group, subgroup, name, description, defaultValue);
+	public StringRule(boolean onResetOnly, String fullname, String description, String defaultValue) {
+		super(onResetOnly, "String", fullname, description, defaultValue);
 	}
 
 	public Object convertValue(String v) {

--- a/src/com/carolinarollergirls/scoreboard/rules/TimeRule.java
+++ b/src/com/carolinarollergirls/scoreboard/rules/TimeRule.java
@@ -3,8 +3,8 @@ package com.carolinarollergirls.scoreboard.rules;
 import com.carolinarollergirls.scoreboard.utils.ClockConversion;
 
 public class TimeRule extends Rule {
-	public TimeRule(boolean onResetOnly, String group, String subgroup, String name, String description, String defaultValue) {
-		super(onResetOnly, "Time", group, subgroup, name, description, null);
+	public TimeRule(boolean onResetOnly, String fullname, String description, String defaultValue) {
+		super(onResetOnly, "Time", fullname, description, null);
 		this.defaultValue = convertValue(defaultValue);
 	}
 

--- a/src/com/carolinarollergirls/scoreboard/view/ScoreBoard.java
+++ b/src/com/carolinarollergirls/scoreboard/view/ScoreBoard.java
@@ -90,9 +90,8 @@ public interface ScoreBoard extends ScoreBoardEventProvider
 	public static final String SETTING_STOP_PC_ON_OTO = "Rule." + Clock.ID_TIMEOUT + ".StopPeriodClockOnOTO";
 	public static final String SETTING_STOP_PC_ON_TTO = "Rule." + Clock.ID_TIMEOUT + ".StopPeriodClockOnTTO";
 	public static final String SETTING_STOP_PC_ON_OR = "Rule." + Clock.ID_TIMEOUT + ".StopPeriodClockOnOR";
-	public static final String SETTING_STOP_PC_AFTER = "Rule." + Clock.ID_TIMEOUT + ".StopPeriodClockAfter";
-	public static final String SETTING_INTERMISSION_DURATION = "Rule." + Clock.ID_INTERMISSION+ ".Duration";
-	public static final String SETTING_INTERMISSION_TYPE_SEQUENCE = "Rule." + Clock.ID_INTERMISSION+ ".TypeSequence";
+	public static final String SETTING_STOP_PC_AFTER_TO_DURATION = "Rule." + Clock.ID_TIMEOUT + ".StopPeriodClockAfterTODuration";
+	public static final String SETTING_INTERMISSION_DURATIONS = "Rule." + Clock.ID_INTERMISSION+ ".Durations";
 	public static final String SETTING_INTERMISSION_DIRECTION = "Rule." + Clock.ID_INTERMISSION + ".Direction";
 	public static final String SETTING_AUTO_START = "Rule.ClockControl.AutoStart";
 	public static final String SETTING_AUTO_START_JAM = "Rule.ClockControl.AutoStartType";

--- a/src/com/carolinarollergirls/scoreboard/view/ScoreBoard.java
+++ b/src/com/carolinarollergirls/scoreboard/view/ScoreBoard.java
@@ -74,6 +74,32 @@ public interface ScoreBoard extends ScoreBoardEventProvider
 	
 	public static final String FRONTEND_SETTING_CLOCK_AFTER_TIMEOUT = "ScoreBoard.ClockAfterTimeout";
 
+	public static final String SETTING_NUMBER_PERIODS = "Rule." + Clock.ID_PERIOD + ".Number";
+	public static final String SETTING_PERIOD_DURATION = "Rule." + Clock.ID_PERIOD + ".Duration";
+	public static final String SETTING_PERIOD_DIRECTION = "Rule." + Clock.ID_PERIOD + ".Direction";
+	public static final String SETTING_PERIOD_END_BETWEEN_JAMS = "Rule." + Clock.ID_PERIOD + ".EndBetweenJams";
+	public static final String SETTING_JAM_NUMBER_PER_PERIOD = "Rule." + Clock.ID_JAM + ".ResetNumberEachPeriod";
+	public static final String SETTING_JAM_DURATION = "Rule." + Clock.ID_JAM + ".Duration";
+	public static final String SETTING_JAM_DIRECTION = "Rule." + Clock.ID_JAM + ".Direction";
+	public static final String SETTING_LINEUP_DURATION = "Rule." + Clock.ID_LINEUP + ".Duration";
+	public static final String SETTING_OVERTIME_LINEUP_DURATION = "Rule." + Clock.ID_LINEUP + ".OvertimeDuration";
+	public static final String SETTING_LINEUP_DIRECTION = "Rule." + Clock.ID_LINEUP + ".Direction";
+	public static final String SETTING_TTO_DURATION = "Rule." + Clock.ID_TIMEOUT + ".TeamTODuration";
+	public static final String SETTING_TIMEOUT_DIRECTION = "Rule." + Clock.ID_TIMEOUT + ".Direction";
+	public static final String SETTING_STOP_PC_ON_TO = "Rule." + Clock.ID_TIMEOUT + ".StopPeriodClockAlways";
+	public static final String SETTING_STOP_PC_ON_OTO = "Rule." + Clock.ID_TIMEOUT + ".StopPeriodClockOnOTO";
+	public static final String SETTING_STOP_PC_ON_TTO = "Rule." + Clock.ID_TIMEOUT + ".StopPeriodClockOnTTO";
+	public static final String SETTING_STOP_PC_ON_OR = "Rule." + Clock.ID_TIMEOUT + ".StopPeriodClockOnOR";
+	public static final String SETTING_STOP_PC_AFTER = "Rule." + Clock.ID_TIMEOUT + ".StopPeriodClockAfter";
+	public static final String SETTING_INTERMISSION_DURATION = "Rule." + Clock.ID_INTERMISSION+ ".Duration";
+	public static final String SETTING_INTERMISSION_TYPE_SEQUENCE = "Rule." + Clock.ID_INTERMISSION+ ".TypeSequence";
+	public static final String SETTING_INTERMISSION_DIRECTION = "Rule." + Clock.ID_INTERMISSION + ".Direction";
+	public static final String SETTING_AUTO_START = "Rule.ClockControl.AutoStart";
+	public static final String SETTING_AUTO_START_JAM = "Rule.ClockControl.AutoStartType";
+	public static final String SETTING_AUTO_START_BUFFER = "Rule.ClockControl.AutoStartBuffer";
+	public static final String SETTING_AUTO_END_JAM = "Rule.ClockControl.AutoEndJam"; //-
+	public static final String SETTING_AUTO_END_TTO = "Rule.ClockControl.AutoEndTTO"; //-
+	
 	public static final String EVENT_IN_PERIOD = "InPeriod";
 	public static final String EVENT_IN_OVERTIME = "InOvertime";
 	public static final String EVENT_OFFICIAL_SCORE = "OfficialScore";
@@ -87,4 +113,22 @@ public interface ScoreBoard extends ScoreBoardEventProvider
 	public static final String EVENT_ADD_TEAM = "AddTeam";
 	public static final String EVENT_REMOVE_TEAM = "RemoveTeam";
 	public static final String EVENT_SETTING = "Setting";
+
+	public static final String TIMEOUT_OWNER_OTO = "O";
+	public static final String TIMEOUT_OWNER_NONE = "";
+	
+	public static final String BUTTON_START = "ScoreBoard.Button.StartLabel";
+	public static final String BUTTON_STOP = "ScoreBoard.Button.StopLabel";
+	public static final String BUTTON_TIMEOUT = "ScoreBoard.Button.TimeoutLabel";
+	public static final String BUTTON_UNDO = "ScoreBoard.Button.UndoLabel";
+	
+	public static final String ACTION_NONE = "---";
+	public static final String ACTION_START_JAM = "Start Jam";
+	public static final String ACTION_STOP_JAM = "Stop Jam";
+	public static final String ACTION_STOP_TO = "End Timeout";
+	public static final String ACTION_LINEUP = "Lineup";
+	public static final String ACTION_TIMEOUT = "Timeout";
+	public static final String ACTION_RE_TIMEOUT = "New Timeout";
+	public static final String ACTION_OVERTIME = "Overtime";
+	public static final String UNDO_PREFIX = "Un-";
 }

--- a/src/com/carolinarollergirls/scoreboard/view/Settings.java
+++ b/src/com/carolinarollergirls/scoreboard/view/Settings.java
@@ -16,6 +16,7 @@ public interface Settings extends ScoreBoardEventProvider {
 	public Map<String, String> getAll();
 	public String get(String k);
 	public boolean getBoolean(String k);
+	public int getInt(String k);
 	public long getLong(String k);
 	public ScoreBoardEventProvider getParent();
 

--- a/src/com/carolinarollergirls/scoreboard/view/Skater.java
+++ b/src/com/carolinarollergirls/scoreboard/view/Skater.java
@@ -21,8 +21,8 @@ public interface Skater extends ScoreBoardEventProvider
 	public String getPosition();
 	public boolean isPenaltyBox();
 	public String getFlags();
-  public List<Penalty> getPenalties();
-  public Penalty getFOEXPPenalty();
+	public List<Penalty> getPenalties();
+	public Penalty getFOEXPPenalty();
 
 	public static final String EVENT_NAME = "Name";
 	public static final String EVENT_NUMBER = "Number";
@@ -30,18 +30,20 @@ public interface Skater extends ScoreBoardEventProvider
 	public static final String EVENT_PENALTY_BOX = "PenaltyBox";
 	public static final String EVENT_FLAGS = "Flags";
 
-  public static final String EVENT_PENALTY = "Penalty";
-  public static final String EVENT_REMOVE_PENALTY = "RemovePenalty";
-  public static final String EVENT_PENALTY_FOEXP = "PenaltyFOEXP";
-  public static final String EVENT_PENALTY_REMOVE_FOEXP = "RemovePenaltyFOEXP";
-  public static final String EVENT_PENALTY_PERIOD = "Period";
-  public static final String EVENT_PENALTY_JAM = "Jam";
-  public static final String EVENT_PENALTY_CODE = "Code";
+	public static final String EVENT_PENALTY = "Penalty";
+	public static final String EVENT_REMOVE_PENALTY = "RemovePenalty";
+	public static final String EVENT_PENALTY_FOEXP = "PenaltyFOEXP";
+	public static final String EVENT_PENALTY_REMOVE_FOEXP = "RemovePenaltyFOEXP";
+	public static final String EVENT_PENALTY_PERIOD = "Period";
+	public static final String EVENT_PENALTY_JAM = "Jam";
+	public static final String EVENT_PENALTY_CODE = "Code";
 
 	public static interface Penalty extends ScoreBoardEventProvider {
 		public String getId();
 		public int getPeriod();
 		public int getJam();
 		public String getCode();
+
+		public static final String SETTING_FO_LIMIT = "Rule.Penalties.NumberToFoulout";
 	}
 }

--- a/src/com/carolinarollergirls/scoreboard/view/Team.java
+++ b/src/com/carolinarollergirls/scoreboard/view/Team.java
@@ -54,6 +54,11 @@ public interface Team extends ScoreBoardEventProvider
 	public static final String LEAD_NO_LEAD = "NoLead";
 	public static final String LEAD_LOST_LEAD = "LostLead";
 
+	public static final String SETTING_NUMBER_TIMEOUTS = "Rule.Team.Timeouts";
+	public static final String SETTING_TIMEOUTS_PER_PERIOD = "Rule.Team.TimeoutsPer";
+	public static final String SETTING_NUMBER_REVIEWS = "Rule.Team.OfficialReviews";
+	public static final String SETTING_REVIEWS_PER_PERIOD = "Rule.Team.OfficialReviewsPer";
+	
 	public static final String EVENT_NAME = "Name";
 	public static final String EVENT_LOGO = "Logo";
 	public static final String EVENT_SCORE = "Score";

--- a/tests/com/carolinarollergirls/scoreboard/defaults/DefaultClockModelTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/defaults/DefaultClockModelTests.java
@@ -23,11 +23,13 @@ import com.carolinarollergirls.scoreboard.model.ScoreBoardModel;
 import com.carolinarollergirls.scoreboard.utils.ScoreBoardClock;
 import com.carolinarollergirls.scoreboard.view.Clock;
 import com.carolinarollergirls.scoreboard.view.FrontendSettings;
+import com.carolinarollergirls.scoreboard.view.Settings;
 
 public class DefaultClockModelTests {
 
 	private ScoreBoardModel sbModelMock;
 	private Ruleset ruleMock;
+	private Settings settingsMock;
 	private FrontendSettings frontendSettingsMock;
 	
 	private Queue<ScoreBoardEvent> collectedEvents;
@@ -46,6 +48,14 @@ public class DefaultClockModelTests {
 	private static String ID = "TEST";
 	
 	private String syncStatus = "false";
+	private boolean periodClockDirection = true;
+	private boolean jamClockDirection = true;
+	private boolean lineupClockDirection = false;
+	private boolean timeoutClockDirection = false;
+	private boolean intermissionClockDirection = true;
+	private int numberPeriods = 2;
+	private long periodDuration = 30 * 60 * 1000;
+	private long jamDuration = 2 * 60 * 1000;
 	
 	private void advance(long time_ms) {
 		ScoreBoardClock.getInstance().advance(time_ms);
@@ -60,6 +70,7 @@ public class DefaultClockModelTests {
 		sbModelMock = Mockito.mock(DefaultScoreBoardModel.class);
 		
 		ruleMock = Mockito.mock(Ruleset.class);
+		settingsMock = Mockito.mock(Settings.class);
 		frontendSettingsMock = Mockito.mock(FrontendSettings.class);
 		
 		Mockito
@@ -74,6 +85,10 @@ public class DefaultClockModelTests {
 			.when(sbModelMock.getFrontendSettings())
 			.thenReturn(frontendSettingsMock);
 		
+		Mockito
+			.when(sbModelMock.getSettings())
+			.thenReturn(settingsMock);
+	
 		// makes it easier to test both sync and non-sync paths through clock model
 		Mockito
 			.when(frontendSettingsMock.get(Clock.FRONTEND_SETTING_SYNC))
@@ -82,7 +97,73 @@ public class DefaultClockModelTests {
 					return syncStatus;
 				}
 			});
-		
+		Mockito
+			.when(settingsMock.getBoolean("Clock.TEST.Direction"))
+			.thenReturn(false);
+		Mockito
+			.when(settingsMock.getBoolean("Clock." + Clock.ID_PERIOD + ".Direction"))
+			.thenAnswer(new Answer<Boolean>() {
+				public Boolean answer(InvocationOnMock invocation) throws Throwable {
+					return periodClockDirection;
+				}
+			});
+		Mockito
+			.when(settingsMock.getBoolean("Clock." + Clock.ID_JAM + ".Direction"))
+			.thenAnswer(new Answer<Boolean>() {
+				public Boolean answer(InvocationOnMock invocation) throws Throwable {
+					return jamClockDirection;
+				}
+			});
+		Mockito
+			.when(settingsMock.getBoolean("Clock." + Clock.ID_LINEUP + ".Direction"))
+			.thenAnswer(new Answer<Boolean>() {
+				public Boolean answer(InvocationOnMock invocation) throws Throwable {
+					return lineupClockDirection;
+				}
+			});
+		Mockito
+			.when(settingsMock.getBoolean("Clock." + Clock.ID_TIMEOUT + ".Direction"))
+			.thenAnswer(new Answer<Boolean>() {
+				public Boolean answer(InvocationOnMock invocation) throws Throwable {
+					return timeoutClockDirection;
+				}
+			});
+		Mockito
+			.when(settingsMock.getBoolean("Clock." + Clock.ID_INTERMISSION + ".Direction"))
+			.thenAnswer(new Answer<Boolean>() {
+				public Boolean answer(InvocationOnMock invocation) throws Throwable {
+					return intermissionClockDirection;
+				}
+			});
+		Mockito
+			.when(settingsMock.getInt("Clock." + Clock.ID_PERIOD + ".MaximumNumber"))
+			.thenAnswer(new Answer<Integer>() {
+				public Integer answer(InvocationOnMock invocation) throws Throwable {
+					return numberPeriods;
+				}
+			});
+		Mockito
+			.when(settingsMock.getInt("Clock." + Clock.ID_INTERMISSION + ".MaximumNumber"))
+			.thenAnswer(new Answer<Integer>() {
+				public Integer answer(InvocationOnMock invocation) throws Throwable {
+					return numberPeriods;
+				}
+			});
+		Mockito
+			.when(settingsMock.getInt("Clock." + Clock.ID_PERIOD + ".MaximumTime"))
+			.thenAnswer(new Answer<Long>() {
+				public Long answer(InvocationOnMock invocation) throws Throwable {
+					return periodDuration;
+				}
+			});
+		Mockito
+			.when(settingsMock.getInt("Clock." + Clock.ID_JAM + ".MaximumTime"))
+			.thenAnswer(new Answer<Long>() {
+				public Long answer(InvocationOnMock invocation) throws Throwable {
+					return jamDuration;
+				}
+			});
+	
 		clock = new DefaultClockModel(sbModelMock, ID);
 	}
 	
@@ -93,12 +174,16 @@ public class DefaultClockModelTests {
 
 	@Test
 	public void testDefaults() {
-		assertEquals(0, clock.getMinimumNumber());
-		assertEquals(0, clock.getMaximumNumber());
-		assertEquals(0, clock.getNumber());
+		assertEquals(DefaultClockModel.DEFAULT_MINIMUM_NUMBER, clock.getMinimumNumber());
+		assertEquals(DefaultClockModel.DEFAULT_MAXIMUM_NUMBER, clock.getMaximumNumber());
+		assertEquals(DefaultClockModel.DEFAULT_MINIMUM_NUMBER, clock.getNumber());
 		
+		assertEquals(DefaultClockModel.DEFAULT_MINIMUM_TIME, clock.getMinimumTime());
+		assertEquals(DefaultClockModel.DEFAULT_MAXIMUM_TIME, clock.getMaximumTime());
+		assertEquals(DefaultClockModel.DEFAULT_MINIMUM_TIME, clock.getTime());
+
 		assertEquals(ID, clock.getId());
-		assertEquals(null, clock.getName());
+		assertEquals(ID, clock.getName());
 		assertFalse(clock.isMasterClock());
 		assertFalse(clock.isCountDirectionDown());
 		assertFalse(clock.isRunning());
@@ -123,7 +208,11 @@ public class DefaultClockModelTests {
 		
 		clock.reset();
 		
-		assertTrue(clock.isCountDirectionDown());
+		assertFalse(clock.isCountDirectionDown());
+		assertEquals(DefaultClockModel.DEFAULT_MINIMUM_NUMBER, clock.getMinimumNumber());
+		assertEquals(DefaultClockModel.DEFAULT_MAXIMUM_NUMBER, clock.getMaximumNumber());
+		assertEquals(DefaultClockModel.DEFAULT_MINIMUM_TIME, clock.getMinimumTime());
+		assertEquals(DefaultClockModel.DEFAULT_MAXIMUM_TIME, clock.getMaximumTime());
 		assertEquals(clock.getMinimumNumber(), clock.getNumber());
 		assertTrue(clock.isTimeAtStart());
 	}
@@ -139,15 +228,15 @@ public class DefaultClockModelTests {
 		
 		clock.reset();
 		assertFalse(clock.isRunning());
-		assertEquals(0, clock.getNumber());
-		assertEquals(0, clock.getTime());
+		assertEquals(DefaultClockModel.DEFAULT_MINIMUM_NUMBER, clock.getNumber());
+		assertEquals(DefaultClockModel.DEFAULT_MINIMUM_TIME, clock.getTime());
 		
-		//of IDs don't match no restore should be done
+		//if IDs don't match no restore should be done
 		clock.id = "OTHER";
 		clock.restoreSnapshot(snapshot);
 		assertFalse(clock.isRunning());
-		assertEquals(0, clock.getNumber());
-		assertEquals(0, clock.getTime());
+		assertEquals(DefaultClockModel.DEFAULT_MINIMUM_NUMBER, clock.getNumber());
+		assertEquals(DefaultClockModel.DEFAULT_MINIMUM_TIME, clock.getTime());
 		
 		clock.id = "TEST";
 		clock.restoreSnapshot(snapshot);
@@ -207,7 +296,7 @@ public class DefaultClockModelTests {
 		assertEquals(1, collectedEvents.size());
 		ScoreBoardEvent event = collectedEvents.poll();
 		assertEquals("Test Clock", event.getValue());
-		assertEquals(null, event.getPreviousValue());
+		assertEquals(ID, event.getPreviousValue());
 	}
 	
 	public void testSetCountDirectionDown() {
@@ -234,17 +323,17 @@ public class DefaultClockModelTests {
 	public void testSetMinimumNumber() {
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MINIMUM_NUMBER, listener));
 		
-		clock.setMinimumNumber(1);
+		clock.setMinimumNumber(1000);
 		
 		// validate constraint: max >= number >= min
-		assertEquals(1, clock.getMinimumNumber());
-		assertEquals(1, clock.getMaximumNumber());
-		assertEquals(1, clock.getNumber());
+		assertEquals(1000, clock.getMinimumNumber());
+		assertEquals(1000, clock.getMaximumNumber());
+		assertEquals(1000, clock.getNumber());
 
 		assertEquals(1, collectedEvents.size());
 		ScoreBoardEvent event = collectedEvents.poll();
-		assertEquals(1, event.getValue());
-		assertEquals(0, event.getPreviousValue());
+		assertEquals(1000, event.getValue());
+		assertEquals(DefaultClockModel.DEFAULT_MINIMUM_NUMBER, event.getPreviousValue());
 	}
 	
 	@Test
@@ -254,6 +343,7 @@ public class DefaultClockModelTests {
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_NUMBER, listener));
 
 		
+		clock.setMaximumNumber(10);
 		clock.setMinimumNumber(10);
 		collectedEvents.clear();
 
@@ -271,16 +361,20 @@ public class DefaultClockModelTests {
 	public void testSetMaximumNumber() {
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MAXIMUM_NUMBER, listener));
 		
+		clock.setMaximumNumber(DefaultClockModel.DEFAULT_MINIMUM_NUMBER);
+		advance(0);
+		collectedEvents.clear();
+		
 		clock.setMaximumNumber(5);
 		
-		assertEquals(0, clock.getMinimumNumber());
+		assertEquals(DefaultClockModel.DEFAULT_MINIMUM_NUMBER, clock.getMinimumNumber());
 		assertEquals(5, clock.getMaximumNumber());
-		assertEquals(0, clock.getNumber());
+		assertEquals(DefaultClockModel.DEFAULT_MINIMUM_NUMBER, clock.getNumber());
 
 		assertEquals(1, collectedEvents.size());
 		ScoreBoardEvent event = collectedEvents.poll();
 		assertEquals(5, event.getValue());
-		assertEquals(0, event.getPreviousValue());
+		assertEquals(DefaultClockModel.DEFAULT_MINIMUM_NUMBER, event.getPreviousValue());
 	}
 	
 	@Test
@@ -312,9 +406,9 @@ public class DefaultClockModelTests {
 
 		clock.changeMaximumNumber(2);
 		
-		assertEquals(0, clock.getMinimumNumber());
+		assertEquals(DefaultClockModel.DEFAULT_MINIMUM_NUMBER, clock.getMinimumNumber());
 		assertEquals(7, clock.getMaximumNumber());
-		assertEquals(0, clock.getNumber());
+		assertEquals(DefaultClockModel.DEFAULT_MINIMUM_NUMBER, clock.getNumber());
 
 		assertEquals(1, collectedEvents.size());
 		ScoreBoardEvent event = collectedEvents.poll();
@@ -326,6 +420,7 @@ public class DefaultClockModelTests {
 	public void testChangeMinimumNumber() {
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MINIMUM_NUMBER, listener));
 		
+		clock.setMaximumNumber(5);
 		clock.setMinimumNumber(5);
 		collectedEvents.clear();
 
@@ -409,6 +504,8 @@ public class DefaultClockModelTests {
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MAXIMUM_TIME, listener));
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_TIME, listener));
 		
+		clock.setMaximumTime(DefaultClockModel.DEFAULT_MINIMUM_TIME);
+		collectedEvents.clear();
 		clock.setMinimumTime(1000);
 		
 		// validate constraint: max > min
@@ -417,16 +514,19 @@ public class DefaultClockModelTests {
 		assertEquals(1000, clock.getTime());
 
 		assertEquals(3, collectedEvents.size());
-		ScoreBoardEvent event = collectedEvents.poll();
-		assertEquals(1000, (long)event.getValue());
-		assertEquals(0, (long)event.getPreviousValue());
+		ScoreBoardEvent event;
+		while (!collectedEvents.isEmpty()) {
+			event = collectedEvents.poll();
+			assertEquals(1000, (long)event.getValue());
+			assertEquals(DefaultClockModel.DEFAULT_MINIMUM_TIME, (long)event.getPreviousValue());
+		}
 	}
 	
 	@Test
 	public void testSetMinimumTime2() {
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MINIMUM_TIME, listener));
 
-		
+		clock.setMaximumTime(2000);
 		clock.setMinimumTime(2000);
 		clock.setMinimumTime(1000);
 		
@@ -452,6 +552,9 @@ public class DefaultClockModelTests {
 	public void testSetMaximumTime() {
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MAXIMUM_TIME, listener));
 		
+		clock.setMaximumTime(0);
+		collectedEvents.clear();
+
 		clock.setMaximumTime(5000);
 		
 		// validate constraint: increase max time doesn't reset min or current time
@@ -498,6 +601,7 @@ public class DefaultClockModelTests {
 	public void testChangeMinimumTime() {
 		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MINIMUM_TIME, listener));
 		
+		clock.setMaximumTime(5000);
 		clock.setMinimumTime(5000);
 		collectedEvents.clear();
 
@@ -758,97 +862,5 @@ public class DefaultClockModelTests {
 		assertTrue(clock.isRunning());
 		assertEquals(3, clock.getNumber());
 		assertTrue(clock.isTimeAtStart());
-	}
-	
-	@Test
-	public void testApplyRule_name()
-	{
-		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_NAME, listener));
-		clock.applyRule("Clock." + ID + ".Name", "New Name");
-		assertEquals("New Name", clock.getName());
-		assertEquals(1, collectedEvents.size());
-		
-		clock.applyRule("Clock.OTHER.Name", "Shouldn't Change");
-		assertEquals("New Name", clock.getName());
-	}
-	
-	@Test
-	public void testApplyRule_direction()
-	{
-		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_DIRECTION, listener));
-		clock.applyRule("Clock." + ID + ".Direction", true);
-		assertTrue(clock.isCountDirectionDown());
-		assertEquals(1, collectedEvents.size());
-		
-		clock.applyRule("Clock.OTHER.Direction", false);
-		assertTrue(clock.isCountDirectionDown());
-	}
-	
-	@Test
-	public void testApplyRule_minimumNumber()
-	{
-		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MINIMUM_NUMBER, listener));
-		clock.applyRule("Clock." + ID + ".MinimumNumber", 10);
-		assertEquals(10, clock.getMinimumNumber());
-		assertEquals(10, clock.getMaximumNumber());
-		assertEquals(10, clock.getNumber());
-		assertEquals(1, collectedEvents.size());
-
-		
-		clock.applyRule("Clock.OTHER.MaximumNumber", 20);
-		assertEquals(10, clock.getMinimumNumber());
-		assertEquals(10, clock.getMaximumNumber());
-		assertEquals(10, clock.getNumber());
-	}
-	
-	@Test
-	public void testApplyRule_maximumNumber()
-	{
-		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MAXIMUM_NUMBER, listener));
-		clock.applyRule("Clock." + ID + ".MaximumNumber", 10);
-		assertEquals(0, clock.getMinimumNumber());
-		assertEquals(10, clock.getMaximumNumber());
-		assertEquals(0, clock.getNumber());
-		assertEquals(1, collectedEvents.size());
-
-		
-		clock.applyRule("Clock.OTHER.MaximumNumber", 20);
-		assertEquals(0, clock.getMinimumNumber());
-		assertEquals(10, clock.getMaximumNumber());
-		assertEquals(0, clock.getNumber());
-	}
-	
-	@Test
-	public void testApplyRule_minimumTime()
-	{
-		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MINIMUM_TIME, listener));
-		clock.applyRule("Clock." + ID + ".MinimumTime", (long)10000);
-		assertEquals(10000, clock.getMinimumTime());
-		assertEquals(10000, clock.getMaximumTime());
-		assertEquals(10000, clock.getTime());
-		assertEquals(1, collectedEvents.size());
-
-		
-		clock.applyRule("Clock.OTHER.MinimumTime", (long)20000);
-		assertEquals(10000, clock.getMinimumTime());
-		assertEquals(10000, clock.getMaximumTime());
-		assertEquals(10000, clock.getTime());
-	}
-	
-	@Test
-	public void testApplyRule_maximumTime()
-	{
-		clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.EVENT_MAXIMUM_TIME, listener));
-		clock.applyRule("Clock." + ID + ".MaximumTime", (long)10000);
-		assertEquals(0, clock.getMinimumTime());
-		assertEquals(10000, clock.getMaximumTime());
-		assertEquals(0, clock.getTime());
-		assertEquals(1, collectedEvents.size());
-
-		
-		clock.applyRule("Clock.OTHER.MaximumTime", (long)20000);
-		assertEquals(0, clock.getMinimumTime());
-		assertEquals(10000, clock.getMaximumTime());
-		assertEquals(0, clock.getTime());
 	}
 }

--- a/tests/com/carolinarollergirls/scoreboard/defaults/DefaultPositionModelTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/defaults/DefaultPositionModelTests.java
@@ -9,13 +9,14 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import com.carolinarollergirls.scoreboard.Ruleset;
 import com.carolinarollergirls.scoreboard.model.PositionModel;
 import com.carolinarollergirls.scoreboard.model.ScoreBoardModel;
 import com.carolinarollergirls.scoreboard.model.SkaterModel;
 import com.carolinarollergirls.scoreboard.model.TeamModel;
 import com.carolinarollergirls.scoreboard.view.Position;
+import com.carolinarollergirls.scoreboard.view.Settings;
 import com.carolinarollergirls.scoreboard.view.SkaterNotFoundException;
+import com.carolinarollergirls.scoreboard.view.Team;
 
 public class DefaultPositionModelTests {
 	private final String firstId = "662caf51-17da-4ef2-8f01-a6d7e1c30d56";
@@ -23,7 +24,7 @@ public class DefaultPositionModelTests {
 	private final String thirdId = "5df0a35b-aaa6-4c30-93ef-07ba4f174cdc";
 	
 	private ScoreBoardModel sbModelMock;
-	private Ruleset ruleMock;
+	private Settings settingsMock;
 	private TeamModel teamModel;
 	private SkaterModel first;
 	private SkaterModel second;
@@ -33,15 +34,29 @@ public class DefaultPositionModelTests {
 	public void setup() {
 		sbModelMock = Mockito.mock(DefaultScoreBoardModel.class);
 		
-		ruleMock = Mockito.mock(Ruleset.class);
+		settingsMock = Mockito.mock(Settings.class);
 		
 		Mockito
 			.when(sbModelMock.getScoreBoard())
 			.thenReturn(sbModelMock);
 		
 		Mockito
-			.when(sbModelMock._getRuleset())
-			.thenReturn(ruleMock);
+			.when(sbModelMock.getSettings())
+			.thenReturn(settingsMock);
+
+		Mockito
+			.when(settingsMock.getInt(Team.SETTING_NUMBER_TIMEOUTS))
+			.thenReturn(3);
+		Mockito
+			.when(settingsMock.getBoolean(Team.SETTING_TIMEOUTS_PER_PERIOD))
+			.thenReturn(false);
+		Mockito
+			.when(settingsMock.getInt(Team.SETTING_NUMBER_REVIEWS))
+			.thenReturn(1);
+
+		Mockito
+			.when(settingsMock.getBoolean(Team.SETTING_REVIEWS_PER_PERIOD))
+			.thenReturn(true);
 		
 		teamModel = new DefaultTeamModel(sbModelMock, "A");
 		

--- a/tests/com/carolinarollergirls/scoreboard/defaults/DefaultScoreboardModelTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/defaults/DefaultScoreboardModelTests.java
@@ -18,6 +18,7 @@ import com.carolinarollergirls.scoreboard.event.ScoreBoardEvent;
 import com.carolinarollergirls.scoreboard.event.ScoreBoardListener;
 import com.carolinarollergirls.scoreboard.jetty.JettyServletScoreBoardController;
 import com.carolinarollergirls.scoreboard.model.ClockModel;
+import com.carolinarollergirls.scoreboard.utils.ClockConversion;
 import com.carolinarollergirls.scoreboard.utils.ScoreBoardClock;
 import com.carolinarollergirls.scoreboard.view.Clock;
 import com.carolinarollergirls.scoreboard.view.ScoreBoard;
@@ -521,7 +522,8 @@ public class DefaultScoreboardModelTests {
 		assertFalse(tc.isRunning());
 		assertTrue(ic.isRunning());
 		assertEquals(2, ic.getNumber());
-		assertEquals(sbm.getSettings().getLong(ScoreBoard.SETTING_INTERMISSION_DURATION + "2"), ic.getMaximumTime());
+		long dur = ClockConversion.fromHumanReadable(sbm.getSettings().get(ScoreBoard.SETTING_INTERMISSION_DURATIONS).split(",")[1]);
+		assertEquals(dur, ic.getMaximumTime());
 		assertTrue(ic.isTimeAtStart());
 		assertFalse(sbm.isInPeriod());
 		assertFalse(sbm.isOfficialScore());
@@ -870,7 +872,7 @@ public class DefaultScoreboardModelTests {
 	
 	@Test
 	public void testPeriodClockEnd_duringLineup() {
-		sbm.getSettingsModel().set(ScoreBoard.SETTING_INTERMISSION_TYPE_SEQUENCE, "1,3,1,2");
+		sbm.getSettingsModel().set(ScoreBoard.SETTING_INTERMISSION_DURATIONS, "5:00,15:00,5:00,60:00");
 		
 		pc.start();
 		assertTrue(pc.isCountDirectionDown());
@@ -893,7 +895,8 @@ public class DefaultScoreboardModelTests {
 		assertTrue(ic.isRunning());
 		assertTrue(ic.isTimeAtStart());
 		assertEquals(2, ic.getNumber());
-		assertEquals(sbm.getSettings().getLong(ScoreBoard.SETTING_INTERMISSION_DURATION + "3"), ic.getTimeRemaining());
+		long dur = ClockConversion.fromHumanReadable(sbm.getSettings().get(ScoreBoard.SETTING_INTERMISSION_DURATIONS).split(",")[1]);
+		assertEquals(dur, ic.getTimeRemaining());
 	}
 	
 	@Test
@@ -1110,7 +1113,7 @@ public class DefaultScoreboardModelTests {
 		sbm.getSettingsModel().set(ScoreBoard.SETTING_STOP_PC_ON_OTO, "false");
 		sbm.getSettingsModel().set(ScoreBoard.SETTING_STOP_PC_ON_TTO, "true");
 		sbm.getSettingsModel().set(ScoreBoard.SETTING_STOP_PC_ON_OR, "true");
-		sbm.getSettingsModel().set(ScoreBoard.SETTING_STOP_PC_AFTER, "120000");
+		sbm.getSettingsModel().set(ScoreBoard.SETTING_STOP_PC_AFTER_TO_DURATION, "120000");
 		
 		assertTrue(pc.isCountDirectionDown());
 		pc.setTime(1200000);

--- a/tests/com/carolinarollergirls/scoreboard/defaults/DefaultScoreboardModelTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/defaults/DefaultScoreboardModelTests.java
@@ -220,7 +220,7 @@ public class DefaultScoreboardModelTests {
 		
 		sbm.startOvertime();
 
-		assertEquals(DefaultScoreBoardModel.ACTION_OVERTIME, sbm.snapshot.getType());
+		assertEquals(ScoreBoard.ACTION_OVERTIME, sbm.snapshot.getType());
 		assertTrue(sbm.isInOvertime());
 		assertFalse(pc.isRunning());
 		assertFalse(jc.isRunning());
@@ -246,7 +246,7 @@ public class DefaultScoreboardModelTests {
 		
 		sbm.startOvertime();
 		
-		assertEquals(DefaultScoreBoardModel.ACTION_OVERTIME, sbm.snapshot.getType());
+		assertEquals(ScoreBoard.ACTION_OVERTIME, sbm.snapshot.getType());
 		assertTrue(sbm.isInOvertime());
 		assertFalse(pc.isRunning());
 		assertFalse(jc.isRunning());
@@ -299,7 +299,7 @@ public class DefaultScoreboardModelTests {
 		
 		sbm.startJam();
 		
-		assertEquals(DefaultScoreBoardModel.ACTION_START_JAM, sbm.snapshot.getType());
+		assertEquals(ScoreBoard.ACTION_START_JAM, sbm.snapshot.getType());
 		assertTrue(pc.isRunning());
 		assertEquals(1, pc.getNumber());
 		assertTrue(jc.isRunning());
@@ -328,7 +328,7 @@ public class DefaultScoreboardModelTests {
 		
 		sbm.startJam();
 		
-		assertEquals(DefaultScoreBoardModel.ACTION_START_JAM, sbm.snapshot.getType());
+		assertEquals(ScoreBoard.ACTION_START_JAM, sbm.snapshot.getType());
 		assertTrue(pc.isRunning());
 		assertEquals(1, pc.getNumber());
 		assertTrue(jc.isRunning());
@@ -357,7 +357,7 @@ public class DefaultScoreboardModelTests {
 		
 		sbm.startJam();
 		
-		assertEquals(DefaultScoreBoardModel.ACTION_START_JAM, sbm.snapshot.getType());
+		assertEquals(ScoreBoard.ACTION_START_JAM, sbm.snapshot.getType());
 		assertTrue(pc.isRunning());
 		assertEquals(1, pc.getNumber());
 		assertTrue(jc.isRunning());
@@ -382,7 +382,7 @@ public class DefaultScoreboardModelTests {
 		
 		sbm.startJam();
 		
-		assertEquals(DefaultScoreBoardModel.ACTION_START_JAM, sbm.snapshot.getType());
+		assertEquals(ScoreBoard.ACTION_START_JAM, sbm.snapshot.getType());
 		assertTrue(pc.isRunning());
 		assertEquals(1, pc.getNumber());
 		assertTrue(jc.isRunning());
@@ -412,7 +412,7 @@ public class DefaultScoreboardModelTests {
 
 		sbm.startJam();
 		
-		assertEquals(DefaultScoreBoardModel.ACTION_START_JAM, sbm.snapshot.getType());
+		assertEquals(ScoreBoard.ACTION_START_JAM, sbm.snapshot.getType());
 		assertTrue(pc.isRunning());
 		assertEquals(2, pc.getNumber());
 		assertTrue(jc.isRunning());
@@ -445,7 +445,7 @@ public class DefaultScoreboardModelTests {
 		sbm.startJam();
 		advance(1000);
 
-		assertEquals(DefaultScoreBoardModel.ACTION_START_JAM, sbm.snapshot.getType());
+		assertEquals(ScoreBoard.ACTION_START_JAM, sbm.snapshot.getType());
 		assertFalse(pc.isRunning());
 		assertEquals(1, pc.getNumber());
 		assertTrue(jc.isRunning());
@@ -484,7 +484,7 @@ public class DefaultScoreboardModelTests {
 		
 		sbm.stopJamTO();
 		
-		assertEquals(DefaultScoreBoardModel.ACTION_STOP_JAM, sbm.snapshot.getType());
+		assertEquals(ScoreBoard.ACTION_STOP_JAM, sbm.snapshot.getType());
 		assertTrue(pc.isRunning());
 		assertFalse(jc.isRunning());
 		assertTrue(lc.isRunning());
@@ -513,7 +513,7 @@ public class DefaultScoreboardModelTests {
 		
 		sbm.stopJamTO();
 		
-		assertEquals(DefaultScoreBoardModel.ACTION_STOP_JAM, sbm.snapshot.getType());
+		assertEquals(ScoreBoard.ACTION_STOP_JAM, sbm.snapshot.getType());
 		assertFalse(pc.isRunning());
 		assertTrue(pc.isTimeAtEnd());
 		assertFalse(jc.isRunning());
@@ -521,7 +521,7 @@ public class DefaultScoreboardModelTests {
 		assertFalse(tc.isRunning());
 		assertTrue(ic.isRunning());
 		assertEquals(2, ic.getNumber());
-		assertEquals(sbm.getSettings().getLong("Clock." + Clock.ID_INTERMISSION + ".Time"), ic.getMaximumTime());
+		assertEquals(sbm.getSettings().getLong(ScoreBoard.SETTING_INTERMISSION_DURATION + "2"), ic.getMaximumTime());
 		assertTrue(ic.isTimeAtStart());
 		assertFalse(sbm.isInPeriod());
 		assertFalse(sbm.isOfficialScore());
@@ -542,7 +542,7 @@ public class DefaultScoreboardModelTests {
 		
 		sbm.stopJamTO();
 		
-		assertEquals(DefaultScoreBoardModel.ACTION_STOP_TO, sbm.snapshot.getType());
+		assertEquals(ScoreBoard.ACTION_STOP_TO, sbm.snapshot.getType());
 		assertFalse(pc.isRunning());
 		assertFalse(jc.isRunning());
 		assertTrue(lc.isRunning());
@@ -567,7 +567,7 @@ public class DefaultScoreboardModelTests {
 		
 		sbm.stopJamTO();
 		
-		assertEquals(DefaultScoreBoardModel.ACTION_STOP_TO, sbm.snapshot.getType());
+		assertEquals(ScoreBoard.ACTION_STOP_TO, sbm.snapshot.getType());
 		assertFalse(pc.isRunning());
 		assertFalse(jc.isRunning());
 		assertFalse(lc.isRunning());
@@ -619,7 +619,7 @@ public class DefaultScoreboardModelTests {
 		
 		sbm.stopJamTO();
 		
-		assertEquals(DefaultScoreBoardModel.ACTION_LINEUP, sbm.snapshot.getType());
+		assertEquals(ScoreBoard.ACTION_LINEUP, sbm.snapshot.getType());
 		assertFalse(pc.isRunning());
 		assertEquals(1, pc.getNumber());
 		assertFalse(jc.isRunning());
@@ -648,7 +648,7 @@ public class DefaultScoreboardModelTests {
 		
 		sbm.stopJamTO();
 		
-		assertEquals(DefaultScoreBoardModel.ACTION_LINEUP, sbm.snapshot.getType());
+		assertEquals(ScoreBoard.ACTION_LINEUP, sbm.snapshot.getType());
 		assertFalse(pc.isRunning());
 		assertEquals(2, pc.getNumber());
 		assertTrue(pc.isTimeAtStart());
@@ -685,7 +685,7 @@ public class DefaultScoreboardModelTests {
 		
 		sbm.timeout();
 		
-		assertEquals(DefaultScoreBoardModel.ACTION_TIMEOUT, sbm.snapshot.getType());
+		assertEquals(ScoreBoard.ACTION_TIMEOUT, sbm.snapshot.getType());
 		assertFalse(pc.isRunning());
 		assertFalse(jc.isRunning());
 		assertFalse(lc.isRunning());
@@ -707,7 +707,7 @@ public class DefaultScoreboardModelTests {
 		
 		sbm.timeout();
 		
-		assertEquals(DefaultScoreBoardModel.ACTION_TIMEOUT, sbm.snapshot.getType());
+		assertEquals(ScoreBoard.ACTION_TIMEOUT, sbm.snapshot.getType());
 		assertFalse(pc.isRunning());
 		assertFalse(jc.isRunning());
 		assertFalse(lc.isRunning());
@@ -726,7 +726,7 @@ public class DefaultScoreboardModelTests {
 		
 		sbm.timeout();
 		
-		assertEquals(DefaultScoreBoardModel.ACTION_TIMEOUT, sbm.snapshot.getType());
+		assertEquals(ScoreBoard.ACTION_TIMEOUT, sbm.snapshot.getType());
 		assertFalse(pc.isRunning());
 		assertFalse(jc.isRunning());
 		assertFalse(lc.isRunning());
@@ -745,7 +745,7 @@ public class DefaultScoreboardModelTests {
 		
 		sbm.timeout();
 		
-		assertEquals(DefaultScoreBoardModel.ACTION_TIMEOUT, sbm.snapshot.getType());
+		assertEquals(ScoreBoard.ACTION_TIMEOUT, sbm.snapshot.getType());
 		assertFalse(pc.isRunning());
 		assertFalse(jc.isRunning());
 		assertFalse(lc.isRunning());
@@ -763,11 +763,11 @@ public class DefaultScoreboardModelTests {
 		tc.setTime(24000);
 		tc.setNumber(7);
 		assertFalse(ic.isRunning());
-		sbm.setTimeoutOwner(DefaultScoreBoardModel.TIMEOUT_OWNER_NONE);
+		sbm.setTimeoutOwner(ScoreBoard.TIMEOUT_OWNER_NONE);
 		
 		sbm.timeout();
 		
-		assertEquals(DefaultScoreBoardModel.ACTION_RE_TIMEOUT, sbm.snapshot.getType());
+		assertEquals(ScoreBoard.ACTION_RE_TIMEOUT, sbm.snapshot.getType());
 		assertFalse(pc.isRunning());
 		assertFalse(jc.isRunning());
 		assertFalse(lc.isRunning());
@@ -775,7 +775,7 @@ public class DefaultScoreboardModelTests {
 		assertTrue(tc.isTimeAtStart());
 		assertEquals(8, tc.getNumber());
 		assertFalse(ic.isRunning());
-		assertEquals(DefaultScoreBoardModel.TIMEOUT_OWNER_NONE, sbm.getTimeoutOwner());
+		assertEquals(ScoreBoard.TIMEOUT_OWNER_NONE, sbm.getTimeoutOwner());
 		
 		sbm.timeout();
 		
@@ -789,7 +789,7 @@ public class DefaultScoreboardModelTests {
 		sbm.setTimeoutType("2", false);
 		sbm.getTeamModel("2").setTimeouts(2);
 
-		assertEquals(DefaultScoreBoardModel.ACTION_TIMEOUT, sbm.snapshot.getType());
+		assertEquals(ScoreBoard.ACTION_TIMEOUT, sbm.snapshot.getType());
 		assertFalse(pc.isRunning());
 		assertFalse(jc.isRunning());
 		assertFalse(lc.isRunning());
@@ -870,6 +870,8 @@ public class DefaultScoreboardModelTests {
 	
 	@Test
 	public void testPeriodClockEnd_duringLineup() {
+		sbm.getSettingsModel().set(ScoreBoard.SETTING_INTERMISSION_TYPE_SEQUENCE, "1,3,1,2");
+		
 		pc.start();
 		assertTrue(pc.isCountDirectionDown());
 		pc.setTime(2000);
@@ -891,6 +893,32 @@ public class DefaultScoreboardModelTests {
 		assertTrue(ic.isRunning());
 		assertTrue(ic.isTimeAtStart());
 		assertEquals(2, ic.getNumber());
+		assertEquals(sbm.getSettings().getLong(ScoreBoard.SETTING_INTERMISSION_DURATION + "3"), ic.getTimeRemaining());
+	}
+	
+	@Test
+	public void testPeriodClockEnd_periodEndInhibitedByRuleset() {
+		sbm.getSettingsModel().set(ScoreBoard.SETTING_PERIOD_END_BETWEEN_JAMS, "false");
+		
+		pc.start();
+		assertTrue(pc.isCountDirectionDown());
+		pc.setTime(2000);
+		pc.setNumber(1);
+		assertFalse(jc.isRunning());
+		lc.start();
+		assertTrue(lc.isTimeAtStart());
+		assertFalse(tc.isRunning());
+		assertFalse(ic.isRunning());
+		
+		advance(2000);
+		
+		assertFalse(pc.isRunning());
+		assertEquals(1, pc.getNumber());
+		assertFalse(jc.isRunning());
+		assertTrue(lc.isRunning());
+		assertEquals(2000, lc.getTimeElapsed());
+		assertFalse(tc.isRunning());
+		assertFalse(ic.isRunning());
 	}
 	
 	@Test
@@ -916,9 +944,9 @@ public class DefaultScoreboardModelTests {
 		assertFalse(tc.isRunning());
 		assertFalse(ic.isRunning());
 	}
-	
+
 	@Test
-	public void testJamClockEnd() {
+	public void testJamClockEnd_pcRemaining() {
 		pc.start();
 		jc.start();
 		assertTrue(jc.isCountDirectionDown());
@@ -934,6 +962,27 @@ public class DefaultScoreboardModelTests {
 		assertFalse(jc.isRunning());
 		assertTrue(lc.isRunning());
 		assertTrue(lc.isTimeAtStart());
+		assertFalse(tc.isRunning());
+		assertFalse(ic.isRunning());
+	}
+
+	@Test
+	public void testJamClockEnd_autoEndDisabled() {
+		sbm.getSettingsModel().set(ScoreBoard.SETTING_AUTO_END_JAM, "false");
+		
+		pc.start();
+		jc.start();
+		assertTrue(jc.isCountDirectionDown());
+		jc.setTime(3000);
+		assertFalse(lc.isRunning());
+		assertFalse(tc.isRunning());
+		assertFalse(ic.isRunning());
+		
+		advance(3000);
+		
+		assertTrue(pc.isRunning());
+		assertFalse(jc.isRunning());
+		assertFalse(lc.isRunning());
 		assertFalse(tc.isRunning());
 		assertFalse(ic.isRunning());
 	}
@@ -966,6 +1015,29 @@ public class DefaultScoreboardModelTests {
 		assertFalse(ic.isRunning());
 		assertTrue(ic.isTimeAtEnd());
 		assertEquals(1, ic.getNumber());
+	}
+
+	@Test
+	public void testIntermissionClockEnd_notLastPeriodContinueCountingJams() {
+		sbm.getSettingsModel().set(ScoreBoard.SETTING_JAM_NUMBER_PER_PERIOD, "false");
+		
+		assertFalse(pc.isRunning());
+		assertTrue(pc.isCountDirectionDown());
+		pc.setTime(0);
+		pc.setNumber(1);
+		assertFalse(jc.isRunning());
+		jc.setTime(4000);
+		jc.setNumber(20);
+		assertFalse(lc.isRunning());
+		assertFalse(tc.isRunning());
+		ic.start();
+		assertTrue(ic.isCountDirectionDown());
+		ic.setNumber(1);
+		ic.setTime(3000);
+		
+		advance(3000);
+		
+		assertEquals(20, jc.getNumber());
 	}
 
 	@Test
@@ -1032,6 +1104,116 @@ public class DefaultScoreboardModelTests {
 		assertEquals(22000, pc.getTimeRemaining());
 	}
 
+	@Test
+	public void testTimeoutsThatDontAlwaysStopPc() {
+		sbm.getSettingsModel().set(ScoreBoard.SETTING_STOP_PC_ON_TO, "false");
+		sbm.getSettingsModel().set(ScoreBoard.SETTING_STOP_PC_ON_OTO, "false");
+		sbm.getSettingsModel().set(ScoreBoard.SETTING_STOP_PC_ON_TTO, "true");
+		sbm.getSettingsModel().set(ScoreBoard.SETTING_STOP_PC_ON_OR, "true");
+		sbm.getSettingsModel().set(ScoreBoard.SETTING_STOP_PC_AFTER, "120000");
+		
+		assertTrue(pc.isCountDirectionDown());
+		pc.setTime(1200000);
+		pc.start();
+		assertFalse(jc.isRunning());
+		lc.start();
+		assertFalse(tc.isRunning());
+		assertFalse(ic.isRunning());
+		
+		sbm.timeout();
+		
+		assertTrue(pc.isRunning());
+		assertEquals(600000, pc.getTimeElapsed());
+		assertTrue(tc.isRunning());
+		assertEquals(0, tc.getTimeElapsed());
+		
+		advance(2000);
+		assertEquals(602000, pc.getTimeElapsed());
+		
+		sbm.setTimeoutType("1", false);
+		
+		assertFalse(pc.isRunning());
+		assertEquals(600000, pc.getTimeElapsed());
+		assertTrue(tc.isRunning());
+		
+		advance(3000);
+		assertEquals(600000, pc.getTimeElapsed());
+		
+		sbm.setTimeoutType("O", false);
+		
+		assertTrue(pc.isRunning());
+		assertEquals(605000, pc.getTimeElapsed());
+		assertTrue(tc.isRunning());
+		
+		advance(115000);
+		
+		assertFalse(pc.isRunning());
+		assertEquals(719800, pc.getTimeElapsed()); //tc ticks first, stopping pc, so pc's tick is skipped 
+		assertTrue(tc.isRunning());
+	}
+	
+	@Test
+	public void testAutoStartJam() {
+		sbm.getSettingsModel().set(ScoreBoard.SETTING_AUTO_START, "true");
+		sbm.getSettingsModel().set(ScoreBoard.SETTING_AUTO_START_JAM, "true");
+		
+		pc.start();
+		assertFalse(jc.isRunning());
+		assertFalse(lc.isCountDirectionDown());
+		assertTrue(32000 <= lc.getMaximumTime());
+		lc.setTime(0);
+		lc.start();
+		assertFalse(tc.isRunning());
+		assertFalse(ic.isRunning());
+		
+		advance(31000);
+		assertFalse(jc.isRunning());
+		advance(1000);
+		
+		assertTrue(pc.isRunning());
+		assertTrue(jc.isRunning());
+		assertEquals(2000, jc.getTimeElapsed());
+		assertFalse(lc.isRunning());
+		assertFalse(tc.isRunning());
+		assertFalse(ic.isRunning());
+	}
+	
+	@Test
+	public void testAutoStartAndEndTimeout() {
+		sbm.getSettingsModel().set(ScoreBoard.SETTING_AUTO_START, "true");
+		sbm.getSettingsModel().set(ScoreBoard.SETTING_AUTO_START_JAM, "false");
+		sbm.getSettingsModel().set(ScoreBoard.SETTING_AUTO_START_BUFFER, "0");
+		sbm.getSettingsModel().set(ScoreBoard.SETTING_AUTO_END_TTO, "true");
+		sbm.getSettingsModel().set(ScoreBoard.SETTING_TTO_DURATION, "25000");
+		
+		pc.start();
+		assertFalse(jc.isRunning());
+		assertFalse(lc.isCountDirectionDown());
+		lc.setTime(0);
+		lc.start();
+		assertFalse(tc.isRunning());
+		assertFalse(ic.isRunning());
+		
+		advance(30000);
+		
+		assertFalse(pc.isRunning());
+		assertFalse(jc.isRunning());
+		assertFalse(lc.isRunning());
+		assertTrue(tc.isRunning());
+		assertTrue(tc.isTimeAtStart());
+		assertFalse(ic.isRunning());
+		
+		sbm.setTimeoutType("2", true);
+		
+		advance(25000);
+		
+		assertFalse(pc.isRunning());
+		assertFalse(jc.isRunning());
+		assertTrue(lc.isRunning());
+		assertFalse(tc.isRunning());
+		assertFalse(ic.isRunning());
+	}
+	
 	@Test
 	public void testResetDoesntAffectFrontendSettings() {
 		sbm.getFrontendSettingsModel().set("foo", "bar");

--- a/tests/com/carolinarollergirls/scoreboard/defaults/DefaultTeamModelTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/defaults/DefaultTeamModelTests.java
@@ -10,8 +10,9 @@ import java.util.Queue;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
-import com.carolinarollergirls.scoreboard.Ruleset;
 import com.carolinarollergirls.scoreboard.event.ConditionalScoreBoardListener;
 import com.carolinarollergirls.scoreboard.event.ScoreBoardEvent;
 import com.carolinarollergirls.scoreboard.event.ScoreBoardListener;
@@ -24,9 +25,13 @@ import com.carolinarollergirls.scoreboard.view.Team;
 public class DefaultTeamModelTests {
 
 	private ScoreBoardModel sbModelMock;
-	private Ruleset ruleMock;
 	private Settings settingsMock;
 	private TeamModel otherTeamMock;
+	
+	private int maxNumberTimeouts = 3;
+	private boolean timeoutsPerPeriod = false;
+	private int maxNumberReviews = 1;
+	private boolean reviewsPerPeriod = true;
 	
 	private Queue<ScoreBoardEvent> collectedEvents;
 	public ScoreBoardListener listener = new ScoreBoardListener() {
@@ -49,17 +54,12 @@ public class DefaultTeamModelTests {
 		
 		sbModelMock = Mockito.mock(DefaultScoreBoardModel.class);
 		
-		ruleMock = Mockito.mock(Ruleset.class);
 		settingsMock = Mockito.mock(Settings.class);
 		otherTeamMock = Mockito.mock(DefaultTeamModel.class);
 		
 		Mockito
 			.when(sbModelMock.getScoreBoard())
 			.thenReturn(sbModelMock);
-		
-		Mockito
-			.when(sbModelMock._getRuleset())
-			.thenReturn(ruleMock);
 		
 		Mockito
 			.when(sbModelMock.getSettings())
@@ -69,7 +69,38 @@ public class DefaultTeamModelTests {
 			.when(sbModelMock.getTeamModel(Mockito.anyString()))
 			.thenReturn(otherTeamMock);
 		
-		team = new DefaultTeamModel(sbModelMock, ID);
+		Mockito
+			.when(settingsMock.getInt(Team.SETTING_NUMBER_TIMEOUTS))
+			.thenAnswer(new Answer<Integer>() {
+				public Integer answer(InvocationOnMock invocation) throws Throwable {
+					return maxNumberTimeouts;
+				}
+			});
+	
+		Mockito
+			.when(settingsMock.getBoolean(Team.SETTING_TIMEOUTS_PER_PERIOD))
+			.thenAnswer(new Answer<Boolean>() {
+				public Boolean answer(InvocationOnMock invocation) throws Throwable {
+					return timeoutsPerPeriod;
+				}
+			});
+		Mockito
+			.when(settingsMock.getInt(Team.SETTING_NUMBER_REVIEWS))
+			.thenAnswer(new Answer<Integer>() {
+				public Integer answer(InvocationOnMock invocation) throws Throwable {
+					return maxNumberReviews;
+				}
+			});
+	
+		Mockito
+			.when(settingsMock.getBoolean(Team.SETTING_REVIEWS_PER_PERIOD))
+			.thenAnswer(new Answer<Boolean>() {
+				public Boolean answer(InvocationOnMock invocation) throws Throwable {
+					return reviewsPerPeriod;
+				}
+			});
+
+	team = new DefaultTeamModel(sbModelMock, ID);
 		ScoreBoardClock.getInstance().stop();
 }
 
@@ -323,7 +354,7 @@ public class DefaultTeamModelTests {
 	@Test
 	public void testSetTimeouts() {
 		team.addScoreBoardListener(new ConditionalScoreBoardListener(team, Team.EVENT_TIMEOUTS, listener));
-		team.maximumTimeouts = 5;
+		maxNumberTimeouts = 5;
 		
 		team.setTimeouts(4);
 		assertEquals(4, team.getTimeouts());
@@ -359,7 +390,7 @@ public class DefaultTeamModelTests {
 	@Test
 	public void testSetOfficialReviews() {
 		team.addScoreBoardListener(new ConditionalScoreBoardListener(team, Team.EVENT_OFFICIAL_REVIEWS, listener));
-		team.maximumOfficialReviews = 5;
+		maxNumberReviews = 5;
 		
 		team.setOfficialReviews(4);
 		assertEquals(4, team.getOfficialReviews());
@@ -382,7 +413,7 @@ public class DefaultTeamModelTests {
 	@Test
 	public void testChangeOfficialReviews() {
 		team.addScoreBoardListener(new ConditionalScoreBoardListener(team, Team.EVENT_OFFICIAL_REVIEWS, listener));
-		team.maximumOfficialReviews = 3;
+		maxNumberReviews = 3;
 		assertEquals(1, team.getOfficialReviews());
 
 		team.changeOfficialReviews(2);
@@ -423,7 +454,7 @@ public class DefaultTeamModelTests {
 		assertTrue(events.contains(Team.EVENT_OFFICIAL_REVIEWS));
 		assertTrue(events.contains(Team.EVENT_RETAINED_OFFICIAL_REVIEW));
 
-		team.maximumOfficialReviews = 2;
+		maxNumberReviews = 2;
 		team.setInTimeout(true);
 		team.setInOfficialReview(true);
 		team.setRetainedOfficialReview(true);
@@ -447,9 +478,9 @@ public class DefaultTeamModelTests {
 		assertTrue(events.contains(Team.EVENT_OFFICIAL_REVIEWS));
 		assertTrue(events.contains(Team.EVENT_RETAINED_OFFICIAL_REVIEW));
 	
-		team.maximumTimeouts = 4;
-		team.timeoutsPerPeriod = true;
-		team.officialReviewsPerPeriod = false;
+		maxNumberTimeouts = 4;
+		timeoutsPerPeriod = true;
+		reviewsPerPeriod = false;
 		team.setRetainedOfficialReview(true);
 		team.setTimeouts(1);
 		team.setOfficialReviews(0);


### PR DESCRIPTION
- Make the number of penalties that lead to foul out configurable (up to 9)
- Add rules to select which types of timeout stop the period clock (if any)
- Add rule that stops period clock if timeouts last longer than a given time
- Support intermissions that are not all of the same length (and display the official score for more than 15 minutes on WFTDA sanctioned rules)
- Allow to disable the automatic ending of jams after 2 minutes
- Allow to enable automatic ending of team timeouts

Also remove rules for clock settings that are not sensible to change
(e.g. minimum times, which should be kept at 0) and rename the remaining
clock rules so they reflect the semantic of the rule (e.g. number of
periods) instead of the internal variable name (e.g.
Clock.Period.maximumNumber).

Under the hood:
- Refer to rules and settings via constants
- Add unit tests for non-default rule settings
- Do not display the common prefix "Rule." in the ruleset editor

closes #111 
closes #170 