### PR TITLE
Let PLTs manually advance the Jam between jams.

### DIFF
--- a/html/controls/plt/plt.css
+++ b/html/controls/plt/plt.css
@@ -15,17 +15,16 @@ table.PLT, .PLT table, .PLT tr, .PLT td, #PenaltyEditor table, #PenaltyEditor tr
 }
 .PLT.Team thead td { font-size: 1em; font-weight: bold; background-color: #222; color: #FFF; }
 .PLT.Team td { text-align: center; vertical-align: middle; }
-.PLT.Team .Number, .Team .Box, .PLT.Team .Total { width: 4.76%; }
-.PLT.Team .Role, .Team .Sitting, .PLT.Team .Trips { width: 7.14%; }
+.PLT.Team .Number, .PLT.Team .Box, .PLT.Team .Total, .PLT.Team .Advance { width: 5%; }
+.PLT.Team .Role, .PLT.Team .Sitting { width: 7%; }
 .PLT.Team tr { background-color: #FFF; }
 .PLT.Team tr:nth-child(4n+0), .PLT.Team tr:nth-child(4n-1) { background-color: #FFE8FF; }
 .PLT.Team .Role { background-color: #FFF; }
-.PLT.Team tr:nth-child(4n+0) .Role:not(.OnTrack), .PLT.Team tr:nth-child(4n-1) .Role:not(.OnTrack) { background-color: #e7f3ff; }
+.PLT.Team tr:nth-child(4n-1) .Role:not(.OnTrack), .PLT.Team .Advance:not(.Active) { background-color: #e7f3ff; }
 .PLT.Team .Sitting, .PLT.Team .Trips { background-color: #e7f3ff; }
-.PLT.Team tr:nth-child(4n+0) .Sitting:not(.inBox), .PLT.Team tr:nth-child(4n-1) .Sitting:not(.inBox),
-.PLT.Team tr:nth-child(4n+0) .Trips, .PLT.Team tr:nth-child(4n-1) .Trips { background-color: #cee7ff; }
+.PLT.Team tr:nth-child(4n-1) .Sitting:not(.inBox), .PLT.Team tr:nth-child(4n-1) .Trips { background-color: #cee7ff; }
 .PLT.Team .Number { font-weight: bold; background-color: #f4f4f4; }
-.PLT.Team tr:nth-child(4n+0) .Number, .PLT.Team tr:nth-child(4n-1) .Number { background-color: #E8E8E8; }
+.PLT.Team tr:nth-child(4n-1) .Number { background-color: #E8E8E8; }
 .PLT.Team .Box0 { background-color: #ffd0ff; }
 .PLT.Team .Role:not(.OnTrack)>span.Num { display: none; }
 .PLT.Team .Role.OnTrack>span.Pos { display: none; }
@@ -44,6 +43,9 @@ table.PLT, .PLT table, .PLT tr, .PLT td, #PenaltyEditor table, #PenaltyEditor tr
 .PLT.Team .Serving { background-color: #70ff70; }
 .PLT.Team .OnTrack { background-color: #70ff70; }
 .PLT.Team .inBox { background-color: #ff4040; }
+.PLT.Team .Advance { border: none; }
+.PLT.Team .Advance.Active { background-color: #70ff70; }
+.PLT.Team tr:nth-child(6n+3) .Advance.Active::after { content: "next Jam"; }
 
 #PenaltyEditor .Codes>div { float: left; width: 150px; height: 90px; margin: 10px; border: 1px solid black; font-weight: bold; }
 #PenaltyEditor .Codes>div.Active { background-color: #F00; color: #FFF; }

--- a/html/controls/plt/plt.css
+++ b/html/controls/plt/plt.css
@@ -44,8 +44,9 @@ table.PLT, .PLT table, .PLT tr, .PLT td, #PenaltyEditor table, #PenaltyEditor tr
 .PLT.Team .OnTrack { background-color: #70ff70; }
 .PLT.Team .inBox { background-color: #ff4040; }
 .PLT.Team .Advance { border: none; }
-.PLT.Team .Advance.Active { background-color: #70ff70; }
-.PLT.Team tr:nth-child(6n+3) .Advance.Active::after { content: "next Jam"; }
+.PLT.Team .Advance.Active { background-color: #ffd000;  vertical-align: bottom; }
+.PLT.Team tr:nth-child(6n+1) .Advance.Active::after { content: "Go To"; }
+.PLT.Team tr:nth-child(6n+3) .Advance.Active::after { content: "Next Jam"; }
 
 #PenaltyEditor .Codes>div { float: left; width: 150px; height: 90px; margin: 10px; border: 1px solid black; font-weight: bold; }
 #PenaltyEditor .Codes>div.Active { background-color: #F00; color: #FFF; }

--- a/html/controls/plt/plt.js
+++ b/html/controls/plt/plt.js
@@ -15,7 +15,8 @@ function preparePltTable(element, teamId, mode, statsbookPeriod) {
 			$('<td>').text('Jammer').appendTo(thead);
 			$('<td>').text('Pivot').appendTo(thead);
 			$('<td>').text('Blocker').appendTo(thead);
-			$('<td>').attr('colspan', '2').text('Box').appendTo(thead);
+			$('<td>').text('Box').appendTo(thead);
+			$('<td>').appendTo(thead);
 			$('<td>').text('#').appendTo(thead);
 		}
 		$('<td>').attr('colspan', '9').attr('id', 'head').text('Penalty/Jam').appendTo(thead);
@@ -36,6 +37,9 @@ function preparePltTable(element, teamId, mode, statsbookPeriod) {
 		WS.Register(['ScoreBoard.Clock(Jam).Number'], updateJam);
 
 		WS.Register(['ScoreBoard.Team('+teamId+').Skater'], function (k, v) { skaterUpdate(teamId, k, v); });
+		WS.Register(['ScoreBoard.Team('+teamId+').FieldingAdvancePending'], function(k, v) {
+			element.find('.Advance').toggleClass('Active', isTrue(v)); 
+		});
 
 		WS.Register(['ScoreBoard.Rulesets.CurrentRule(Penalties.NumberToFoulout)']);
 		
@@ -112,8 +116,6 @@ function preparePltTable(element, teamId, mode, statsbookPeriod) {
 				element.find('.Skater.Penalty[id=' + id + '] .'+v).addClass('OnTrack');
 			} else if (field === 'PenaltyBox') {
 				element.find('.Skater.Penalty[id=' + id + '] .Sitting').toggleClass('inBox', isTrue(v));
-			} else if (field === 'CurrentBoxSymbols') {
-				element.find('.Skater.Penalty[id=' + id + '] .Trips').text(v);
 			}
 		} else {
 			// Look for penalty
@@ -256,9 +258,12 @@ function preparePltTable(element, teamId, mode, statsbookPeriod) {
 				boxCell.addClass('inBox');
 			}
 			p.append(boxCell);
-			var tripCell = $('<td>').addClass('Trips').attr('rowspan', 2)
-				.text(WS.state['ScoreBoard.Team('+t+').Skater('+id+').CurrentBoxSymbols']);
-			p.append(tripCell);
+			
+			var advanceCell = $('<td>').addClass('Advance').attr('rowspan', 2).click(function() {
+				WS.Set('ScoreBoard.Team('+t+').AdvanceFieldings', true);
+			});
+			if (isTrue(WS.state['ScoreBoard.Team('+t+').FieldingAdvancePending'])) { advanceCell.addClass('Active'); }
+			p.append(advanceCell);
 	
 			var numberCell = $('<td>').addClass('Number').attr('rowspan', 2).text(number).click(function () { openPenaltyEditor(t, id, 10); });
 			p.append(numberCell);

--- a/src/com/carolinarollergirls/scoreboard/core/BoxTrip.java
+++ b/src/com/carolinarollergirls/scoreboard/core/BoxTrip.java
@@ -11,6 +11,8 @@ public interface BoxTrip extends ScoreBoardEventProvider {
     
     public void end();
     
+    public Team getTeam();
+    
     public boolean isCurrent();
     public Fielding getCurrentFielding();
     public Fielding getStartFielding();

--- a/src/com/carolinarollergirls/scoreboard/core/Skater.java
+++ b/src/com/carolinarollergirls/scoreboard/core/Skater.java
@@ -35,6 +35,7 @@ public interface Skater extends ScoreBoardEventProvider {
     public Position getPosition();
     public void setPosition(Position position);
     public Role getRole();
+    public Role getRole(TeamJam tj);
     public void setRole(Role role);
     public void setRoleToBase();
     public Role getBaseRole();

--- a/src/com/carolinarollergirls/scoreboard/core/Team.java
+++ b/src/com/carolinarollergirls/scoreboard/core/Team.java
@@ -71,6 +71,7 @@ public interface Team extends ScoreBoardEventProvider, TimeoutOwner {
     public Position getPosition(FloorPosition fp);
 
     public void field(Skater s, Role r);
+    public boolean hasFieldingAdvancePending();
 
     public boolean isLost();
     public boolean isLead();
@@ -91,6 +92,7 @@ public interface Team extends ScoreBoardEventProvider, TimeoutOwner {
         RUNNING_OR_UPCOMING_TEAM_JAM(TeamJam.class, null),
         RUNNING_OR_ENDED_TEAM_JAM(TeamJam.class, null),
         LAST_ENDED_TEAM_JAM(TeamJam.class, null),
+        FIELDING_ADVANCE_PENDING(Boolean.class, false),
         CURRENT_TRIP(ScoringTrip.class, null),
         SCORE(Integer.class, 0),
         JAM_SCORE(Integer.class, 0),
@@ -134,6 +136,7 @@ public interface Team extends ScoreBoardEventProvider, TimeoutOwner {
     public enum Command implements CommandProperty {
         ADD_TRIP,
         REMOVE_TRIP,
+        ADVANCE_FIELDINGS,
         TIMEOUT,
         OFFICIAL_REVIEW;
         

--- a/src/com/carolinarollergirls/scoreboard/core/Team.java
+++ b/src/com/carolinarollergirls/scoreboard/core/Team.java
@@ -71,6 +71,7 @@ public interface Team extends ScoreBoardEventProvider, TimeoutOwner {
     public Position getPosition(FloorPosition fp);
 
     public void field(Skater s, Role r);
+    public void field(Skater s, Role r, TeamJam tj);
     public boolean hasFieldingAdvancePending();
 
     public boolean isLost();

--- a/src/com/carolinarollergirls/scoreboard/core/impl/BoxTripImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/impl/BoxTripImpl.java
@@ -241,6 +241,9 @@ public class BoxTripImpl extends ScoreBoardEventProviderImpl implements BoxTrip 
             unlink();
         }
     }
+    
+    @Override
+    public Team getTeam() { return (Team)getParent(); }
 
     @Override
     public boolean isCurrent() { return (Boolean)get(Value.IS_CURRENT); }

--- a/src/com/carolinarollergirls/scoreboard/core/impl/FieldingImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/impl/FieldingImpl.java
@@ -42,6 +42,14 @@ public class FieldingImpl extends ParentOrderedScoreBoardEventProviderImpl<Field
                     return false;
                 } else {
                     getTeamJam().getTeam().add(Team.Child.BOX_TRIP, new BoxTripImpl(this));
+                    if (getTeamJam().getTeam().hasFieldingAdvancePending()) {
+                        if (getNext().getSkater() == null && getNext().getCurrentRole() == getCurrentRole()) {
+                            getNext().setSkater(getSkater());
+                        } else {
+                            getTeamJam().getTeam().field(getSkater(), getCurrentRole(), getTeamJam().getNext());
+                        }
+                        getCurrentBoxTrip().add(BoxTrip.Child.FIELDING, getSkater().getFielding(getTeamJam().getNext()));
+                    }
                 }
             } else if (!(Boolean)value && getCurrentBoxTrip() != null && getCurrentBoxTrip().isCurrent()) {
                 getCurrentBoxTrip().end();
@@ -115,7 +123,9 @@ public class FieldingImpl extends ParentOrderedScoreBoardEventProviderImpl<Field
     public Position getPosition() { return (Position)get(Value.POSITION); }
 
     @Override
-    public boolean isCurrent() { return teamJam.isRunningOrUpcoming(); }
+    public boolean isCurrent() {
+        return (teamJam.isRunningOrUpcoming() && !teamJam.getTeam().hasFieldingAdvancePending()) 
+                || teamJam.isRunningOrEnded() && teamJam.getTeam().hasFieldingAdvancePending(); }
 
     @Override
     public Role getCurrentRole() { return getPosition().getFloorPosition().getRole(teamJam); }

--- a/src/com/carolinarollergirls/scoreboard/core/impl/FieldingImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/impl/FieldingImpl.java
@@ -138,6 +138,7 @@ public class FieldingImpl extends ParentOrderedScoreBoardEventProviderImpl<Field
             trips.add((BoxTrip) v);
         }
         Collections.sort(trips, new Comparator<BoxTrip>() {
+            @Override
             public int compare(BoxTrip b1, BoxTrip b2) {
                 if (b1 == b2) { return 0; }
                 if (b1 == null) { return 1; }

--- a/src/com/carolinarollergirls/scoreboard/core/impl/PositionImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/impl/PositionImpl.java
@@ -51,7 +51,6 @@ public class PositionImpl extends ScoreBoardEventProviderImpl implements Positio
     public void updateCurrentFielding() {
         synchronized (coreLock) {
             setCurrentFielding(getTeam().getRunningOrUpcomingTeamJam().getFielding(floorPosition));
-            if (getSkater() != null) { getSkater().set(Value.CURRENT_FIELDING, getCurrentFielding()); }
         }
     }
 

--- a/src/com/carolinarollergirls/scoreboard/core/impl/SkaterImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/impl/SkaterImpl.java
@@ -99,6 +99,9 @@ public class SkaterImpl extends ScoreBoardEventProviderImpl implements Skater {
             updateEligibility();
         } else if (prop == Child.FIELDING && ((Fielding)item).isCurrent()) {
             set(Value.CURRENT_FIELDING, item, Flag.INTERNAL);
+        } else if (prop == Child.FIELDING && team.hasFieldingAdvancePending() &&
+                ((Fielding)item).getTeamJam().isRunningOrEnded()) {
+            setRole(((Fielding)item).getCurrentRole());
         }
     }
     @Override
@@ -147,6 +150,12 @@ public class SkaterImpl extends ScoreBoardEventProviderImpl implements Skater {
 
     @Override
     public Role getRole() { return (Role)get(Value.ROLE); }
+    @Override
+    public Role getRole(TeamJam tj) {
+        Fielding f = getFielding(tj);
+        if (f == null) { return getBaseRole(); }
+        return f.getCurrentRole();
+    }
     @Override
     public void setRole(Role r) { set(Value.ROLE, r, Flag.INTERNAL); }
     @Override

--- a/tests/com/carolinarollergirls/scoreboard/core/impl/FieldingImplTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/core/impl/FieldingImplTests.java
@@ -49,7 +49,7 @@ public class FieldingImplTests {
 
     @Before
     public void setUp() throws Exception {
-        collectedEvents = new LinkedList<ScoreBoardEvent>();
+        collectedEvents = new LinkedList<>();
 
         sb = new ScoreBoardImpl();
         sb.addScoreBoardListener(batchCounter);

--- a/tests/com/carolinarollergirls/scoreboard/core/impl/StatsImplTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/core/impl/StatsImplTests.java
@@ -259,6 +259,7 @@ public class StatsImplTests {
 
         // Jam ends.
         sb.stopJamTO();
+        team1.execute(Team.Command.ADVANCE_FIELDINGS);
         advance(1000);
         // New jammer does not replace jammer from previous jam.
         team1.field(skater4, Role.JAMMER);

--- a/tests/com/carolinarollergirls/scoreboard/core/impl/TeamImplTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/core/impl/TeamImplTests.java
@@ -488,7 +488,15 @@ public class TeamImplTests {
         skater5.setPenaltyBox(true);
         skater4.setPenaltyBox(true);
         sb.stopJamTO();
+        assertEquals(team.getPosition(FloorPosition.BLOCKER1), skater1.getPosition());
+        assertEquals(team.getPosition(FloorPosition.BLOCKER2), skater2.getPosition());
+        assertNull(skater3.getPosition());
+        assertEquals(team.getPosition(FloorPosition.BLOCKER3), skater4.getPosition());
+        assertEquals(team.getPosition(FloorPosition.PIVOT), skater5.getPosition());
+        assertEquals(team.getPosition(FloorPosition.JAMMER), skater6.getPosition());
 
+        team.execute(Team.Command.ADVANCE_FIELDINGS);
+        
         assertNull(skater1.getPosition());
         assertNull(skater2.getPosition());
         assertNull(skater3.getPosition());
@@ -512,6 +520,7 @@ public class TeamImplTests {
         skater6.setPenaltyBox(false);
         sb.startJam();
         sb.stopJamTO();
+        team.execute(Team.Command.ADVANCE_FIELDINGS);
 
         assertNull(skater1.getPosition());
         assertNull(skater2.getPosition());

--- a/tests/com/carolinarollergirls/scoreboard/core/impl/TeamImplTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/core/impl/TeamImplTests.java
@@ -73,6 +73,7 @@ public class TeamImplTests {
         team.setStarPass(true);
 
         sb.stopJamTO();
+        team.execute(Team.Command.ADVANCE_FIELDINGS);
 
         assertTrue(team.isStarPass());
         assertFalse(team.isFieldingStarPass());
@@ -394,12 +395,12 @@ public class TeamImplTests {
 
     @Test
     public void testField() {
-        Skater skater1 = new SkaterImpl(team, "S1", "One", "1", "");
-        Skater skater2 = new SkaterImpl(team, "S2", "Two", "2", "");
-        Skater skater3 = new SkaterImpl(team, "S3", "Three", "3", "");
-        Skater skater4 = new SkaterImpl(team, "S4", "Four", "4", "");
-        Skater skater5 = new SkaterImpl(team, "S5", "Five", "5", "");
-        Skater skater6 = new SkaterImpl(team, "S6", "Six", "6", "");
+        Skater skater1 = team.addSkater("S1", "One", "1", "");
+        Skater skater2 = team.addSkater("S2", "Two", "2", "");
+        Skater skater3 = team.addSkater("S3", "Three", "3", "");
+        Skater skater4 = team.addSkater("S4", "Four", "4", "");
+        Skater skater5 = team.addSkater("S5", "Five", "5", "");
+        Skater skater6 = team.addSkater("S6", "Six", "6", "");
 
         team.field(skater1, Role.JAMMER);
         team.field(skater2, Role.PIVOT);
@@ -486,14 +487,47 @@ public class TeamImplTests {
 
         skater6.setPenaltyBox(true);
         skater5.setPenaltyBox(true);
-        skater4.setPenaltyBox(true);
+        skater2.setPenaltyBox(true);
         sb.stopJamTO();
+
         assertEquals(team.getPosition(FloorPosition.BLOCKER1), skater1.getPosition());
         assertEquals(team.getPosition(FloorPosition.BLOCKER2), skater2.getPosition());
         assertNull(skater3.getPosition());
         assertEquals(team.getPosition(FloorPosition.BLOCKER3), skater4.getPosition());
         assertEquals(team.getPosition(FloorPosition.PIVOT), skater5.getPosition());
         assertEquals(team.getPosition(FloorPosition.JAMMER), skater6.getPosition());
+        assertEquals(Role.BLOCKER, skater1.getRole());
+        assertEquals(Role.BLOCKER, skater2.getRole());
+        assertEquals(Role.BENCH, skater3.getRole());
+        assertEquals(Role.BLOCKER, skater4.getRole());
+        assertEquals(Role.JAMMER, skater5.getRole());
+        assertEquals(Role.BLOCKER, skater6.getRole());
+        assertEquals(skater5, team.getPosition(FloorPosition.JAMMER).getSkater());
+        assertNull(team.getPosition(FloorPosition.PIVOT).getSkater());
+        assertEquals(skater6, team.getPosition(FloorPosition.BLOCKER1).getSkater());
+        assertEquals(skater2, team.getPosition(FloorPosition.BLOCKER2).getSkater());
+        assertNull(team.getPosition(FloorPosition.BLOCKER3).getSkater());
+        
+        skater2.setPenaltyBox(false);
+        skater4.setPenaltyBox(true);
+
+        assertEquals(team.getPosition(FloorPosition.BLOCKER1), skater1.getPosition());
+        assertEquals(team.getPosition(FloorPosition.BLOCKER2), skater2.getPosition());
+        assertNull(skater3.getPosition());
+        assertEquals(team.getPosition(FloorPosition.BLOCKER3), skater4.getPosition());
+        assertEquals(team.getPosition(FloorPosition.PIVOT), skater5.getPosition());
+        assertEquals(team.getPosition(FloorPosition.JAMMER), skater6.getPosition());
+        assertEquals(Role.BLOCKER, skater1.getRole());
+        assertEquals(Role.BLOCKER, skater2.getRole());
+        assertEquals(Role.BENCH, skater3.getRole());
+        assertEquals(Role.BLOCKER, skater4.getRole());
+        assertEquals(Role.JAMMER, skater5.getRole());
+        assertEquals(Role.BLOCKER, skater6.getRole());
+        assertEquals(skater5, team.getPosition(FloorPosition.JAMMER).getSkater());
+        assertNull(team.getPosition(FloorPosition.PIVOT).getSkater());
+        assertEquals(skater6, team.getPosition(FloorPosition.BLOCKER1).getSkater());
+        assertNull(team.getPosition(FloorPosition.BLOCKER2).getSkater());
+        assertEquals(skater4, team.getPosition(FloorPosition.BLOCKER3).getSkater());
 
         team.execute(Team.Command.ADVANCE_FIELDINGS);
         


### PR DESCRIPTION
Any box trip starts/endings entered before advancing are treated as
having occured during the jam that just ended. Ones entered after
advancing are treated as having occured between jams.

If the jam is not manually advanced, it will be automatically advanced
at the start of the next jam.