### PR TITLE
Make registering multiple WS names work as you'd expect.

### DIFF
--- a/html/json/WS.js
+++ b/html/json/WS.js
@@ -270,8 +270,26 @@ var WS = {
 		$.each($("[sbDisplay]"), function(idx, elem) {
 			elem = $(elem);
 			var paths = WS.getPaths(elem, "sbDisplay");
-			if (paths.length > 0)
-				WS.Register(paths, { element: elem, modifyFunc: window[elem.attr("sbModify")] });
+			if (paths.length > 0) {
+				// When there's multiple names, use the
+				// first non-empty one.
+				var mf = function() {
+					var v = null;
+					var path;
+					for (var i = 0; i < paths.length; i++) {
+						path = paths[i];
+						if (WS.state[path] != null ) {
+							v = WS.state[path];
+							break;
+						}
+					}
+					if (window[elem.attr("sbModify")] != null) {
+						v = window[elem.attr("sbModify")](path, v);
+					}
+					return v;
+				}
+				WS.Register(paths, { element: elem, modifyFunc: mf });
+			}
 		});
 		$.each($("[sbTrigger]"), function(idx, elem) {
 			elem = $(elem);

--- a/html/views/overlays/interactive/admin.js
+++ b/html/views/overlays/interactive/admin.js
@@ -88,9 +88,14 @@ $('#Controls input, #Controls .Selector').change(function() {
 	t = $(this).attr('data-setting');
 	v = $(this).val();
 	if ($(this).attr("type") == "color") {
-		$(this).attr("cleared", "false")
+		$(this).attr("cleared", "false");
 	}
-	if(t) WS.Set(t, v);
+	if (v == '' && t.endsWith('.Name')) {
+		// Delete the AlternateName
+		WS.Set(t.substr(0, t.length-5), null);
+	} else if(t) {
+		WS.Set(t, v);
+	}
 });
 
 $('.SelectUpdator').change(function() {

--- a/html/views/overlays/interactive/index.html
+++ b/html/views/overlays/interactive/index.html
@@ -19,7 +19,7 @@
 					<div class="Team1" sbContext="Team(1)">	
 					<div class="Team Row Wrapper barBackgroundTop"> 
 						<div class="Indicator ColourTeam1 Box">&nbsp;</div>
-						<div class="Name  VerticalCenter Box" sbDisplay="AlternateName(overlay).Name,Name" sbModify="nameUpdate"></div>
+						<div class="Name  VerticalCenter Box" sbDisplay="AlternateName(overlay).Name,Name"></div>
 						<div class="Score VerticalCenter Box" sbDisplay="Score"></div>
 						<div class="Mini Box">
 							<div class="JamScore" sbDisplay="JamScore"></div>
@@ -39,7 +39,7 @@
 					<div class="Team2" sbContext="Team(2)">
 						<div class="Team Row Wrapper barBackgroundBottom">
 							<div class="Indicator ColourTeam2 Box">&nbsp;</div>
-							<div class="Name Box" sbDisplay="AlternateName(overlay).Name,Name" sbModify="nameUpdate"></div>
+							<div class="Name Box" sbDisplay="AlternateName(overlay).Name,Name"></div>
 							<div class="Score Box" sbDisplay="Score"></div>
 							<div class="Mini Box"><div class="JamScore" sbDisplay="JamScore"></div><div class="LeadJammer Lead">&#9733;</div></div>
 							<div class="DotTimeouts Box"><div class="Dot Timeout1"></div><div class="Dot Timeout2"></div><div class="Dot Timeout3"></div><div class="Dot OfficialReview1"></div></div>

--- a/html/views/standard/common.js
+++ b/html/views/standard/common.js
@@ -29,19 +29,8 @@ function getTeamId(k) {
 }
 
 function nameUpdate(k, v) {
-	id = getTeamId(k);
-	var prefix = "ScoreBoard.Team(" + id + ").";
-	var name = WS.state[prefix + "Name"];
-	var altName1 = WS.state[prefix + "AlternateName(overlay).Name"];
-	var altName2 = WS.state[prefix + "AlternateName(scoreboard).Name"];
-
-	if (altName1 != null && altName1 != "")
-		name = altName1;
-	else if (altName2 != null && altName2 != "")
-		name = altName2;
-
-	$(".Team" + id).toggleClass("HasName", name != "");
-	return name;
+	$(".Team" + id).toggleClass("HasName", v != "");
+	return v;
 }
 
 function logoUpdate(k, v) {


### PR DESCRIPTION
This now provides the first non-null value, so you don't
have to add that logic by hand.

Simplify how scoreboard team names are handled.

This incidentally makes it so that sbDisplay will
now only pick up exact key matches.