### PR TITLE
Add Team Total penalty count to bottom of whiteboard

### DIFF
--- a/html/views/wb/whiteboard.html
+++ b/html/views/wb/whiteboard.html
@@ -27,6 +27,12 @@
 			</thead>
 			<tbody>
 			</tbody>
+			<tfoot>
+				<tr id="foot1">
+					<td colspan="11">TEAM TOTAL</td>
+					<td class="teamTotal">0</td>
+				</tr>
+			</tfoot>
 		</table>
 		<table class="Team Team2" cellpadding="0" cellspacing="0" border="1">
 			<thead>
@@ -39,6 +45,12 @@
 			</thead>
 			<tbody>
 			</tbody>
+			<tfoot>
+				<tr id="foot2">
+					<td colspan="11">TEAM TOTAL</td>
+					<td class="teamTotal">0</td>
+				</tr>
+			</tfoot>
 		</table>
 	</body>
 </html>

--- a/html/views/wb/whiteboard.js
+++ b/html/views/wb/whiteboard.js
@@ -110,6 +110,11 @@ function displayPenalty(t, s, p) {
 	$('.Team' + t + ' .Skater[id=' + s + ']').toggleClass("Warn1", cnt == limit-2 && !fo_exp);
 	$('.Team' + t + ' .Skater[id=' + s + ']').toggleClass("Warn2", cnt == limit-1 && !fo_exp);
 	$('.Team' + t + ' .Skater[id=' + s + ']').toggleClass("Warn3", cnt >= limit || fo_exp);
+
+	// Update the team's total penalties
+	var teamCnt = 0;
+	$('.Team' + t + ' .Skater .Total').each(function(idx, elem) { teamCnt += parseInt($(elem).text(), 10); })
+	$('#foot' + t + ' .teamTotal').text(teamCnt);
 }
 
 function makeSkaterRows(t, id, number) { //team, id, number


### PR DESCRIPTION
This was requested by our PBTs and PLTs as an easy way to double-check their paperwork.  It simply adds a 'TEAM TOTAL' counter to the bottom of each team on the whiteboard.