### PR TITLE
 Whiteboard Team colors same as Penalty tracker

### DIFF
--- a/html/views/wb/tcdg2016wb.css
+++ b/html/views/wb/tcdg2016wb.css
@@ -284,7 +284,7 @@ a {
 */
 .Team .Name .Number, .Team .Box, .Team .FO_EXP, .Team .Total { width: 5%; }
 .Number { left: 0%; width: 10%; text-align: right; }
-.Name { left: 12%; width: 44%; height: 100%; text-align: left; overflow: hidden; }
+.Name { left: 12%; width: 44%; height: 110%; text-align: left; overflow: hidden; }
 /* .Team tr:nth-child(4n-2), .Team tr:nth-child(4n-0) { background-color: #CCC; } */
 /* .Penalty { height: 50%; } */
 /* 

--- a/html/views/wb/whiteboard.js
+++ b/html/views/wb/whiteboard.js
@@ -19,8 +19,8 @@ function initialize() {
 		WS.Register([ 'ScoreBoard.Team(' + t + ').Name' ]);
 		WS.Register([ 'ScoreBoard.Team(' + t + ').AlternateName' ]);
 		WS.Register(['ScoreBoard.Team(' + t + ').Color'], function (k, v) {
-				$('#head' + t).css('background-color', WS.state['ScoreBoard.Team(' + t + ').Color(operator_bg)']);
-				$('#head' + t).css('color', WS.state['ScoreBoard.Team(' + t + ').Color(operator_fg)']);
+				$('#head' + t).css('background-color', WS.state['ScoreBoard.Team(' + t + ').Color(overlay_bg)']);
+				$('#head' + t).css('color', WS.state['ScoreBoard.Team(' + t + ').Color(overlay_fg)']);
 			});
 	});
 	WS.Register( [ 'ScoreBoard.Clock(Period).Number' ], function(k, v) { period = v; });

--- a/html/views/wb/whiteboard.js
+++ b/html/views/wb/whiteboard.js
@@ -18,11 +18,10 @@ function initialize() {
 	$.each([1, 2], function(idx, t) {
 		WS.Register([ 'ScoreBoard.Team(' + t + ').Name' ]);
 		WS.Register([ 'ScoreBoard.Team(' + t + ').AlternateName' ]);
-		WS.Register([ 'ScoreBoard.Team(' + t + ').Color' ], function(k, v) {
-			$('.Team' + t + 'custColor').css('color', WS.state['ScoreBoard.Team(' + t + ').Color(overlay_fg)']);
-			$('.Team' + t + 'custColor').css('background-color', WS.state['ScoreBoard.Team(' + t + ').Color(overlay_bg)']); 
-			$('#head' + t).css('background-color', WS.state['ScoreBoard.Team(' + t + ').Color(overlay_bg)']); 
-		});
+		WS.Register(['ScoreBoard.Team(' + t + ').Color'], function (k, v) {
+				$('#head' + t).css('background-color', WS.state['ScoreBoard.Team(' + t + ').Color(operator_bg)']);
+				$('#head' + t).css('color', WS.state['ScoreBoard.Team(' + t + ').Color(operator_fg)']);
+			});
 	});
 	WS.Register( [ 'ScoreBoard.Clock(Period).Number' ], function(k, v) { period = v; });
 	WS.Register( [ 'ScoreBoard.Clock(Jam).Number' ], function(k, v) { jam = v; });


### PR DESCRIPTION
This would make the whiteboard headers coloured and pull those colours from the operator colours. 
Congruent to the PT screen

(first commit seems already merged, but still shows up here)


