### PR TITLE
Use utf-8 charset for html and other text responses.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -108,6 +108,10 @@
 			</classpath>
 		</javac>
 
+		<copy todir="${dest.dir}">
+			<fileset dir="${src.dir}" includes="**/*.properties"/>
+		</copy>
+
 		<mkdir dir="${jar.dir}"/>
 		<one-jar destfile="${jar.dir}/${jar.file}" manifest="${jar.dir}/one-jar.mf" mainmanifest="${jar.dir}/${manifest.file}">
 			<main>

--- a/html/controls/lt/index.html
+++ b/html/controls/lt/index.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 	<head>
-		<meta charset="utf-8"/>
 		<title>Lineup Tracker</title>
 		<!--
 		 Copyright (C) 2008-2012 Mr Temper <MrTemper@CarolinaRollergirls.com>

--- a/html/controls/plt/index.html
+++ b/html/controls/plt/index.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 	<head>
-		<meta charset="utf-8"/>
 		<title>Penalty Lineup Tracker</title>
 		<!--
 		 Copyright (C) 2008-2012 Mr Temper <MrTemper@CarolinaRollergirls.com>

--- a/html/controls/pt/index.html
+++ b/html/controls/pt/index.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 	<head>
-		<meta charset="utf-8"/>
 		<title>Penalty Tracker</title>
 		<!--
 		 Copyright (C) 2008-2012 Mr Temper <MrTemper@CarolinaRollergirls.com>

--- a/html/views/wb/index.html
+++ b/html/views/wb/index.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 	<head>
-		<meta charset="utf-8"/>
 		<title>Penalty Tracker</title>
 		<!--
 		 Copyright (C) 2008-2012 Mr Temper <MrTemper@CarolinaRollergirls.com>

