### PR TITLE
Reset jam clock when intermission ends

### DIFF
--- a/src/com/carolinarollergirls/scoreboard/defaults/DefaultScoreBoardModel.java
+++ b/src/com/carolinarollergirls/scoreboard/defaults/DefaultScoreBoardModel.java
@@ -246,6 +246,7 @@ public class DefaultScoreBoardModel extends DefaultScoreBoardEventProvider imple
 		if (settings.getBoolean("ScoreBoard." + Clock.ID_JAM + ".ResetNumberEachPeriod")) {
 			jc.setNumber(jc.getMinimumNumber());
 		}
+		jc.resetTime();
 		for (TeamModel t : getTeamModels()) {
 			t.resetTimeouts(false);
 		}		

--- a/tests/com/carolinarollergirls/scoreboard/defaults/DefaultScoreboardModelTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/defaults/DefaultScoreboardModelTests.java
@@ -960,6 +960,7 @@ public class DefaultScoreboardModelTests {
 		assertTrue(pc.isTimeAtStart());
 		assertEquals(2, pc.getNumber());
 		assertFalse(jc.isRunning());
+		assertTrue(jc.isTimeAtStart());
 		assertEquals(0, jc.getNumber());
 		assertFalse(lc.isRunning());
 		assertFalse(tc.isRunning());


### PR DESCRIPTION
As reported in the FB group, a display of P2J0 and random time is confusing.