### PR TITLE
Specify cache-control headers for static content

### DIFF
--- a/src/com/carolinarollergirls/scoreboard/jetty/JettyServletScoreBoardController.java
+++ b/src/com/carolinarollergirls/scoreboard/jetty/JettyServletScoreBoardController.java
@@ -140,7 +140,8 @@ public class JettyServletScoreBoardController
 		if (null != staticPath) {
 			ServletContextHandler c = new ServletContextHandler(contexts, "/", ServletContextHandler.SESSIONS);
 			ServletHolder sh = new ServletHolder(new DefaultServlet());
-			sh.setInitParameter("org.eclipse.jetty.servlet.Default.cacheControl", "no-cache");
+			sh.setInitParameter("cacheControl", "no-cache");
+			sh.setInitParameter("etags", "true");
 			c.addServlet(sh, "/*");
 			c.addFilter(mf, "/*", 1);
 			c.setResourceBase((new File(ScoreBoardManager.getDefaultPath(), staticPath)).getPath());


### PR DESCRIPTION
no-cache means the browser will check with the server on each load,
and the etags help ensure it'll only pull down the full file if needed.

This should eliminate issues around users with old JS loaded.

Fixes #63