### PR TITLE
Add "No more jams" indication

### DIFF
--- a/html/controls/operator.css
+++ b/html/controls/operator.css
@@ -75,6 +75,7 @@ table.RowTable { border-spacing: 0px; }
 
 	#TeamTime table.Time>tbody>tr>td { width: 20%; }
 	#TeamTime table.Time tr.Name td.Name.Running { background: #3f3; }
+	#TeamTime table.Time tr.Name td.Name.Running.NoMoreJam { background: #f33; }
 	#TeamTime table.Time tr.Name td.Name a { font-size: 150%; }
 	#TeamTime table.Time tr.Name td.Name a.InvertedTime { padding-left: 5px; font-size: 75%; }
 	#TeamTime table.Time tr.Name td.Name a.InvertedTime:before { content: "("; }

--- a/html/controls/operator.js
+++ b/html/controls/operator.js
@@ -942,21 +942,18 @@ function createPeriodDialog() {
 	var table = $("<table>").appendTo(dialog);
 	var headers = $("<tr><td/><td/><td/><td/><td/></tr>").appendTo(table);
 	$("<a>").text("Nr").addClass("Title")
-		.appendTo(headers.find("td:eq(0)").addClass("Title"));
+		.appendTo(headers.children("td:eq(0)").addClass("Title"));
 	$("<a>").text("Jams").addClass("Title")
-		.appendTo(headers.find("td:eq(1)").addClass("Title"));
+		.appendTo(headers.children("td:eq(1)").addClass("Title"));
 	$("<a>").text("Duration").addClass("Title")
-		.appendTo(headers.find("td:eq(2)").addClass("Title"));
+		.appendTo(headers.children("td:eq(2)").addClass("Title"));
 
-	var periodRegex = /Period\(([^\)]+)\)\.([^\.]+)/;
 	WS.Register(['ScoreBoard.Period'], function (k, v) {
-		var match = (k || "").match(periodRegex);
-		if (match == null || match.length == 0) { return; }
-		var nr = match[1];
-		if (nr == 0) { return; }
+		var nr = k.Period;
+		if (nr == null || nr == 0) { return; }
 		var prefix = "ScoreBoard.Period(" + nr + ")";
-		var key = match[2];
-		if (k != prefix + "." + key) { return; }
+		var key = k.field;
+		if (k.parts.length > 3) { return; }
 		if (!(["CurrentJamNumber", "Duration", "Number", "Running"].includes(key))) { return; }
 
 		var row = table.find("tr.Period[nr="+nr+"]");
@@ -990,10 +987,10 @@ function createPeriodDialog() {
 			return;
 		}
 		if (v != null) {
-			if (key == "CurrentJamNumber") { row.find("td.Jams").text(v); }
-			if (key == "Duration" && !isTrue(WS.state[prefix + '.Running'])) { row.find("td.Duration").text(_timeConversions.msToMinSec(v)); }
-			if (key == "Running" && isTrue(v)) { row.find("td.Duration").text("running"); }
-			if (key == "Running" && !isTrue(v)) { row.find("td.Duration").text(_timeConversions.msToMinSec(WS.state[prefix + '.Duration'])); }
+			if (key == "CurrentJamNumber") { row.children("td.Jams").text(v); }
+			if (key == "Duration" && !isTrue(WS.state[prefix + '.Running'])) { row.children("td.Duration").text(_timeConversions.msToMinSec(v)); }
+			if (key == "Running" && isTrue(v)) { row.children("td.Duration").text("running"); }
+			if (key == "Running" && !isTrue(v)) { row.children("td.Duration").text(_timeConversions.msToMinSec(WS.state[prefix + '.Duration'])); }
 		}
 	});
 
