### PR TITLE
Graphic Penalty Display: Fixing hidden descenders in the Skater names

### DIFF
--- a/html/views/wb/tcdg2016wb.css
+++ b/html/views/wb/tcdg2016wb.css
@@ -284,7 +284,7 @@ a {
 */
 .Team .Name .Number, .Team .Box, .Team .FO_EXP, .Team .Total { width: 5%; }
 .Number { left: 0%; width: 10%; text-align: right; }
-.Name { left: 12%; width: 44%; height: 100%; text-align: left; overflow: hidden; }
+.Name { left: 12%; width: 44%; height: 110%; text-align: left; overflow: hidden; }
 /* .Team tr:nth-child(4n-2), .Team tr:nth-child(4n-0) { background-color: #CCC; } */
 /* .Penalty { height: 50%; } */
 /* 


### PR DESCRIPTION

![2018-10-19 09_08_03-wftda crg whiteboard overlay](https://user-images.githubusercontent.com/26040981/47205808-e53b2a00-d37e-11e8-8bcb-63b011b560a7.png)

Currently the descenders (y,g asf) are cut off. This fixes the display of names.

![2018-10-19 09_08_52-wftda crg whiteboard overlay](https://user-images.githubusercontent.com/26040981/47205809-e79d8400-d37e-11e8-8aa8-dcdc0b7ab14f.png)