--- a/src/org/eclipse/jetty/http/mime.properties
+++ b/src/org/eclipse/jetty/http/mime.properties
@@ -1,0 +1,181 @@
+ai	= application/postscript
+aif	= audio/x-aiff
+aifc	= audio/x-aiff
+aiff	= audio/x-aiff
+apk = application/vnd.android.package-archive
+asc	= text/plain; charset=utf-8
+asf     = video/x.ms.asf
+asx     = video/x.ms.asx
+au	= audio/basic
+avi	= video/x-msvideo
+bcpio	= application/x-bcpio
+bin	= application/octet-stream
+cab     = application/x-cabinet
+cdf	= application/x-netcdf
+class	= application/java-vm
+cpio	= application/x-cpio
+cpt	= application/mac-compactpro
+crt	= application/x-x509-ca-cert
+csh	= application/x-csh
+css	= text/css; charset=utf-8
+csv     = text/comma-separated-values; charset=utf-8
+dcr	= application/x-director
+dir	= application/x-director
+dll     = application/x-msdownload
+dms	= application/octet-stream
+doc	= application/msword
+dtd     = application/xml-dtd
+dvi	= application/x-dvi
+dxr	= application/x-director
+eps	= application/postscript
+etx	= text/x-setext; charset=utf-8
+exe	= application/octet-stream
+ez	= application/andrew-inset
+gif	= image/gif
+gtar	= application/x-gtar
+gz	= application/gzip
+gzip	= application/gzip
+hdf	= application/x-hdf
+hqx	= application/mac-binhex40
+htc = text/x-component; charset=utf-8
+htm	= text/html; charset=utf-8
+html	= text/html; charset=utf-8
+ice	= x-conference/x-cooltalk
+ico	= image/x-icon
+ief	= image/ief
+iges	= model/iges
+igs	= model/iges
+jad     = text/vnd.sun.j2me.app-descriptor; charset=utf-8
+jar     = application/java-archive
+java	= text/plain; charset=utf-8
+jnlp	= application/x-java-jnlp-file
+jpe	= image/jpeg
+jpeg	= image/jpeg
+jpg	= image/jpeg
+js	= application/x-javascript
+jsp	= text/html; charset=utf-8
+kar	= audio/midi
+latex	= application/x-latex
+lha	= application/octet-stream
+lzh	= application/octet-stream
+man	= application/x-troff-man
+mathml	= application/mathml+xml
+me	= application/x-troff-me
+mesh	= model/mesh
+mid	= audio/midi
+midi	= audio/midi
+mif	= application/vnd.mif
+mol     = chemical/x-mdl-molfile
+mov	= video/quicktime
+movie	= video/x-sgi-movie
+mp2	= audio/mpeg
+mp3	= audio/mpeg
+mpe	= video/mpeg
+mpeg	= video/mpeg
+mpg	= video/mpeg
+mpga	= audio/mpeg
+ms	= application/x-troff-ms
+msh	= model/mesh
+msi	= application/octet-stream
+nc	= application/x-netcdf
+oda	= application/oda
+odb     = application/vnd.oasis.opendocument.database
+odc     = application/vnd.oasis.opendocument.chart
+odf     = application/vnd.oasis.opendocument.formula
+odg     = application/vnd.oasis.opendocument.graphics
+odi     = application/vnd.oasis.opendocument.image
+odm     = application/vnd.oasis.opendocument.text-master
+odp     = application/vnd.oasis.opendocument.presentation
+ods     = application/vnd.oasis.opendocument.spreadsheet
+odt     = application/vnd.oasis.opendocument.text
+ogg	= application/ogg
+otc     = application/vnd.oasis.opendocument.chart-template
+otf     = application/vnd.oasis.opendocument.formula-template
+otg     = application/vnd.oasis.opendocument.graphics-template
+oth     = application/vnd.oasis.opendocument.text-web
+oti     = application/vnd.oasis.opendocument.image-template
+otp     = application/vnd.oasis.opendocument.presentation-template
+ots     = application/vnd.oasis.opendocument.spreadsheet-template
+ott     = application/vnd.oasis.opendocument.text-template
+pbm	= image/x-portable-bitmap
+pdb	= chemical/x-pdb
+pdf	= application/pdf
+pgm	= image/x-portable-graymap
+pgn	= application/x-chess-pgn
+png	= image/png
+pnm	= image/x-portable-anymap
+ppm	= image/x-portable-pixmap
+pps     = application/vnd.ms-powerpoint
+ppt	= application/vnd.ms-powerpoint
+ps	= application/postscript
+qt	= video/quicktime
+ra	= audio/x-pn-realaudio
+ram	= audio/x-pn-realaudio
+ras	= image/x-cmu-raster
+rdf	= application/rdf+xml
+rgb	= image/x-rgb
+rm	= audio/x-pn-realaudio
+roff	= application/x-troff
+rpm	= application/x-rpm
+rtf	= application/rtf
+rtx	= text/richtext; charset=utf-8
+rv      = video/vnd.rn-realvideo
+ser     = application/java-serialized-object
+sgm	= text/sgml; charset=utf-8
+sgml	= text/sgml; charset=utf-8
+sh	= application/x-sh
+shar	= application/x-shar
+silo	= model/mesh
+sit	= application/x-stuffit
+skd	= application/x-koan
+skm	= application/x-koan
+skp	= application/x-koan
+skt	= application/x-koan
+smi	= application/smil
+smil	= application/smil
+snd	= audio/basic
+spl	= application/x-futuresplash
+src	= application/x-wais-source
+sv4cpio	= application/x-sv4cpio
+sv4crc	= application/x-sv4crc
+svg	= image/svg+xml
+swf	= application/x-shockwave-flash
+t	= application/x-troff
+tar	= application/x-tar
+tar.gz	= application/x-gtar
+tcl	= application/x-tcl
+tex	= application/x-tex
+texi	= application/x-texinfo
+texinfo	= application/x-texinfo
+tgz	= application/x-gtar
+tif	= image/tiff
+tiff	= image/tiff
+tr	= application/x-troff
+tsv	= text/tab-separated-values; charset=utf-8
+txt	= text/plain; charset=utf-8
+ustar	= application/x-ustar
+vcd	= application/x-cdlink
+vrml	= model/vrml
+vxml	= application/voicexml+xml
+wav	= audio/x-wav
+wbmp	= image/vnd.wap.wbmp
+wml	= text/vnd.wap.wml; charset=utf-8
+wmlc	= application/vnd.wap.wmlc
+wmls	= text/vnd.wap.wmlscript; charset=utf-8
+wmlsc	= application/vnd.wap.wmlscriptc
+wrl	= model/vrml
+wtls-ca-certificate	= application/vnd.wap.wtls-ca-certificate
+xbm	= image/x-xbitmap
+xht	= application/xhtml+xml
+xhtml	= application/xhtml+xml
+xls	= application/vnd.ms-excel
+xml	= application/xml
+xpm	= image/x-xpixmap
+xsd	= application/xml
+xsl	= application/xml
+xslt	= application/xslt+xml
+xul	= application/vnd.mozilla.xul+xml
+xwd	= image/x-xwindowdump
+xyz	= chemical/x-xyz
+z	= application/compress
+zip	= application/zip


### PR DESCRIPTION
The version of jetty we're using really doesn't
make setting this correctly easy. Hack in the charset in
the mime entries, overriding what Jetty has by default.