### PR TITLE
Position related improvements & bugfixes

### DIFF
--- a/html/controls/lt/lt-sheet.js
+++ b/html/controls/lt/lt-sheet.js
@@ -104,7 +104,7 @@ function prepareLtSheetTable(element, teamId, mode) {
 			var jamRow = $('<tr>').addClass('Jam').attr('nr', nr);
 			if (mode != 'copyToStatsbook') {
 				$('<td>').addClass('JamNumber Darker').text(nr).appendTo(jamRow);
-				$('<td>').addClass('NP Darker').click(function() { WS.Set(prefix+'NoPivot', $(this).text() == ""); }).appendTo(jamRow);
+				$('<td>').addClass('NP Darker').click(function() { WS.Set(prefix+'NoNamedPivot', $(this).text() == ""); }).appendTo(jamRow);
 			}
 			$.each( [ "Jammer", "Pivot", "Blocker1", "Blocker2", "Blocker3" ], function() {
 				var pos = String(this);
@@ -246,27 +246,34 @@ function prepareFieldingEditor(teamId) {
 	}		
 	
 	function processSkater(k, v) {
-		var match = (k || "").match(/Skater\(([^\)]+)\)\.Number/);
+		var match = (k || "").match(/Skater\(([^\)]+)\)\.([^\.]+)/);
 		if (match == null || match.length == 0)
 			return;
 
 		var id = match[1];
-		var option = $(".FieldingEditor #skater option[value='"+id+"']")
-		var inserted = false;
-		if (v != null && option.length == 0) {
-			var option = $('<option>').attr('value', id).text(v);
+		var field = match[2];
+		if (field != 'Role' && field != 'Number') { return; }
+		var role = WS.state['ScoreBoard.Team('+teamId+').Skater('+id+').Role'];
+		var number = WS.state['ScoreBoard.Team('+teamId+').Skater('+id+').Number'];
+		
+		var playing = (role != null && role != 'NotInGame'); 
+		
+		var option = $("#FieldingEditor #skater option[value='"+id+"']");
+		if (playing && option.length == 0) {
+			var option = $('<option>').attr('value', id).text(number);
+			var inserted = false;
 			$('#FieldingEditor #skater').children().each(function (idx, s) {
-				if (s.text > String(v) && idx > 0) {
+				if (s.text > number && idx > 0) {
 					$(s).before(option);
 					inserted = true;
 					return false;
 				}
 			});
 			if (!inserted) option.appendTo($('#FieldingEditor #skater'));
-		} else if (v == null) {
+		} else if (!playing) {
 			option.remove();
 		} else {
-			option.text(v);
+			option.text(number);
 		}
 	}
 	

--- a/html/controls/operator.js
+++ b/html/controls/operator.js
@@ -825,11 +825,7 @@ function createTeamTable() {
 			noPivotButton.val(!isTrue(value));
 			noPivotButton.toggleClass("Active", isTrue(value));
 		});
-		if (first) {
-			noPivotButton.appendTo(starPassTd);
-		} else {
-			noPivotButton.prependTo(starPassTd);
-		}
+		noPivotButton.appendTo(starPassTd);
 
 		var makeSkaterDropdown = function(pos, elem, sort) {
 			var sortFunc = _windowFunctions.alphaCompareByProp;

--- a/html/controls/operator.js
+++ b/html/controls/operator.js
@@ -825,7 +825,11 @@ function createTeamTable() {
 			noPivotButton.val(!isTrue(value));
 			noPivotButton.toggleClass("Active", isTrue(value));
 		});
-		noPivotButton.appendTo(starPassTd);
+		if (first) {
+			noPivotButton.appendTo(starPassTd);
+		} else {
+			noPivotButton.prependTo(starPassTd);
+		}
 
 		var makeSkaterDropdown = function(pos, elem, sort) {
 			var sortFunc = _windowFunctions.alphaCompareByProp;
@@ -837,11 +841,12 @@ function createTeamTable() {
 					optionFilterElement: "Role",
 					optionChildFilter: function(node) { return (node.$sb("Role").$sbGet() != 'NotInGame'); },
 					compareOptions: function(a, b) { return sortFunc("text", a, b); },
-					firstOption: { text: "No "+pos, value: "" }
+					firstOption: { text: '?', value: "" }
 				} }).addClass(pos+" By"+elem+" "+sort+"Sort");
 		};
 
 		var jammerSelectTd = jammer1Tr.children("td:eq("+(first?"1":"0")+")").addClass("Jammer");
+		$('<span>').text('Jammer:').appendTo(jammerSelectTd);
 		makeSkaterDropdown("Jammer", "Number", "Alpha").appendTo(jammerSelectTd);
 
 		var jammerBox = sbTeam.$sb("Position(Jammer).PenaltyBox");
