### PR TITLE
Skip processing stats in XML frontend

### DIFF
--- a/html/javascript/core.js
+++ b/html/javascript/core.js
@@ -528,6 +528,11 @@ _crgScoreBoard = {
 	processScoreBoardElement: function(parent, element, triggerArray) {
 		var $element = $(element);
 		var name = element.nodeName;
+		if (name == 'Period' || name == 'Jam') {
+			// The XML parts of the scoreboard don't use this, and it's
+			// relatively slow to process.
+			return;
+		}
 		var id = $element.attr("Id");
 		var remove = _crgScoreBoard.hasXmlElementPI($element, "Remove");
 		var once = _crgScoreBoard.hasXmlElementPI($element, "Once");


### PR DESCRIPTION
Processing many hundreds of XML elements
that we don't need takes hundreds of milliseconds.