@@ -1011,27 +1008,24 @@ function createJamDialog() {
 	var tableTemplate = $("<table>").addClass("Period");
 	var headers = $("<tr><td/><td/><td/><td/><td/><td/></tr>").appendTo(tableTemplate);
 	$("<a>").text("Nr").addClass("Title")
-		.appendTo(headers.find("td:eq(0)").addClass("Title"));
+		.appendTo(headers.children("td:eq(0)").addClass("Title"));
 	$("<a>").text("Points").addClass("Title")
-		.appendTo(headers.find("td:eq(1)").addClass("Title"));
+		.appendTo(headers.children("td:eq(1)").addClass("Title"));
 	$("<a>").text("Duration").addClass("Title")
-		.appendTo(headers.find("td:eq(2)").addClass("Title"));
+		.appendTo(headers.children("td:eq(2)").addClass("Title"));
 	$("<a>").text("PC at end").addClass("Title")
-	.appendTo(headers.find("td:eq(3)").addClass("Title"));
+		.appendTo(headers.children("td:eq(3)").addClass("Title"));
 	var currentPeriod;
 
-	var jamRegex = /Period\(([^\)]+)\)\.Jam\(([^\)]+)\)\.(?:TeamJam\(([^\)]+)\)\.)?([^\.\(]+)/;
 	WS.Register(['ScoreBoard.Period'], function (k, v) {
-		var match = (k || "").match(jamRegex);
-		if (match == null || match.length == 0) { return; }
-		var per = match[1];
+		var per = k.Period;
 		if (per == 0) { return; }
-		var nr = match[2];
+		var nr = k.Jam;
 		var prefix = "ScoreBoard.Period(" + per + ").Jam(" + nr + ")";
-		var tj = match[3];
+		var tj = k.TeamJam;
 		var tjPrefix = prefix + ".TeamJam(" + tj + ")";
-		var key = match[4];
-		if (!((k == prefix + "." + key && ["Duration", "Number"].includes(key))
+		var key = k.field;
+		if (!((k == prefix + "." + key && ["Duration", "Number", "PeriodClockElapsedEnd"].includes(key))
 				|| k == tjPrefix + ".JamScore")) { return; }
 		
 		var table = dialog.find("table.Period[nr="+per+"]");
@@ -1076,19 +1070,19 @@ function createJamDialog() {
 			return;
 		}
 		if (v != null) {
-			if (key == "JamScore") { row.find("td.Points ."+tj).text(v); }
+			if (key == "JamScore") { row.children("td.Points ."+tj).text(v); }
 			if (key == "Duration") {
 				if (WS.state[prefix + '.WalltimeEnd'] == 0 && WS.state[prefix + '.WalltimeStart'] > 0) {
-					row.find("td.Duration").text("running");
+					row.children("td.Duration").text("running");
 				} else {
-					row.find("td.Duration").text(_timeConversions.msToMinSec(v));
+					row.children("td.Duration").text(_timeConversions.msToMinSec(v));
 				}
 			}
 			if (key == 'PeriodClockElapsedEnd') {
 				if (WS.state[prefix + '.WalltimeEnd'] == 0 && WS.state[prefix + '.WalltimeStart'] > 0) {
-					row.find("td.PC").text("running");
+					row.children("td.PC").text("running");
 				} else {
-					row.find("td.PC").text(_timeConversions.msToMinSec(v));
+					row.children("td.PC").text(_timeConversions.msToMinSec(v));
 				}
 			}
 		}
@@ -1104,7 +1098,7 @@ function createJamDialog() {
 		title: "Jams",
 		autoOpen: false,
 		modal: true,
-		width: 500,
+		width: 550,
 		buttons: { Close: function() { $(this).dialog("close"); } }
 	});
 }
@@ -1132,17 +1126,17 @@ function createTimeoutDialog() {
 	var table = $("<table>").appendTo(dialog);
 	var headers = $("<tr><td/><td/><td/><td/><td/><td/><td/></tr>").appendTo(table);
 	$("<a>").text("Period").addClass("Title")
-		.appendTo(headers.find("td:eq(0)").addClass("Title"));
+		.appendTo(headers.children("td:eq(0)").addClass("Title"));
 	$("<a>").text("After Jam").addClass("Title")
-		.appendTo(headers.find("td:eq(1)").addClass("Title"));
+		.appendTo(headers.children("td:eq(1)").addClass("Title"));
 	$("<a>").text("Duration").addClass("Title")
-		.appendTo(headers.find("td:eq(2)").addClass("Title"));
+		.appendTo(headers.children("td:eq(2)").addClass("Title"));
 	$("<a>").text("Period Clock").addClass("Title")
-	.appendTo(headers.find("td:eq(3)").addClass("Title"));
+	.appendTo(headers.children("td:eq(3)").addClass("Title"));
 	$("<a>").text("Type").addClass("Title")
-		.appendTo(headers.find("td:eq(4)").addClass("Title"));
+		.appendTo(headers.children("td:eq(4)").addClass("Title"));
 	$("<a>").text("Retained").addClass("Title")
-	.appendTo(headers.find("td:eq(5)").addClass("Title"));
+		.appendTo(headers.children("td:eq(5)").addClass("Title"));
 	
 	var footer = $("<tr><td/><td colspan=\"3\"/><td/><td/><td/></tr>").attr('id', 'toFooter').appendTo(table);
 	periodDropdownTemplate.clone().appendTo(footer.find('td:eq(0)'));
@@ -1170,7 +1164,7 @@ function createTimeoutDialog() {
 			lastPeriodListed = i;
 		}
 		for (i = lastPeriodListed; i > p; i--) {
-			periodDropdownTemplate.find('option[value='+i+']').remove();
+			periodDropdownTemplate.children('option[value='+i+']').remove();
 			table.find('#PeriodDropdown option[value='+i+']').remove();
 			clearPeriod(i);
 			lastPeriodListed = i-1;
@@ -1189,12 +1183,12 @@ function createTimeoutDialog() {
 		}
 	}
 	function removeJam(p, j) {
-		jamDropdownTemplate[p].find('option[value='+i+']').remove();
+		jamDropdownTemplate[p].children('option[value='+i+']').remove();
 		table.find('#JamDropdown[period='+p+'] option[value='+i+']').remove();
 	}
 	function clearPeriod(p) {
 		table.find('tr.Timeout[period='+p+']').remove();
-		jamDropdownTemplate[p].find('option').remove();
+		jamDropdownTemplate[p].children('option').remove();
 		table.find('#JamDropdown[period='+p+'] option').remove();
 		firstJamListed[p] = 0;
 		lastJamListed[p] = 0;

--- a/html/controls/operator.js
+++ b/html/controls/operator.js
@@ -1179,6 +1179,7 @@ function createTimeoutDialog() {
 	});
 	
 	function addJam(p, j, append) {
+		console.log('add P'+p+'J'+j);
 		var option = $('<option>').attr('value', j).text('J'+j);
 		if (append) {
 			jamDropdownTemplate[p].append(option.clone());
@@ -1189,10 +1190,12 @@ function createTimeoutDialog() {
 		}
 	}
 	function removeJam(p, j) {
+		console.log('remove P'+p+'J'+j);
 		jamDropdownTemplate[p].find('option[value='+i+']').remove();
 		table.find('#JamDropdown[period='+p+'] option[value='+i+']').remove();
 	}
 	function clearPeriod(p) {
+		console.log('clear P'+p);
 		table.find('tr.Timeout[period='+p+']').remove();
 		jamDropdownTemplate[p].find('option').remove();
 		table.find('#JamDropdown[period='+p+'] option').remove();

--- a/html/controls/operator.js
+++ b/html/controls/operator.js
@@ -896,6 +896,9 @@ function createTimeTable() {
 		sbClock.$sb("Running").$sbBindAndRun("sbchange", function(event,value) {
 			nameTd.toggleClass("Running", isTrue(value));
 		});
+		$sb("ScoreBoard.NoMoreJam").$sbBindAndRun("sbchange", function(event,value) {
+			nameTd.toggleClass("NoMoreJam", isTrue(value));
+		});
 
 		sbClock.$sb("Number").$sbControl("<a>").appendTo(numberTr.children("td:eq(1)")
 				.addClass("Number").css("width", "20%"));
@@ -1006,13 +1009,15 @@ function createPeriodDialog() {
 function createJamDialog() {
 	var dialog = $("<div>").addClass("NumberDialog");
 	var tableTemplate = $("<table>").addClass("Period");
-	var headers = $("<tr><td/><td/><td/><td/><td/></tr>").appendTo(tableTemplate);
+	var headers = $("<tr><td/><td/><td/><td/><td/><td/></tr>").appendTo(tableTemplate);
 	$("<a>").text("Nr").addClass("Title")
 		.appendTo(headers.find("td:eq(0)").addClass("Title"));
 	$("<a>").text("Points").addClass("Title")
 		.appendTo(headers.find("td:eq(1)").addClass("Title"));
 	$("<a>").text("Duration").addClass("Title")
 		.appendTo(headers.find("td:eq(2)").addClass("Title"));
+	$("<a>").text("PC at end").addClass("Title")
+	.appendTo(headers.find("td:eq(3)").addClass("Title"));
 	var currentPeriod;
 
 	var jamRegex = /Period\(([^\)]+)\)\.Jam\(([^\)]+)\)\.(?:TeamJam\(([^\)]+)\)\.)?([^\.\(]+)/;
@@ -1045,6 +1050,7 @@ function createJamDialog() {
 				.append($('<td>').addClass('Points').append($('<span>').addClass('1'))
 						.append($('<span>').text(" - ")).append($('<span>').addClass('2')))
 				.append($('<td>').addClass('Duration'))
+				.append($('<td>').addClass('PC'))
 				.append($('<td>').append($("<button>").text("Delete")
 						.button().click(function () {
 							//TODO: confirmation popup
@@ -1076,6 +1082,13 @@ function createJamDialog() {
 					row.find("td.Duration").text("running");
 				} else {
 					row.find("td.Duration").text(_timeConversions.msToMinSec(v));
+				}
+			}
+			if (key == 'PeriodClockElapsedEnd') {
+				if (WS.state[prefix + '.WalltimeEnd'] == 0 && WS.state[prefix + '.WalltimeStart'] > 0) {
+					row.find("td.PC").text("running");
+				} else {
+					row.find("td.PC").text(_timeConversions.msToMinSec(v));
 				}
 			}
 		}

--- a/html/controls/operator.js
+++ b/html/controls/operator.js
@@ -1025,7 +1025,7 @@ function createJamDialog() {
 		var tj = k.TeamJam;
 		var tjPrefix = prefix + ".TeamJam(" + tj + ")";
 		var key = k.field;
-		if (!((k == prefix + "." + key && ["Duration", "Number", "PeriodClockElapsedEnd"].includes(key))
+		if (!((k == prefix + "." + key && ["Duration", "Number", "PeriodClockDisplayEnd"].includes(key))
 				|| k == tjPrefix + ".JamScore")) { return; }
 		
 		var table = dialog.find("table.Period[nr="+per+"]");
@@ -1078,7 +1078,7 @@ function createJamDialog() {
 					row.children("td.Duration").text(_timeConversions.msToMinSec(v));
 				}
 			}
-			if (key == 'PeriodClockElapsedEnd') {
+			if (key == 'PeriodClockDisplayEnd') {
 				if (WS.state[prefix + '.WalltimeEnd'] == 0 && WS.state[prefix + '.WalltimeStart'] > 0) {
 					row.children("td.PC").text("running");
 				} else {

--- a/html/controls/operator.js
+++ b/html/controls/operator.js
@@ -1179,7 +1179,6 @@ function createTimeoutDialog() {
 	});
 	
 	function addJam(p, j, append) {
-		console.log('add P'+p+'J'+j);
 		var option = $('<option>').attr('value', j).text('J'+j);
 		if (append) {
 			jamDropdownTemplate[p].append(option.clone());
@@ -1190,12 +1189,10 @@ function createTimeoutDialog() {
 		}
 	}
 	function removeJam(p, j) {
-		console.log('remove P'+p+'J'+j);
 		jamDropdownTemplate[p].find('option[value='+i+']').remove();
 		table.find('#JamDropdown[period='+p+'] option[value='+i+']').remove();
 	}
 	function clearPeriod(p) {
-		console.log('clear P'+p);
 		table.find('tr.Timeout[period='+p+']').remove();
 		jamDropdownTemplate[p].find('option').remove();
 		table.find('#JamDropdown[period='+p+'] option').remove();

--- a/html/views/standard/index.js
+++ b/html/views/standard/index.js
@@ -92,7 +92,10 @@ function initialize() {
 		})
 	});
 
-
+	WS.Register(['ScoreBoard.NoMoreJam'], function(k, v) {
+		$('.Clock.Lineup').toggleClass('Red', isTrue(v));
+		$('.Clock.Timeout').toggleClass('Red', isTrue(v));
+	});
 
 	(function() {
 		var switchTimeMs = 5000;

--- a/src/com/carolinarollergirls/scoreboard/core/Jam.java
+++ b/src/com/carolinarollergirls/scoreboard/core/Jam.java
@@ -27,6 +27,7 @@ public interface Jam extends NumberedScoreBoardEventProvider<Jam> {
         DURATION(Long.class, 0L),
         PERIOD_CLOCK_ELAPSED_START(Long.class, 0L),
         PERIOD_CLOCK_ELAPSED_END(Long.class, 0L),
+        PERIOD_CLOCK_DISPLAY_END(Long.class, 0L),
         WALLTIME_START(Long.class, 0L),
         WALLTIME_END(Long.class, 0L);
 

--- a/src/com/carolinarollergirls/scoreboard/core/ScoreBoard.java
+++ b/src/com/carolinarollergirls/scoreboard/core/ScoreBoard.java
@@ -118,7 +118,8 @@ public interface ScoreBoard extends ScoreBoardEventProvider {
         OFFICIAL_SCORE(Boolean.class, false),
         CURRENT_TIMEOUT(Timeout.class, null),
         TIMEOUT_OWNER(TimeoutOwner.class, null),
-        OFFICIAL_REVIEW(Boolean.class, false);
+        OFFICIAL_REVIEW(Boolean.class, false),
+        NO_MORE_JAM(Boolean.class, false);
 
         private Value(Class<?> t, Object dv) { type = t; defaultValue = dv; }
         private final Class<?> type;

--- a/src/com/carolinarollergirls/scoreboard/core/impl/JamImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/impl/JamImpl.java
@@ -135,6 +135,7 @@ public class JamImpl extends NumberedScoreBoardEventProviderImpl<Jam> implements
             requestBatchStart();
             set(Value.DURATION, scoreBoard.getClock(Clock.ID_JAM).getTimeElapsed());
             set(Value.PERIOD_CLOCK_ELAPSED_END, scoreBoard.getClock(Clock.ID_PERIOD).getTimeElapsed());
+            set(Value.PERIOD_CLOCK_DISPLAY_END, scoreBoard.getClock(Clock.ID_PERIOD).getTime());
             set(Value.WALLTIME_END, ScoreBoardClock.getInstance().getCurrentWalltime());
             requestBatchEnd();
         }

--- a/src/com/carolinarollergirls/scoreboard/core/impl/ScoreBoardImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/impl/ScoreBoardImpl.java
@@ -90,7 +90,7 @@ public class ScoreBoardImpl extends ScoreBoardEventProviderImpl implements Score
             if (!getRulesets().getBoolean(Rule.PERIOD_END_BETWEEN_JAMS)) { return false; }
             Jam lastJam = getCurrentPeriod().getCurrentJam();
             long pcRemaining = getClock(Clock.ID_PERIOD).getMaximumTime() - lastJam.getPeriodClockElapsedEnd();
-            if (pcRemaining > getRulesets().getLong(Rule.LINEUP_DURATION)) { return false; }
+            if (pcRemaining >= getRulesets().getLong(Rule.LINEUP_DURATION)) { return false; }
             boolean ttoForcesJam = getRulesets().getBoolean(Rule.STOP_PC_ON_TO) || getRulesets().getBoolean(Rule.STOP_PC_ON_TTO);
             boolean orForcesJam = getRulesets().getBoolean(Rule.STOP_PC_ON_TO) || getRulesets().getBoolean(Rule.STOP_PC_ON_OR);
             boolean otoForcesJam = getRulesets().getBoolean(Rule.EXTRA_JAM_AFTER_OTO) &&

--- a/src/com/carolinarollergirls/scoreboard/core/impl/ScoreBoardImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/impl/ScoreBoardImpl.java
@@ -70,6 +70,9 @@ public class ScoreBoardImpl extends ScoreBoardEventProviderImpl implements Score
         getClock(Clock.ID_TIMEOUT);
         getClock(Clock.ID_INTERMISSION);
         addWriteProtection(Child.CLOCK);
+        setRecalculated(Value.NO_MORE_JAM).addSource(this, Value.IN_JAM).addSource(this, Value.IN_PERIOD)
+        .addSource(getRulesets(), Rulesets.Value.CURRENT_RULESET_ID)
+        .addIndirectSource(this, Value.CURRENT_PERIOD, Period.Child.TIMEOUT);
         reset();
         addInPeriodListeners();
         xmlScoreBoard = new XmlScoreBoard(this);
@@ -82,6 +85,24 @@ public class ScoreBoardImpl extends ScoreBoardEventProviderImpl implements Score
     protected Object computeValue(PermanentProperty prop, Object value, Object last, Flag flag) {
         if (prop == Value.UPCOMING_JAM && !(value instanceof Jam)) {
             value = new JamImpl(this, getCurrentPeriod().getCurrentJam());
+        } else if (prop == Value.NO_MORE_JAM) {
+            if (isInJam() || !isInPeriod()) { return false; }
+            if (!getRulesets().getBoolean(Rule.PERIOD_END_BETWEEN_JAMS)) { return false; }
+            Jam lastJam = getCurrentPeriod().getCurrentJam();
+            long pcRemaining = getClock(Clock.ID_PERIOD).getMaximumTime() - lastJam.getPeriodClockElapsedEnd();
+            if (pcRemaining > getRulesets().getLong(Rule.LINEUP_DURATION)) { return false; }
+            boolean ttoForcesJam = getRulesets().getBoolean(Rule.STOP_PC_ON_TO) || getRulesets().getBoolean(Rule.STOP_PC_ON_TTO);
+            boolean orForcesJam = getRulesets().getBoolean(Rule.STOP_PC_ON_TO) || getRulesets().getBoolean(Rule.STOP_PC_ON_OR);
+            boolean otoForcesJam = getRulesets().getBoolean(Rule.EXTRA_JAM_AFTER_OTO) &&
+                    (getRulesets().getBoolean(Rule.STOP_PC_ON_TO) || getRulesets().getBoolean(Rule.STOP_PC_ON_TTO));
+            for (ValueWithId v : lastJam.getAll(Jam.Child.TIMEOUTS_AFTER)) {
+                Timeout t = (Timeout)v;
+                if (t.getOwner() instanceof Team) {
+                    if (t.isReview() && orForcesJam) { return false; }
+                    if (!t.isReview() && ttoForcesJam) { return false; }
+                } else if (otoForcesJam) { return false; }
+            }
+            return true;
         }
         return value;
     }
@@ -173,7 +194,6 @@ public class ScoreBoardImpl extends ScoreBoardEventProviderImpl implements Score
             setInPeriod(false);
             setInOvertime(false);
             setOfficialScore(false);
-            restartPcAfterTimeout = false;
             snapshot = null;
             replacePending = false;
 
@@ -375,7 +395,6 @@ public class ScoreBoardImpl extends ScoreBoardEventProviderImpl implements Score
         }
         pc.resetTime();
         jc.resetTime();
-        restartPcAfterTimeout = false;
         requestBatchEnd();
     }
     private void _possiblyEndPeriod() {
@@ -418,16 +437,15 @@ public class ScoreBoardImpl extends ScoreBoardEventProviderImpl implements Score
 
         requestBatchStart();
         jc.stop();
-        set(Value.IN_JAM, false);
         getCurrentPeriod().stopJam();
+        // Order is crucial here. 
+        // Moving this above Period.stopJam() will break NoMoreJam detection
+        // Moving it below Team.stopJam() will break setting positions/fieldings 
+        set(Value.IN_JAM, false);
         getTeam(Team.ID_1).stopJam();
         getTeam(Team.ID_2).stopJam();
         setInOvertime(false);
 
-        //TODO: Make this value configurable in the ruleset.
-        if (pc.getTimeRemaining() < 30000) {
-            restartPcAfterTimeout = true;
-        }
         if (pc.isRunning()) {
             _startLineup();
         } else {
@@ -491,16 +509,13 @@ public class ScoreBoardImpl extends ScoreBoardEventProviderImpl implements Score
         if (!getSettings().get(SETTING_CLOCK_AFTER_TIMEOUT).equals(Clock.ID_TIMEOUT)) {
             tc.stop();
         }
-        if (getTimeoutOwner() instanceof Team) {
-            restartPcAfterTimeout = false;
-        }
         getCurrentTimeout().stop();
         if (!timeoutFollows) {
             set(Value.CURRENT_TIMEOUT, noTimeoutDummy);
             if (pc.isTimeAtEnd()) {
                 _possiblyEndPeriod();
             } else {
-                if (restartPcAfterTimeout) {
+                if ((Boolean)get(Value.NO_MORE_JAM)) {
                     pc.start();
                 }
                 if (getSettings().get(SETTING_CLOCK_AFTER_TIMEOUT).equals(Clock.ID_LINEUP)) {
@@ -600,7 +615,6 @@ public class ScoreBoardImpl extends ScoreBoardEventProviderImpl implements Score
         setInOvertime(snapshot.inOvertime());
         set(Value.IN_JAM, snapshot.inJam());
         setInPeriod(snapshot.inPeriod());
-        restartPcAfterTimeout = snapshot.restartPcAfterTo();
         for (Button button : Button.values()) {
             button.setLabel(snapshot.getLabels().get(button));
         }
@@ -687,7 +701,6 @@ public class ScoreBoardImpl extends ScoreBoardEventProviderImpl implements Score
     protected boolean replacePending = false;
 
     protected Timeout noTimeoutDummy;
-    protected boolean restartPcAfterTimeout;
 
     protected XmlScoreBoard xmlScoreBoard;
 
@@ -752,7 +765,6 @@ public class ScoreBoardImpl extends ScoreBoardEventProviderImpl implements Score
             inOvertime = sb.isInOvertime();
             inJam = sb.isInJam();
             inPeriod = sb.isInPeriod();
-            restartPcAfterTo = sb.restartPcAfterTimeout;
             currentPeriod = sb.getCurrentPeriod();
             periodSnapshot = sb.getCurrentPeriod().snapshot();
             labels = new HashMap<>();
@@ -775,7 +787,6 @@ public class ScoreBoardImpl extends ScoreBoardEventProviderImpl implements Score
         public boolean inOvertime() { return inOvertime; }
         public boolean inJam() { return inJam; }
         public boolean inPeriod() { return inPeriod; }
-        public boolean restartPcAfterTo() { return restartPcAfterTo; }
         public Period getCurrentPeriod() { return currentPeriod; }
         public PeriodSnapshot getPeriodSnapshot() { return periodSnapshot; }
         public Map<Button, String> getLabels() { return labels; }
@@ -790,7 +801,6 @@ public class ScoreBoardImpl extends ScoreBoardEventProviderImpl implements Score
         protected boolean inOvertime;
         protected boolean inJam;
         protected boolean inPeriod;
-        protected boolean restartPcAfterTo;
         protected Period currentPeriod;
         protected PeriodSnapshot periodSnapshot;
         protected Map<Button, String> labels;

--- a/src/com/carolinarollergirls/scoreboard/core/impl/TimeoutImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/impl/TimeoutImpl.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 import com.carolinarollergirls.scoreboard.core.Clock;
 import com.carolinarollergirls.scoreboard.core.Jam;
 import com.carolinarollergirls.scoreboard.core.Period;
+import com.carolinarollergirls.scoreboard.core.ScoreBoard;
 import com.carolinarollergirls.scoreboard.core.Team;
 import com.carolinarollergirls.scoreboard.core.Timeout;
 import com.carolinarollergirls.scoreboard.core.TimeoutOwner;
@@ -63,21 +64,32 @@ public class TimeoutImpl extends ScoreBoardEventProviderImpl implements Timeout 
             if (value instanceof Team) {
                 ((Team) value).add(Team.Child.TIME_OUT, this);
             }
+            if (get(Value.PRECEDING_JAM) == scoreBoard.getCurrentPeriod().getCurrentJam()) {
+                scoreBoard.set(ScoreBoard.Value.NO_MORE_JAM, scoreBoard.get(ScoreBoard.Value.NO_MORE_JAM), Flag.RECALCULATE);
+            }
         }
         if (prop == Value.REVIEW && getOwner() instanceof Team) {
             ((Team)getOwner()).recountTimeouts();
+            if (get(Value.PRECEDING_JAM) == scoreBoard.getCurrentPeriod().getCurrentJam()) {
+                scoreBoard.set(ScoreBoard.Value.NO_MORE_JAM, scoreBoard.get(ScoreBoard.Value.NO_MORE_JAM), Flag.RECALCULATE);
+            }
         }
         if (prop == Value.RETAINED_REVIEW && getOwner() instanceof Team) {
             ((Team)getOwner()).recountTimeouts();
         }
-        if (prop == Value.PRECEDING_JAM && value != null &&
-                ((Jam)value).getParent() != getParent()) {
-            getParent().remove(Period.Child.TIMEOUT, this);
-            parent = ((Jam)value).getParent();
-            getParent().add(Period.Child.TIMEOUT, this);
-        }
-        if (prop == Value.PRECEDING_JAM && getOwner() instanceof Team) {
-            ((Team) getOwner()).recountTimeouts();
+        if (prop == Value.PRECEDING_JAM) {
+            if (value != null && ((Jam)value).getParent() != getParent()) {
+                getParent().remove(Period.Child.TIMEOUT, this);
+                parent = ((Jam)value).getParent();
+                getParent().add(Period.Child.TIMEOUT, this);
+            }
+            if (getOwner() instanceof Team) {
+                ((Team) getOwner()).recountTimeouts();
+            }
+            if (value == scoreBoard.getCurrentPeriod().getCurrentJam() ||
+                    last == scoreBoard.getCurrentPeriod().getCurrentJam()) {
+                scoreBoard.set(ScoreBoard.Value.NO_MORE_JAM, scoreBoard.get(ScoreBoard.Value.NO_MORE_JAM), Flag.RECALCULATE);
+            }
         }
     }
 

--- a/src/com/carolinarollergirls/scoreboard/event/RecalculateScoreBoardListener.java
+++ b/src/com/carolinarollergirls/scoreboard/event/RecalculateScoreBoardListener.java
@@ -24,7 +24,7 @@ public class RecalculateScoreBoardListener implements UnlinkableScoreBoardListen
         return this;
     }
     public RecalculateScoreBoardListener addIndirectSource(ScoreBoardEventProvider indirectionElement,
-            PermanentProperty indirectionProperty, PermanentProperty watchedProperty) {
+            PermanentProperty indirectionProperty, Property watchedProperty) {
         IndirectScoreBoardListener l = new
                 IndirectScoreBoardListener(indirectionElement, indirectionProperty, watchedProperty, this);
         sources.put(l, null);

--- a/src/com/carolinarollergirls/scoreboard/rules/Rule.java
+++ b/src/com/carolinarollergirls/scoreboard/rules/Rule.java
@@ -21,6 +21,7 @@ public enum Rule {
     STOP_PC_ON_TTO(new BooleanRule("Timeout.StopPeriodClockOnTTO", "Stop the period clock on team timeouts?", false, "True", "False")),
     STOP_PC_ON_OR(new BooleanRule("Timeout.StopPeriodClockOnOR", "Stop the period clock on official reviews?", false, "True", "False")),
     STOP_PC_AFTER_TO_DURATION(new TimeRule("Timeout.StopPeriodClockAfterTODuration", "Stop the period clock, if a timeout lasts longer than this time. Set to a high value to disable.", "60:00")),
+    EXTRA_JAM_AFTER_OTO(new BooleanRule("Timeut.ExtraJamAfterOTO", "Can an OTO cause an extra Jam to be played when there wouldn't be one otherwise?", false, "True", "False")),
 
     INTERMISSION_DURATIONS(new StringRule("Intermission.Durations", "List of the duration of intermissions as they appear in the game, separated by commas.", "15:00,60:00")),
     INTERMISSION_DIRECTION(new BooleanRule("Intermission.ClockDirection", "Which way should the intermission clock count?", true, "Count Down", "Count Up")),
@@ -36,6 +37,8 @@ public enum Rule {
     NUMBER_REVIEWS(new IntegerRule("Team.OfficialReviews", "How many official reviews each team is granted per game or period", 1)),
     REVIEWS_PER_PERIOD(new BooleanRule("Team.OfficialReviewsPer", "Are official reviews granted per period or per game?", true, "Period", "Game")),
     NUMBER_RETAINS(new IntegerRule("Team.MaxRetains", "How many times per game or period a team can retain an official review", 1)),
+    
+    MANDATORY_OVERTIME(new BooleanRule("Overtime.Mandatory", "Will a tied game always go to overtime?", true, "True", "False")),
 
     PENALTIES_FILE(new StringRule("Penalties.DefinitionFile", "File that contains the penalty code definitions to be used", "/config/penalties/wftda2018.json")),
     FO_LIMIT(new IntegerRule("Penalties.NumberToFoulout", "After how many penalties a skater has fouled out of the game. Note that the software currently does not support more than 9 penalties per skater.", 7));

--- a/src/com/carolinarollergirls/scoreboard/rules/Rule.java
+++ b/src/com/carolinarollergirls/scoreboard/rules/Rule.java
@@ -37,8 +37,6 @@ public enum Rule {
     NUMBER_REVIEWS(new IntegerRule("Team.OfficialReviews", "How many official reviews each team is granted per game or period", 1)),
     REVIEWS_PER_PERIOD(new BooleanRule("Team.OfficialReviewsPer", "Are official reviews granted per period or per game?", true, "Period", "Game")),
     NUMBER_RETAINS(new IntegerRule("Team.MaxRetains", "How many times per game or period a team can retain an official review", 1)),
-    
-    MANDATORY_OVERTIME(new BooleanRule("Overtime.Mandatory", "Will a tied game always go to overtime?", true, "True", "False")),
 
     PENALTIES_FILE(new StringRule("Penalties.DefinitionFile", "File that contains the penalty code definitions to be used", "/config/penalties/wftda2018.json")),
     FO_LIMIT(new IntegerRule("Penalties.NumberToFoulout", "After how many penalties a skater has fouled out of the game. Note that the software currently does not support more than 9 penalties per skater.", 7));

--- a/tests/com/carolinarollergirls/scoreboard/core/impl/ScoreboardImplTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/core/impl/ScoreboardImplTests.java
@@ -1344,30 +1344,39 @@ public class ScoreboardImplTests {
         sb.startJam();
         pc.setTime(35000);
         sb.stopJamTO();
+        assertFalse((Boolean)sb.get(ScoreBoard.Value.NO_MORE_JAM));
         assertTrue(pc.isRunning());
         assertTrue(lc.isRunning());
         advance(10000);
         sb.timeout();
         advance(20000);
         sb.stopJamTO();
+        assertFalse((Boolean)sb.get(ScoreBoard.Value.NO_MORE_JAM));
         assertFalse(pc.isRunning());
 
         //jam ended after 30s mark, official timeout
         sb.startJam();
         sb.stopJamTO();
+        assertTrue((Boolean)sb.get(ScoreBoard.Value.NO_MORE_JAM));
         assertEquals(25000, pc.getTime());
         assertTrue(pc.isRunning());
         advance(1000);
         sb.timeout();
         advance(35000);
+        assertTrue((Boolean)sb.get(ScoreBoard.Value.NO_MORE_JAM));
+        sb.setTimeoutType(Timeout.Owners.OTO, false);
+        assertTrue((Boolean)sb.get(ScoreBoard.Value.NO_MORE_JAM));
         sb.stopJamTO();
+        assertTrue((Boolean)sb.get(ScoreBoard.Value.NO_MORE_JAM));
         assertTrue(pc.isRunning());
 
         //follow up with team timeout
         advance(2000);
         sb.setTimeoutType(sb.getTeam(Team.ID_1), false);
+        assertFalse((Boolean)sb.get(ScoreBoard.Value.NO_MORE_JAM));
         advance(60000);
         sb.stopJamTO();
+        assertFalse((Boolean)sb.get(ScoreBoard.Value.NO_MORE_JAM));
         assertFalse(pc.isRunning());
         assertEquals(22000, pc.getTimeRemaining());
     }


### PR DESCRIPTION
When there won't be another regular jam in this period without
intervention (TTO/OR), mark the headers of running clocks in red on the
operator screen and display the lineup/timeout clock with a red
background on the main view.

Closes #218 

Includes #283 as I needed those stats to reliably detect if there has been a timeout that gives another jam.