@@ -854,6 +859,7 @@ function createTeamTable() {
 		jammerBoxButton.appendTo(jammerSelectTd);
 
 		var pivotSelectTd = jammer2Tr.children("td:eq("+(first?"1":"0")+")").addClass("Pivot");
+		$('<span>').text('Piv/4th Bl:').appendTo(pivotSelectTd);
 		makeSkaterDropdown("Pivot", "Number", "Alpha").appendTo(pivotSelectTd);
 
 		var pivotBox = sbTeam.$sb("Position(Pivot).PenaltyBox");

--- a/html/javascript/utils.js
+++ b/html/javascript/utils.js
@@ -252,9 +252,9 @@ _crgUtils = {
 	 *		 Optional name of each child subelement value to use
 	 *		 for the option value.
 	 *		 If not set, the child node's $sbId will be used.
-	 *   optionFilterElement: string
-	 *   	Optional name of a child subelement that will trigger a
-	 *   	reevaluation of the filter when changed
+	 *	 optionFilterElement: string
+	 *		 Optional name of a child subelement that will trigger a
+	 *		 reevaluation of the filter when changed
 	 */
 	setupSelect: function(s, params) {
 		s = $(s);

--- a/html/javascript/utils.js
+++ b/html/javascript/utils.js
@@ -252,6 +252,9 @@ _crgUtils = {
 	 *		 Optional name of each child subelement value to use
 	 *		 for the option value.
 	 *		 If not set, the child node's $sbId will be used.
+	 *   optionFilterElement: string
+	 *   	Optional name of a child subelement that will trigger a
+	 *   	reevaluation of the filter when changed
 	 */
 	setupSelect: function(s, params) {
 		s = $(s);
@@ -287,6 +290,7 @@ _crgUtils = {
 		var optionChildFilter = (params.optionChildFilter || function() { return true; });
 		var optionNameElement = params.optionNameElement;
 		var optionValueElement = params.optionValueElement;
+		var optionFilterElement = params.optionFilterElement;
 
 //FIXME - need to add code to unbind if/when the option/select is removed from the DOM!
 		var setOptionName = function(option, node) {
@@ -337,8 +341,20 @@ _crgUtils = {
 
 		if (optionParent && optionChildName) {
 			_crgUtils.bindAddRemoveEach(optionParent, optionChildName, function(event, node) {
-				if (optionChildFilter(node))
+				if (optionChildFilter(node)) {
 					addOption(createOption(node));
+				}
+				if (optionFilterElement) {
+					node.$sb(optionFilterElement).$sbBindAndRun("sbchange", function(event, value) {
+						if (optionChildFilter(node)) {
+							if (!s.find("option[data-optionid='"+node.$sbPath+"']").size()) {
+								addOption(createOption(node));
+							}
+						} else {
+							removeOption(node);
+						}
+					});
+				}
 			}, function(event, node) {
 				removeOption(node);
 			});

--- a/html/views/overlays/interactive/index.html
+++ b/html/views/overlays/interactive/index.html
@@ -59,7 +59,7 @@
 						<div class="Box TextRight Name" sbDisplay="Name,Number" sbContext="Clock(Jam)" sbModify="toClockInitialNumber"></div>
 					</div>
 
-					<div class="ClockBarMiddle Wrapper SlideDown ShowInIntermission ShowInLineUp ShowInTimeout Box BigName ClockDescription" sbDisplay="Clock(Intermission).Running, Clock.(Intermission).Number, Clock(Lineup).Running, Clock(Lineup).Name, Clock(Timeout).Name, Clock(Timeout).Running, TimeoutOwner, OfficialReviews, Team(1).Timeouts, Team(2).OfficialReviews, Team(2).Timeouts, Settings.Setting(ScoreBoard.Intermission.PreGame), Settings.Setting(ScoreBoard.Intermission.Intermission), Settings.Setting(ScoreBoard.Intermission.Unofficial), Settings.Setting(ScoreBoard.Intermission.Official), OfficialScore, Clock(Intermission).Number, Clock(Intermission).MaximumNumber" sbModify="clockType"></div>
+					<div class="ClockBarMiddle Wrapper SlideDown ShowInIntermission ShowInLineUp ShowInTimeout Box BigName ClockDescription" sbDisplay="Clock(Intermission).Running, Clock.(Intermission).Number, Clock(Lineup).Running, Clock(Lineup).Name, Clock(Timeout).Name, Clock(Timeout).Running, TimeoutOwner, OfficialReviews, Team(1).Timeouts, Team(2).OfficialReviews, Team(2).Timeouts, Settings.Setting(ScoreBoard.Intermission.PreGame), Settings.Setting(ScoreBoard.Intermission.Intermission), Settings.Setting(ScoreBoard.Intermission.Unofficial), Settings.Setting(ScoreBoard.Intermission.Official), OfficialScore, Clock(Intermission).Number, Rulesets.CurrentRule(Period.Number)" sbModify="clockType"></div>
 					<div class="ClockBarBottom Wrapper Row BottomRow barBackgroundBottom">
 						<div class="Box TextLeft Time Clock Show ShowInJam ShowInLineup ShowInTimeout" sbContext="Clock(Period)" sbDisplay="Time" sbModify="toTime"></div>
 						<div class="Box BoxLarge TextCenter Time Clock ShowInIntermission" sbDisplay="Clock(Intermission).Time" sbModify="toTime"></div>
@@ -76,7 +76,7 @@
 
 				<div class="ClockBox Wrapper OverlayPanel PanelHideBottom MediumPanel AnimatedPanel">
 						<div class="Wrapper Clock SlideDown ShowInIntermission ShowInLineUp ShowInTimeout">
-							<div class="Box BigName ShowInIntermission Clock" sbDisplay="Settings.Setting(ScoreBoard.Intermission.PreGame), Settings.Setting(ScoreBoard.Intermission.Intermission), Settings.Setting(ScoreBoard.Intermission.Unofficial), Settings.Setting(ScoreBoard.Intermission.Official), OfficialScore, Clock(Intermission).Number, Clock(Intermission).MaximumNumber" sbModify="intermissionDisplay"></div>
+							<div class="Box BigName ShowInIntermission Clock" sbDisplay="Settings.Setting(ScoreBoard.Intermission.PreGame), Settings.Setting(ScoreBoard.Intermission.Intermission), Settings.Setting(ScoreBoard.Intermission.Unofficial), Settings.Setting(ScoreBoard.Intermission.Official), OfficialScore, Clock(Intermission).Number, Rulesets.CurrentRule(Period.Number)" sbModify="intermissionDisplay"></div>
 							<div class="Box BoxLarge TextCenter Time Clock ShowInIntermission" sbDisplay="Clock(Intermission).Time" sbModify="toTime"></div>
 						</div>
 				</div>

--- a/html/views/overlays/interactive/index.js
+++ b/html/views/overlays/interactive/index.js
@@ -13,7 +13,7 @@ function initialize() {
 	WS.AutoRegister();
 
 	WS.Register( [ "ScoreBoard.Clock(Intermission).Number",
-		       "ScoreBoard.Clock(Intermission).MaximumNumber",
+		       "ScoreBoard.Rulesets.CurrentRule(Period.Number)",
 		       "ScoreBoard.Settings.Setting(ScoreBoard.Intermission.PreGame)",
 		       "ScoreBoard.Settings.Setting(ScoreBoard.Intermission.Unofficial)",
 		       "ScoreBoard.Settings.Setting(ScoreBoard.Intermission.Official)",
@@ -308,7 +308,7 @@ function clockType(k,v) {
 		$('.ClockDescription').css('backgroundColor', '#888');
 	} else if(ic) {
 		var num = WS.state["ScoreBoard.Clock(Intermission).Number"];
-		var max = WS.state["ScoreBoard.Clock(Intermission).MaximumNumber"];
+		var max = WS.state["ScoreBoard.Rulesets.CurrentRule(Period.Number)"];
 		var isOfficial = WS.state["ScoreBoard.OfficialScore"];
 		if (num == 0)  
 			ret = WS.state["ScoreBoard.Settings.Setting(ScoreBoard.Intermission.PreGame)"];

--- a/src/com/carolinarollergirls/scoreboard/core/Clock.java
+++ b/src/com/carolinarollergirls/scoreboard/core/Clock.java
@@ -27,12 +27,6 @@ public interface Clock extends ScoreBoardEventProvider {
     public int getNumber();
     public void setNumber(int n);
     public void changeNumber(int n);
-    public int getMinimumNumber();
-    public void setMinimumNumber(int n);
-    public void changeMinimumNumber(int n);
-    public int getMaximumNumber();
-    public void setMaximumNumber(int n);
-    public void changeMaximumNumber(int n);
 
     /**
      *
@@ -94,8 +88,6 @@ public interface Clock extends ScoreBoardEventProvider {
         ID(String.class, ""),
         NAME(String.class, ""),
         NUMBER(Integer.class, 0),
-        MINIMUM_NUMBER(Integer.class, 0),
-        MAXIMUM_NUMBER(Integer.class, 0),
         TIME(Long.class, 0L),
         INVERTED_TIME(Long.class, 0L),
         MINIMUM_TIME(Long.class, 0L),

--- a/src/com/carolinarollergirls/scoreboard/core/FloorPosition.java
+++ b/src/com/carolinarollergirls/scoreboard/core/FloorPosition.java
@@ -18,7 +18,7 @@ public enum FloorPosition {
         if (role == Role.PIVOT && teamJam.isStarPass()) {
             return Role.JAMMER;
         } else if (role == Role.JAMMER && teamJam.isStarPass() ||
-                role == Role.PIVOT && teamJam.hasNoPivot()) {
+                role == Role.PIVOT && teamJam.hasNoNamedPivot()) {
             return Role.BLOCKER;
         } else {
             return role; 

--- a/src/com/carolinarollergirls/scoreboard/core/Team.java
+++ b/src/com/carolinarollergirls/scoreboard/core/Team.java
@@ -103,6 +103,11 @@ public interface Team extends ScoreBoardEventProvider, TimeoutOwner {
         OFFICIAL_REVIEWS(Integer.class, 0),
         IN_TIMEOUT(Boolean.class, false),
         IN_OFFICIAL_REVIEW(Boolean.class, false),
+        // NO_NAMED_PIVOT is only false when a pivot has been explicitly set.
+        // NO_PIVOT is only true when either a 4th blocker has been set or the
+        // "no skater fielded" flag has been set for the pivot position.
+        // They differ when neither of these inputs has been made (yet) or all
+        // inputs have been reversed.
         NO_NAMED_PIVOT(Boolean.class, true),
         NO_PIVOT(Boolean.class, false),
         RETAINED_OFFICIAL_REVIEW(Boolean.class, false),

--- a/src/com/carolinarollergirls/scoreboard/core/Team.java
+++ b/src/com/carolinarollergirls/scoreboard/core/Team.java
@@ -80,7 +80,7 @@ public interface Team extends ScoreBoardEventProvider, TimeoutOwner {
     public boolean isInjury();
     public boolean isDisplayLead();
     public boolean isStarPass();
-    public boolean hasNoPivot();
+    public boolean hasNoNamedPivot();
 
 
     public static final String ID_1 = "1";
@@ -103,7 +103,8 @@ public interface Team extends ScoreBoardEventProvider, TimeoutOwner {
         OFFICIAL_REVIEWS(Integer.class, 0),
         IN_TIMEOUT(Boolean.class, false),
         IN_OFFICIAL_REVIEW(Boolean.class, false),
-        NO_PIVOT(Boolean.class, true),
+        NO_NAMED_PIVOT(Boolean.class, true),
+        NO_PIVOT(Boolean.class, false),
         RETAINED_OFFICIAL_REVIEW(Boolean.class, false),
         LOST(Boolean.class, false),
         LEAD(Boolean.class, false),

--- a/src/com/carolinarollergirls/scoreboard/core/TeamJam.java
+++ b/src/com/carolinarollergirls/scoreboard/core/TeamJam.java
@@ -60,6 +60,11 @@ public interface TeamJam extends ParentOrderedScoreBoardEventProvider<TeamJam> {
         DISPLAY_LEAD(Boolean.class, false),
         STAR_PASS(Boolean.class, false),
         STAR_PASS_TRIP(ScoringTrip.class, null),
+        // NO_NAMED_PIVOT is only false when a pivot has been explicitly set.
+        // NO_PIVOT is only true when either a 4th blocker has been set or the
+        // "no skater fielded" flag has been set for the pivot position.
+        // They differ when neither of these inputs has been made (yet) or all
+        // inputs have been reversed.
         NO_NAMED_PIVOT(Boolean.class, true),
         NO_PIVOT(Boolean.class, false);
 

--- a/src/com/carolinarollergirls/scoreboard/core/TeamJam.java
+++ b/src/com/carolinarollergirls/scoreboard/core/TeamJam.java
@@ -39,8 +39,8 @@ public interface TeamJam extends ParentOrderedScoreBoardEventProvider<TeamJam> {
     public boolean isStarPass();
     public ScoringTrip getStarPassTrip();
 
-    public boolean hasNoPivot();
-    public void setNoPivot(boolean np);
+    public boolean hasNoNamedPivot();
+    public void setNoNamedPivot(boolean np);
 
     public Fielding getFielding(FloorPosition fp);
 
@@ -60,7 +60,8 @@ public interface TeamJam extends ParentOrderedScoreBoardEventProvider<TeamJam> {
         DISPLAY_LEAD(Boolean.class, false),
         STAR_PASS(Boolean.class, false),
         STAR_PASS_TRIP(ScoringTrip.class, null),
-        NO_PIVOT(Boolean.class, true);
+        NO_NAMED_PIVOT(Boolean.class, true),
+        NO_PIVOT(Boolean.class, false);
 
         private Value(Class<?> t, Object dv) { type = t; defaultValue = dv; }
         private final Class<?> type;

--- a/src/com/carolinarollergirls/scoreboard/core/impl/ClockImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/impl/ClockImpl.java
@@ -20,7 +20,6 @@ import com.carolinarollergirls.scoreboard.event.ScoreBoardEvent;
 import com.carolinarollergirls.scoreboard.event.ScoreBoardEvent.CommandProperty;
 import com.carolinarollergirls.scoreboard.event.ScoreBoardEvent.PermanentProperty;
 import com.carolinarollergirls.scoreboard.event.ScoreBoardListener;
-import com.carolinarollergirls.scoreboard.rules.Rule;
 import com.carolinarollergirls.scoreboard.utils.ClockConversion;
 import com.carolinarollergirls.scoreboard.utils.ScoreBoardClock;
 
@@ -35,8 +34,6 @@ public class ClockImpl extends ScoreBoardEventProviderImpl implements Clock {
         } else {
             values.put(Value.NUMBER, 0);
         }
-        setRecalculated(Value.NUMBER).addSource(this, Value.MAXIMUM_NUMBER).addSource(this, Value.MINIMUM_NUMBER);
-        setRecalculated(Value.MAXIMUM_NUMBER).addSource(this, Value.MINIMUM_NUMBER);
         setRecalculated(Value.TIME).addSource(this, Value.MAXIMUM_TIME).addSource(this, Value.MINIMUM_TIME);
         setRecalculated(Value.MAXIMUM_TIME).addSource(this, Value.MINIMUM_TIME);
         setRecalculated(Value.INVERTED_TIME).addSource(this, Value.MAXIMUM_TIME).addSource(this, Value.TIME);
@@ -68,11 +65,8 @@ public class ClockImpl extends ScoreBoardEventProviderImpl implements Clock {
         if (prop == Value.MAXIMUM_TIME && (Long)value < getMinimumTime()) {
             return getMinimumTime();
         }
-        if ((prop == Value.MAXIMUM_NUMBER || prop == Value.NUMBER) && (Integer)value < getMinimumNumber()) {
-            return getMinimumNumber();
-        }
-        if (prop == Value.NUMBER && (Integer)value > getMaximumNumber()) {
-            return getMaximumNumber();
+        if (prop == Value.NUMBER && (Integer)value < 0) {
+            return 0;
         }
         return value;
     }
@@ -122,7 +116,7 @@ public class ClockImpl extends ScoreBoardEventProviderImpl implements Clock {
             rulesetChangeListener.scoreBoardChange(null);
 
             // We hardcode the assumption that numbers count up.
-            setNumber(getMinimumNumber());
+            setNumber(0);
 
             resetTime();
         }
@@ -134,16 +128,6 @@ public class ClockImpl extends ScoreBoardEventProviderImpl implements Clock {
             // Get default values from current settings or use hardcoded values
             Rulesets r = getScoreBoard().getRulesets();
             setCountDirectionDown(Boolean.parseBoolean(r.get(Rulesets.Child.CURRENT_RULE, getId() + ".ClockDirection").getValue()));
-            if (getId().equals(ID_JAM) || getId().equals(ID_INTERMISSION) || getId().equals(ID_PERIOD)) {
-                setMinimumNumber(0);
-            } else {
-                setMinimumNumber(DEFAULT_MINIMUM_NUMBER);
-            }
-            if (getId().equals(ID_PERIOD) || getId().equals(ID_INTERMISSION)) {
-                setMaximumNumber(r.getInt(Rule.NUMBER_PERIODS));
-            } else {
-                setMaximumNumber(DEFAULT_MAXIMUM_NUMBER);
-            }
             setMinimumTime(DEFAULT_MINIMUM_TIME);
             if (getId().equals(ID_PERIOD) || getId().equals(ID_JAM)) {
                 setMaximumTime(ClockConversion.fromHumanReadable(r.get(Rulesets.Child.CURRENT_RULE, getId() + ".Duration").getValue()));
@@ -184,19 +168,6 @@ public class ClockImpl extends ScoreBoardEventProviderImpl implements Clock {
     @Override
     public void changeNumber(int change) { set(Value.NUMBER, change, Flag.CHANGE); }
 
-    @Override
-    public int getMinimumNumber() { return (Integer)get(Value.MINIMUM_NUMBER); }
-    @Override
-    public void setMinimumNumber(int n) { set(Value.MINIMUM_NUMBER, n); }
-    @Override
-    public void changeMinimumNumber(int change) { set(Value.MINIMUM_NUMBER, change, Flag.CHANGE); }
-
-    @Override
-    public int getMaximumNumber() { return (Integer)get(Value.MAXIMUM_NUMBER); }
-    @Override
-    public void setMaximumNumber(int n) { set(Value.MAXIMUM_NUMBER, n); }
-    @Override
-    public void changeMaximumNumber(int change) { set(Value.MAXIMUM_NUMBER, change, Flag.CHANGE); }
 
     @Override
     public long getTime() { return (Long)get(Value.TIME); }
@@ -323,8 +294,6 @@ public class ClockImpl extends ScoreBoardEventProviderImpl implements Clock {
 
     public static UpdateClockTimerTask updateClockTimerTask = new UpdateClockTimerTask();
 
-    public static final int DEFAULT_MINIMUM_NUMBER = 1;
-    public static final int DEFAULT_MAXIMUM_NUMBER = 999;
     public static final long DEFAULT_MINIMUM_TIME = 0;
     public static final long DEFAULT_MAXIMUM_TIME = 24 * 60 * 60 * 1000; // 1 day for long time to derby
     public static final boolean DEFAULT_DIRECTION = false;   // up

--- a/src/com/carolinarollergirls/scoreboard/core/impl/FieldingImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/impl/FieldingImpl.java
@@ -42,7 +42,7 @@ public class FieldingImpl extends ParentOrderedScoreBoardEventProviderImpl<Field
                     return false;
                 } else {
                     getTeamJam().getTeam().add(Team.Child.BOX_TRIP, new BoxTripImpl(this));
-                    if (getTeamJam().getTeam().hasFieldingAdvancePending()) {
+                    if (getTeamJam().getTeam().hasFieldingAdvancePending() && isCurrent()) {
                         if (getNext().getSkater() == null && getNext().getCurrentRole() == getCurrentRole()) {
                             getNext().setSkater(getSkater());
                         } else {

--- a/src/com/carolinarollergirls/scoreboard/core/impl/PositionImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/impl/PositionImpl.java
@@ -15,6 +15,7 @@ import com.carolinarollergirls.scoreboard.core.Skater;
 import com.carolinarollergirls.scoreboard.core.Team;
 import com.carolinarollergirls.scoreboard.event.ScoreBoardEventProviderImpl;
 import com.carolinarollergirls.scoreboard.event.ScoreBoardEvent.CommandProperty;
+import com.carolinarollergirls.scoreboard.event.ScoreBoardEvent.PermanentProperty;
 
 public class PositionImpl extends ScoreBoardEventProviderImpl implements Position {
     public PositionImpl(Team t, FloorPosition fp) {
@@ -35,6 +36,23 @@ public class PositionImpl extends ScoreBoardEventProviderImpl implements Positio
     public void execute(CommandProperty prop) {
         if (prop == Command.CLEAR) {
             set(Value.SKATER, null);
+        }
+    }
+    
+    @Override
+    protected Object computeValue(PermanentProperty prop, Object value, Object last, Flag flag) {
+        if (prop == Value.SKATER && floorPosition == FloorPosition.PIVOT && flag != Flag.COPY) {
+            // can't set here as Skater hasn't been set yet so NoNamedPivot can't be set properly
+            // but also can't detect that change came from UI in valueChanged() thus this flag
+            setNoPivot = true;
+        }
+        return value;
+    }
+    @Override
+    protected void valueChanged(PermanentProperty prop, Object value, Object last, Flag flag) {
+        if (prop == Value.SKATER && setNoPivot) {
+            getTeam().set(Team.Value.NO_NAMED_PIVOT, value == null);
+            setNoPivot = false;
         }
     }
 
@@ -70,4 +88,6 @@ public class PositionImpl extends ScoreBoardEventProviderImpl implements Positio
     public void setPenaltyBox(boolean box) { set(Value.PENALTY_BOX, box); }
 
     protected FloorPosition floorPosition;
+    
+    private boolean setNoPivot = false;
 }

--- a/src/com/carolinarollergirls/scoreboard/core/impl/ScoreBoardImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/impl/ScoreBoardImpl.java
@@ -237,7 +237,7 @@ public class ScoreBoardImpl extends ScoreBoardEventProviderImpl implements Score
             if (pc.isRunning() || isInJam()) {
                 return;
             }
-            if (pc.getNumber() < pc.getMaximumNumber()) {
+            if (pc.getNumber() < getRulesets().getInt(Rule.NUMBER_PERIODS)) {
                 return;
             }
             if (!pc.isTimeAtEnd()) {
@@ -533,7 +533,7 @@ public class ScoreBoardImpl extends ScoreBoardEventProviderImpl implements Score
         ic.stop();
         if (getCurrentPeriodNumber() == 0 || 
                 (ic.getTimeRemaining() < 60000 
-                        && pc.getNumber() < pc.getMaximumNumber())) {
+                        && pc.getNumber() < getRulesets().getInt(Rule.NUMBER_PERIODS))) {
             //If less than one minute of intermission is left and there is another period,
             // go to the next period. Otherwise extend the previous period.
             //Always start period 1 as there is no previous period to extend.

--- a/src/com/carolinarollergirls/scoreboard/core/impl/SkaterImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/impl/SkaterImpl.java
@@ -81,6 +81,14 @@ public class SkaterImpl extends ScoreBoardEventProviderImpl implements Skater {
                 }
             }
         }
+        if (prop == Value.FLAGS) {
+            if ("ALT".equals(value) || "BC".equals(value)) {
+                set(Value.BASE_ROLE, Role.NOT_IN_GAME);
+            } else if (get(Value.BASE_ROLE) == Role.NOT_IN_GAME) {
+                set(Value.BASE_ROLE, Role.BENCH);
+                updateEligibility();
+            }
+        }
         if (prop == Value.BASE_ROLE && get(Value.ROLE) == last) {
             set(Value.ROLE, value, Flag.INTERNAL);
         }

--- a/src/com/carolinarollergirls/scoreboard/core/impl/TeamImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/impl/TeamImpl.java
@@ -109,9 +109,11 @@ public class TeamImpl extends ScoreBoardEventProviderImpl implements Team {
     public void execute(CommandProperty prop) {
         switch((Command)prop) {
         case ADD_TRIP:
+            tripScoreTimerTask.cancel();
             getRunningOrEndedTeamJam().addScoringTrip();
             break;
         case REMOVE_TRIP:
+            tripScoreTimerTask.cancel();
             getRunningOrEndedTeamJam().removeScoringTrip();
             break;
         case ADVANCE_FIELDINGS:

--- a/src/com/carolinarollergirls/scoreboard/core/impl/TeamJamImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/impl/TeamJamImpl.java
@@ -110,7 +110,8 @@ public class TeamJamImpl extends ParentOrderedScoreBoardEventProviderImpl<TeamJa
                 ((ScoringTrip)last).set(ScoringTrip.Value.CURRENT, false);
             }
         }
-        if (prop == Value.NO_NAMED_PIVOT && getFielding(FloorPosition.PIVOT).getSkater() != null) {
+        if (prop == Value.NO_NAMED_PIVOT && getFielding(FloorPosition.PIVOT).getSkater() != null &&
+                getFielding(FloorPosition.PIVOT).isCurrent()) {
             getFielding(FloorPosition.PIVOT).getSkater().setRole(FloorPosition.PIVOT.getRole(this));
         }
         if (prop == Value.NO_PIVOT && (Boolean)value) {

--- a/src/com/carolinarollergirls/scoreboard/event/ScoreBoardEventProviderImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/event/ScoreBoardEventProviderImpl.java
@@ -302,12 +302,12 @@ public abstract class ScoreBoardEventProviderImpl implements ScoreBoardEventProv
             }
             if (!isWritable(prop, flag)) { return false; }
             Object last = get(prop);
+            value = _computeValue(prop, value, last, flag);
             if (reverseCopyListeners.containsKey(prop) && flag != Flag.COPY) {
                 reverseCopyListeners.get(prop).scoreBoardChange(new ScoreBoardEvent(
                         this, prop, value, last), flag);
                 return false;
             }
-            value = _computeValue(prop, value, last, flag);
             if (Objects.equals(value, last)) { return false; }
             values.put(prop, value);
             _valueChanged(prop, value, last, flag);

--- a/tests/com/carolinarollergirls/scoreboard/core/impl/ClockImplTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/core/impl/ClockImplTests.java
@@ -62,9 +62,7 @@ public class ClockImplTests {
 
     @Test
     public void testDefaults() {
-        assertEquals(ClockImpl.DEFAULT_MINIMUM_NUMBER, clock.getMinimumNumber());
-        assertEquals(ClockImpl.DEFAULT_MAXIMUM_NUMBER, clock.getMaximumNumber());
-        assertEquals(ClockImpl.DEFAULT_MINIMUM_NUMBER, clock.getNumber());
+        assertEquals(0, clock.getNumber());
 
         assertEquals(ClockImpl.DEFAULT_MINIMUM_TIME, clock.getMinimumTime());
         assertEquals(ClockImpl.DEFAULT_MAXIMUM_TIME, clock.getMaximumTime());
@@ -85,8 +83,6 @@ public class ClockImplTests {
 
     @Test
     public void testReset() {
-        clock.setMaximumNumber(5);
-        clock.setMinimumNumber(2);
         clock.setNumber(4);
         clock.setMaximumTime(1200000);
         clock.setTime(5000);
@@ -95,17 +91,14 @@ public class ClockImplTests {
         clock.reset();
 
         assertFalse(clock.isCountDirectionDown());
-        assertEquals(ClockImpl.DEFAULT_MINIMUM_NUMBER, clock.getMinimumNumber());
-        assertEquals(ClockImpl.DEFAULT_MAXIMUM_NUMBER, clock.getMaximumNumber());
         assertEquals(ClockImpl.DEFAULT_MINIMUM_TIME, clock.getMinimumTime());
         assertEquals(ClockImpl.DEFAULT_MAXIMUM_TIME, clock.getMaximumTime());
-        assertEquals(clock.getMinimumNumber(), clock.getNumber());
+        assertEquals(0, clock.getNumber());
         assertTrue(clock.isTimeAtStart());
     }
 
     @Test
     public void testRestoreSnapshot() {
-        clock.setMaximumNumber(5);
         clock.setNumber(4);
         clock.setMaximumTime(1200000);
         clock.setTime(5000);
@@ -114,14 +107,14 @@ public class ClockImplTests {
 
         clock.reset();
         assertFalse(clock.isRunning());
-        assertEquals(ClockImpl.DEFAULT_MINIMUM_NUMBER, clock.getNumber());
+        assertEquals(0, clock.getNumber());
         assertEquals(ClockImpl.DEFAULT_MINIMUM_TIME, clock.getTime());
 
         //if IDs don't match no restore should be done
         snapshot.id = "OTHER";
         clock.restoreSnapshot(snapshot);
         assertFalse(clock.isRunning());
-        assertEquals(ClockImpl.DEFAULT_MINIMUM_NUMBER, clock.getNumber());
+        assertEquals(0, clock.getNumber());
         assertEquals(ClockImpl.DEFAULT_MINIMUM_TIME, clock.getTime());
 
         snapshot.id = ID;
@@ -206,128 +199,9 @@ public class ClockImplTests {
     }
 
     @Test
-    public void testSetMinimumNumber() {
-        clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.Value.MINIMUM_NUMBER, listener));
-
-        clock.setMinimumNumber(1000);
-
-        // validate constraint: max >= number >= min
-        assertEquals(1000, clock.getMinimumNumber());
-        assertEquals(1000, clock.getMaximumNumber());
-        assertEquals(1000, clock.getNumber());
-
-        assertEquals(1, collectedEvents.size());
-        ScoreBoardEvent event = collectedEvents.poll();
-        assertEquals(1000, event.getValue());
-        assertEquals(ClockImpl.DEFAULT_MINIMUM_NUMBER, event.getPreviousValue());
-    }
-
-    @Test
-    public void testSetMinimumNumber2() {
-        clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.Value.MINIMUM_NUMBER, listener));
-        clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.Value.MAXIMUM_NUMBER, listener));
-        clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.Value.NUMBER, listener));
-
-
-        clock.setMaximumNumber(10);
-        clock.setMinimumNumber(10);
-        collectedEvents.clear();
-
-        clock.setMinimumNumber(5);
-
-        // validate constraint: number is automatically set to max
-        assertEquals(5, clock.getMinimumNumber());
-        assertEquals(10, clock.getMaximumNumber());
-        assertEquals(10, clock.getNumber());
-
-        assertEquals(1, collectedEvents.size());
-    }
-
-    @Test
-    public void testSetMaximumNumber() {
-        clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.Value.MAXIMUM_NUMBER, listener));
-
-        clock.setMaximumNumber(ClockImpl.DEFAULT_MINIMUM_NUMBER);
-        advance(0);
-        collectedEvents.clear();
-
-        clock.setMaximumNumber(5);
-
-        assertEquals(ClockImpl.DEFAULT_MINIMUM_NUMBER, clock.getMinimumNumber());
-        assertEquals(5, clock.getMaximumNumber());
-        assertEquals(ClockImpl.DEFAULT_MINIMUM_NUMBER, clock.getNumber());
-
-        assertEquals(1, collectedEvents.size());
-        ScoreBoardEvent event = collectedEvents.poll();
-        assertEquals(5, event.getValue());
-        assertEquals(ClockImpl.DEFAULT_MINIMUM_NUMBER, event.getPreviousValue());
-    }
-
-    @Test
-    public void testSetMaximumNumber2() {
-        clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.Value.MINIMUM_NUMBER, listener));
-        clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.Value.MAXIMUM_NUMBER, listener));
-        clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.Value.NUMBER, listener));
-
-
-        clock.setMinimumNumber(10);
-        collectedEvents.clear();
-
-        clock.setMaximumNumber(5);
-
-        // validate constraint: cannot set a max that is < min
-        assertEquals(10, clock.getMinimumNumber());
-        assertEquals(10, clock.getMaximumNumber());
-        assertEquals(10, clock.getNumber());
-
-        assertEquals(1, collectedEvents.size());
-    }
-
-    @Test
-    public void testChangeMaximumNumber() {
-        clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.Value.MAXIMUM_NUMBER, listener));
-
-        clock.setMaximumNumber(5);
-        collectedEvents.clear();
-
-        clock.changeMaximumNumber(2);
-
-        assertEquals(ClockImpl.DEFAULT_MINIMUM_NUMBER, clock.getMinimumNumber());
-        assertEquals(7, clock.getMaximumNumber());
-        assertEquals(ClockImpl.DEFAULT_MINIMUM_NUMBER, clock.getNumber());
-
-        assertEquals(1, collectedEvents.size());
-        ScoreBoardEvent event = collectedEvents.poll();
-        assertEquals(7, event.getValue());
-        assertEquals(5, event.getPreviousValue());
-    }
-
-    @Test
-    public void testChangeMinimumNumber() {
-        clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.Value.MINIMUM_NUMBER, listener));
-
-        clock.setMaximumNumber(5);
-        clock.setMinimumNumber(5);
-        collectedEvents.clear();
-
-        clock.changeMinimumNumber(2);
-
-        assertEquals(7, clock.getMinimumNumber());
-        assertEquals(7, clock.getMaximumNumber());
-        assertEquals(7, clock.getNumber());
-
-        assertEquals(1, collectedEvents.size());
-        ScoreBoardEvent event = collectedEvents.poll();
-        assertEquals(7, event.getValue());
-        assertEquals(5, event.getPreviousValue());
-    }
-
-    @Test
     public void testChangeNumber() {
         clock.addScoreBoardListener(new ConditionalScoreBoardListener(clock, Clock.Value.NUMBER, listener));
 
-        clock.setMaximumNumber(12);
-        clock.setMinimumNumber(3);
         collectedEvents.clear();
 
         clock.setNumber(5);
@@ -335,53 +209,31 @@ public class ClockImplTests {
         assertEquals(1, collectedEvents.size());
         ScoreBoardEvent event = collectedEvents.poll();
         assertEquals(5, event.getValue());
-        assertEquals(3, event.getPreviousValue());
+        assertEquals(0, event.getPreviousValue());
 
         clock.changeNumber(3);
         assertEquals(8, clock.getNumber());
         assertEquals(1, collectedEvents.size());
         collectedEvents.clear();
 
-        // validate constraint: cannot set number above maximum
-        clock.setNumber(23);
-        assertEquals(12, clock.getNumber());
-        assertEquals(1, collectedEvents.size());
-        collectedEvents.clear();
-
-        // validate constraint: cannot set number below minimum
+        // validate constraint: cannot set negative number
         clock.setNumber(-2);
-        assertEquals(3, clock.getNumber());
+        assertEquals(0, clock.getNumber());
         assertEquals(1, collectedEvents.size());
         collectedEvents.clear();
 
-        // ...and check that constraint is not a >0 type constraint
-        clock.setNumber(1);
+        clock.setNumber(3);
         assertEquals(3, clock.getNumber());
-        assertEquals(0, collectedEvents.size());
         collectedEvents.clear();
-
         clock.changeNumber(6);
         assertEquals(9, clock.getNumber());
         assertEquals(1, collectedEvents.size());
         collectedEvents.clear();
 
-        // validate constraint: cannot changeNumber above maximum
-        clock.changeNumber(6);
-        assertEquals(12, clock.getNumber());
-        assertEquals(1, collectedEvents.size());
-        collectedEvents.clear();
-
-
         clock.setNumber(5);
         clock.changeNumber(-1);
         assertEquals(4, clock.getNumber());
         assertEquals(2, collectedEvents.size());
-        collectedEvents.clear();
-
-        // validate constraint: cannot changeNumber below minimum
-        clock.changeNumber(-4);
-        assertEquals(3, clock.getNumber());
-        assertEquals(1, collectedEvents.size());
     }
 
     @Test
@@ -752,7 +604,6 @@ public class ClockImplTests {
 
     @Test
     public void testRestart() {
-        clock.setMaximumNumber(5);
         clock.setNumber(2);
         clock.setMaximumTime(60000);
         clock.setTime(45000);

--- a/tests/com/carolinarollergirls/scoreboard/core/impl/ScoreboardImplTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/core/impl/ScoreboardImplTests.java
@@ -251,7 +251,7 @@ public class ScoreboardImplTests {
         fastForwardPeriod();
         assertFalse(pc.isRunning());
         assertTrue(pc.isTimeAtEnd());
-        assertEquals(pc.getMaximumNumber(), pc.getNumber());
+        assertEquals(sb.getRulesets().getInt(Rule.NUMBER_PERIODS), pc.getNumber());
         assertFalse(jc.isRunning());
         jc.setTime(0);
         assertTrue(jc.isTimeAtEnd());
@@ -280,7 +280,7 @@ public class ScoreboardImplTests {
         sb.timeout();
         assertFalse(pc.isRunning());
         assertTrue(pc.isTimeAtEnd());
-        assertEquals(pc.getMaximumNumber(), pc.getNumber());
+        assertEquals(sb.getRulesets().getInt(Rule.NUMBER_PERIODS), pc.getNumber());
         assertFalse(jc.isRunning());
         jc.setTime(0);
         assertTrue(jc.isTimeAtEnd());
@@ -304,7 +304,7 @@ public class ScoreboardImplTests {
 
     @Test
     public void testStartOvertime_notLastPeriod() {
-        assertNotEquals(pc.getNumber(), pc.getMaximumNumber());
+        assertNotEquals(pc.getNumber(), sb.getRulesets().getInt(Rule.NUMBER_PERIODS));
 
         sb.startOvertime();
 
@@ -317,7 +317,7 @@ public class ScoreboardImplTests {
         fastForwardPeriod();
         ic.setTime(0);
         sb.startJam();
-        assertEquals(pc.getMaximumNumber(), pc.getNumber());
+        assertEquals(sb.getRulesets().getInt(Rule.NUMBER_PERIODS), pc.getNumber());
         assertTrue(pc.isRunning());
         ScoreBoardSnapshot saved = sb.snapshot;
 
@@ -333,7 +333,7 @@ public class ScoreboardImplTests {
         ic.setTime(0);
         sb.startJam();
         pc.setTime(0);
-        assertEquals(pc.getMaximumNumber(), pc.getNumber());
+        assertEquals(sb.getRulesets().getInt(Rule.NUMBER_PERIODS), pc.getNumber());
         assertFalse(pc.isRunning());
         assertTrue(jc.isRunning());
         ScoreBoardSnapshot saved = sb.snapshot;
@@ -1292,7 +1292,7 @@ public class ScoreboardImplTests {
         assertFalse(pc.isRunning());
         assertTrue(pc.isCountDirectionDown());
         assertTrue(pc.isTimeAtEnd());
-        assertEquals(pc.getMaximumNumber(), pc.getNumber());
+        assertEquals(sb.getRulesets().getInt(Rule.NUMBER_PERIODS), pc.getNumber());
         assertFalse(jc.isRunning());
         assertEquals(21, jc.getNumber());
         jc.setTime(56000);
@@ -1300,14 +1300,14 @@ public class ScoreboardImplTests {
         assertFalse(tc.isRunning());
         assertTrue(ic.isRunning());
         assertTrue(ic.isCountDirectionDown());
-        assertEquals(pc.getMaximumNumber(), ic.getNumber());
+        assertEquals(sb.getRulesets().getInt(Rule.NUMBER_PERIODS), ic.getNumber());
         ic.setTime(3000);
 
         advance(3000);
 
         assertFalse(pc.isRunning());
         assertTrue(pc.isTimeAtEnd());
-        assertEquals(pc.getMaximumNumber(), pc.getNumber());
+        assertEquals(sb.getRulesets().getInt(Rule.NUMBER_PERIODS), pc.getNumber());
         assertFalse(jc.isRunning());
         assertEquals(21, jc.getNumber());
         assertEquals(56000, jc.getTime());
@@ -1315,7 +1315,7 @@ public class ScoreboardImplTests {
         assertFalse(tc.isRunning());
         assertFalse(ic.isRunning());
         assertTrue(ic.isTimeAtEnd());
-        assertEquals(pc.getMaximumNumber(), ic.getNumber());
+        assertEquals(sb.getRulesets().getInt(Rule.NUMBER_PERIODS), ic.getNumber());
         checkLabels(prevStartLabel, prevStopLabel, prevTimeoutLabel, prevUndoLabel);
     }
 

--- a/tests/com/carolinarollergirls/scoreboard/core/impl/TeamImplTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/core/impl/TeamImplTests.java
@@ -408,7 +408,7 @@ public class TeamImplTests {
         team.field(skater4, Role.BLOCKER);
         team.field(skater5, Role.BLOCKER);
 
-        assertFalse(team.hasNoPivot());
+        assertFalse(team.hasNoNamedPivot());
         assertEquals(skater1, team.getPosition(FloorPosition.JAMMER).getSkater());
         assertEquals(team.getPosition(FloorPosition.JAMMER), skater1.getPosition());
         assertEquals(Role.JAMMER, skater1.getRole());
@@ -443,14 +443,14 @@ public class TeamImplTests {
 
         team.field(skater2, Role.BLOCKER);
 
-        assertTrue(team.hasNoPivot());
+        assertTrue(team.hasNoNamedPivot());
         assertEquals(skater2, team.getPosition(FloorPosition.PIVOT).getSkater());
         assertEquals(team.getPosition(FloorPosition.PIVOT), skater2.getPosition());
         assertEquals(Role.BLOCKER, skater2.getRole());
 
         team.field(skater4, Role.PIVOT);
 
-        assertFalse(team.hasNoPivot());
+        assertFalse(team.hasNoNamedPivot());
         assertEquals(skater4, team.getPosition(FloorPosition.PIVOT).getSkater());
         assertEquals(team.getPosition(FloorPosition.PIVOT), skater4.getPosition());
         assertEquals(Role.PIVOT, skater4.getRole());
@@ -460,7 +460,7 @@ public class TeamImplTests {
 
         team.field(skater5, Role.PIVOT);
 
-        assertFalse(team.hasNoPivot());
+        assertFalse(team.hasNoNamedPivot());
         assertEquals(skater5, team.getPosition(FloorPosition.PIVOT).getSkater());
         assertEquals(team.getPosition(FloorPosition.PIVOT), skater5.getPosition());
         assertEquals(Role.PIVOT, skater5.getRole());
@@ -477,7 +477,7 @@ public class TeamImplTests {
         
         team.setStarPass(true);
 
-        assertFalse(team.hasNoPivot());
+        assertFalse(team.hasNoNamedPivot());
         assertEquals(skater6, team.getPosition(FloorPosition.JAMMER).getSkater());
         assertEquals(team.getPosition(FloorPosition.JAMMER), skater6.getPosition());
         assertEquals(Role.BLOCKER, skater6.getRole());

--- a/tests/com/carolinarollergirls/scoreboard/core/impl/TeamImplTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/core/impl/TeamImplTests.java
@@ -73,6 +73,10 @@ public class TeamImplTests {
         team.setStarPass(true);
 
         sb.stopJamTO();
+        
+        assertTrue(team.isStarPass());
+        assertTrue(team.isFieldingStarPass());
+        
         team.execute(Team.Command.ADVANCE_FIELDINGS);
 
         assertTrue(team.isStarPass());
@@ -573,5 +577,25 @@ public class TeamImplTests {
         assertNull(team.getPosition(FloorPosition.BLOCKER1).getSkater());
         assertNull(team.getPosition(FloorPosition.BLOCKER2).getSkater());
         assertEquals(skater4, team.getPosition(FloorPosition.BLOCKER3).getSkater());
+    }
+
+    @Test
+    public void testFieldPivot() {
+        Skater skater1 = team.addSkater("S1", "One", "1", "");
+        
+        sb.startJam();
+        sb.stopJamTO();
+        
+        team.getPosition(FloorPosition.PIVOT).setSkater(skater1);
+        
+        assertEquals(skater1, team.getPosition(FloorPosition.PIVOT).getSkater());
+        assertFalse(team.getRunningOrUpcomingTeamJam().hasNoNamedPivot());
+        assertTrue(team.getRunningOrEndedTeamJam().hasNoNamedPivot());
+        assertEquals(Role.BENCH, skater1.getRole());
+        assertEquals(1, skater1.getAll(Skater.Child.FIELDING).size());
+        
+        team.execute(Team.Command.ADVANCE_FIELDINGS);
+        
+        assertEquals(Role.PIVOT, skater1.getRole());
     }
 }


### PR DESCRIPTION
* When skaters are marked as "Not Skating" or bench staff, don't show them in selection dropdowns or the PT/LT/PLT input
* When the operator enters a pivot, mark them as pivot (supersedes #266)
* Only mark "No Pivot", if the position is explicitly marked as "No Skater fielded" or 4 Blockers have been entered. Add "No Pivot" Marker to Operator screen.
* Don't allow a star pass if there is no pivot.
* Fix the bug where having multiple operator screens would add additional 0 point scoring trips.
* Remove minimum and maximum number, they are no longer used