### PR TITLE
Fixed non-blinking official review dots. Resolves issue #173

### DIFF
--- a/html/views/standard/common.js
+++ b/html/views/standard/common.js
@@ -97,7 +97,7 @@ function smallDescriptionUpdate(k, v) {
 				if (or) {
 					ret = "Official Review";
 					$(".Team" + to + ">.OfficialReviews:not(.Header)").addClass("Red");
-					var dotSel = ".Team" + to + " .OfficialReview" + (WS.state["ScoreBoard.Team(" + to + ").OfficialReviews"] + 1);
+					var dotSel = ".Team" + to + " .OfficialReview1";
 					$(dotSel).addClass("Active");
 				} else {
 					ret = "Team Timeout";

--- a/html/views/standard/index.css
+++ b/html/views/standard/index.css
@@ -198,7 +198,7 @@ body.box_flat .Box.FlatTop {
 	background: none;
 }
 .DotOfficialReviews .Dot.OfficialReview1.Retained{
-	background: -webkit-gradient(linear, 0 0, 0 100%, from(#E9E9E9), color-stop(100%, #AFAFAF)) !important;
+	background: -webkit-gradient(linear, 0 0, 0 100%, from(#E9E9E9), color-stop(100%, #D9D9D9)) !important;
 }
 .DotOfficialReviews .Dot.Retained:after {
 	content: "";

--- a/html/views/standard/index.css
+++ b/html/views/standard/index.css
@@ -198,7 +198,7 @@ body.box_flat .Box.FlatTop {
 	background: none;
 }
 .DotOfficialReviews .Dot.OfficialReview1.Retained{
-	background: -webkit-gradient(linear, 0 0, 0 100%, from(#E9E9E9), color-stop(100%, #D9D9D9)) !important;
+	background: -webkit-gradient(linear, 0 0, 0 100%, from(#E9E9E9), color-stop(100%, #AFAFAF)) !important;
 }
 .DotOfficialReviews .Dot.Retained:after {
 	content: "";

--- a/html/views/wb/tcdg2016wb.js
+++ b/html/views/wb/tcdg2016wb.js
@@ -101,7 +101,7 @@ function displayPenalty(t, s, p) {
 	var limit = WS.state['ScoreBoard.Setting(Rule.Penalties.NumberToFoulout)'];
 	var fo_exp = ($($('.Team' + t + ' .Skater.Penalty[id=' + s + '] .BoxFO_EXP')[0]).data("id") != null);
 	$('.Team' + t + ' .Skater.Penalty[id=' + s + '] .Box').each(function(idx, elem) { cnt += ($(elem).data("id") != null ? 1 : 0); });
-	totalBox.text(cnt);
+	//totalBox.text(cnt);
 	$('.Team' + t + ' .Skater[id=' + s + ']').toggleClass("Warn1", cnt == limit-2 && !fo_exp);
 	$('.Team' + t + ' .Skater[id=' + s + ']').toggleClass("Warn2", cnt == limit-1 && !fo_exp);
 	$('.Team' + t + ' .Skater[id=' + s + ']').toggleClass("Warn3", cnt >= limit || fo_exp);

--- a/html/views/wb/tcdg2016wb.js
+++ b/html/views/wb/tcdg2016wb.js
@@ -101,7 +101,6 @@ function displayPenalty(t, s, p) {
 	var limit = WS.state['ScoreBoard.Setting(Rule.Penalties.NumberToFoulout)'];
 	var fo_exp = ($($('.Team' + t + ' .Skater.Penalty[id=' + s + '] .BoxFO_EXP')[0]).data("id") != null);
 	$('.Team' + t + ' .Skater.Penalty[id=' + s + '] .Box').each(function(idx, elem) { cnt += ($(elem).data("id") != null ? 1 : 0); });
-	//totalBox.text(cnt);
 	$('.Team' + t + ' .Skater[id=' + s + ']').toggleClass("Warn1", cnt == limit-2 && !fo_exp);
 	$('.Team' + t + ' .Skater[id=' + s + ']').toggleClass("Warn2", cnt == limit-1 && !fo_exp);
 	$('.Team' + t + ' .Skater[id=' + s + ']').toggleClass("Warn3", cnt >= limit || fo_exp);


### PR DESCRIPTION
Turns out the problem fortunately didn't involve mucking with pseudoclasses.  Rather, it appears the code which made a WS query to determine which dot to blink for team timeouts was cut-n-pasted for official reviews.  Since there is only ever one official review dot, that did nae work so well.  Fixed.

In addition, I tidied up the gradient for the dots, and commented out an unused line in the wb file that was throwing errors into the console.  If you really, really want me to put those in separate PRs I will.