### PR TITLE
Make WS updates more efficient.

### DIFF
--- a/src/com/carolinarollergirls/scoreboard/jetty/WS.java
+++ b/src/com/carolinarollergirls/scoreboard/jetty/WS.java
@@ -242,6 +242,7 @@ public class WS extends WebSocketServlet {
                         } else {
                             updates.put(k, state.get(k));
                         }
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
Use a trie to find relevant callbacks, this cuts about 90% of
WS-related CPU.

We don't need to go through all the paths when we've already found one.