### PR TITLE
Make Team.Color and .AlternateName ValWithId

### DIFF
--- a/html/controls/lt/lt-sheet.js
+++ b/html/controls/lt/lt-sheet.js
@@ -8,11 +8,11 @@ function prepareLtSheetTable(element, teamId, mode) {
 
 		if (mode != 'plt') {
 			WS.Register(['ScoreBoard.Team(' + teamId + ').Name'], function () { teamNameUpdate(); });
-			WS.Register(['ScoreBoard.Team(' + teamId + ').AlternateName(operator).Name'], function () { teamNameUpdate(); });
+			WS.Register(['ScoreBoard.Team(' + teamId + ').AlternateName(operator)'], function () { teamNameUpdate(); });
 	
 			WS.Register(['ScoreBoard.Team(' + teamId + ').Color'], function (k, v) {
-				element.find('#head').css('background-color', WS.state['ScoreBoard.Team(' + teamId + ').Color(operator_bg).Color']);
-				element.find('#head').css('color', WS.state['ScoreBoard.Team(' + teamId + ').Color(operator_fg).Color']);
+				element.find('#head').css('background-color', WS.state['ScoreBoard.Team(' + teamId + ').Color(operator_bg)']);
+				element.find('#head').css('color', WS.state['ScoreBoard.Team(' + teamId + ').Color(operator_fg)']);
 			});
 		}
 		
@@ -22,8 +22,8 @@ function prepareLtSheetTable(element, teamId, mode) {
 	function teamNameUpdate() {
 		teamName = WS.state['ScoreBoard.Team(' + teamId + ').Name'];
 
-		if (WS.state['ScoreBoard.Team(' + teamId + ').AlternateName(operator).Name'] != null) {
-			teamName = WS.state['ScoreBoard.Team(' + teamId + ').AlternateName(operator).Name']
+		if (WS.state['ScoreBoard.Team(' + teamId + ').AlternateName(operator)'] != null) {
+			teamName = WS.state['ScoreBoard.Team(' + teamId + ').AlternateName(operator)']
 		}
 
 		element.find('#head .Team').text(teamName);

--- a/html/controls/mobile.js
+++ b/html/controls/mobile.js
@@ -18,7 +18,7 @@ $sb(function() {
 	$.each( [ "1", "2" ], function(i, t) {
 		$sb("ScoreBoard.Team("+t+")").$sbBindAddRemoveEach("AlternateName", function(event, node) {
 			if ($sb(node).$sbId == "mobile")
-				$sb(node).$sb("Name").$sbBindAndRun("sbchange", function(event2, val) {
+				$sb(node).$sbBindAndRun("sbchange", function(event2, val) {
 					$(".Team"+t+".Name,.Team"+t+".AlternateName")
 						.toggleClass("HasAlternateName", $.trim(val) != "");
 				});
@@ -34,16 +34,16 @@ function setupJamControlPage() {
 	$sb("ScoreBoard.Team(1).Timeout").$sbControl("#JamControlPage div.Timeout button.Team1").val(true);
 	$sb("ScoreBoard.Team(1).OfficialReview").$sbControl("#JamControlPage div.OfficialReview button.Team1").val(true);
 	$sb("ScoreBoard.Team(1).Name").$sbElement("#JamControlPage div.Timeout button.Team1>span.Name");
-	$sb("ScoreBoard.Team(1).AlternateName(operator).Name").$sbElement("#JamControlPage div.Timeout button.Team1>span.AlternateName");
+	$sb("ScoreBoard.Team(1).AlternateName(operator)").$sbElement("#JamControlPage div.Timeout button.Team1>span.AlternateName");
 	$sb("ScoreBoard.Team(1).Name").$sbElement("#JamControlPage div.OfficialReview button.Team1>span.Name");
-	$sb("ScoreBoard.Team(1).AlternateName(operator).Name").$sbElement("#JamControlPage div.OfficialReview button.Team1>span.AlternateName");
+	$sb("ScoreBoard.Team(1).AlternateName(operator)").$sbElement("#JamControlPage div.OfficialReview button.Team1>span.AlternateName");
 	$sb("ScoreBoard.OfficialTimeout").$sbControl("#JamControlPage div.Timeout button.Official").val(true);
 	$sb("ScoreBoard.Team(2).Timeout").$sbControl("#JamControlPage div.Timeout button.Team2").val(true);
 	$sb("ScoreBoard.Team(2).OfficialReview").$sbControl("#JamControlPage div.OfficialReview button.Team2").val(true);
 	$sb("ScoreBoard.Team(2).Name").$sbElement("#JamControlPage div.Timeout button.Team2>span.Name");
-	$sb("ScoreBoard.Team(2).AlternateName(operator).Name").$sbElement("#JamControlPage div.Timeout button.Team2>span.AlternateName");
+	$sb("ScoreBoard.Team(2).AlternateName(operator)").$sbElement("#JamControlPage div.Timeout button.Team2>span.AlternateName");
 	$sb("ScoreBoard.Team(2).Name").$sbElement("#JamControlPage div.OfficialReview button.Team2>span.Name");
-	$sb("ScoreBoard.Team(2).AlternateName(operator).Name").$sbElement("#JamControlPage div.OfficialReview button.Team2>span.AlternateName");
+	$sb("ScoreBoard.Team(2).AlternateName(operator)").$sbElement("#JamControlPage div.OfficialReview button.Team2>span.AlternateName");
 
 	$.each( [ "Period", "Jam", "Timeout" ], function(i, clock) {
 		$sb("ScoreBoard.Clock("+clock+").Running").$sbBindAndRun("sbchange", function(event, value) {

--- a/html/controls/operator.js
+++ b/html/controls/operator.js
@@ -602,14 +602,14 @@ function createTeamTable() {
 				if (val == "") {
 					sbTeam.$sb("AlternateName(operator)").$sbRemove();
 				} else {
-					sbTeam.$sb("AlternateName(operator).Name").$sbSet(val);
+					sbTeam.$sb("AlternateName(operator)").$sbSet(val);
 				}
 			}
 		});
 		
 		sbTeam.$sbBindAddRemoveEach("AlternateName", function(event, node) {
 			if ($sb(node).$sbId == "operator")
-				$sb(node).$sb("Name").$sbBindAndRun("sbchange", function(event, val) {
+				$sb(node).$sbBindAndRun("sbchange", function(event, val) {
 					altNameA.html($.trim(val));
 					altNameInput.val($.trim(val));
 					nameA.toggleClass("AlternateName", ($.trim(val) != ""));
@@ -1644,7 +1644,7 @@ function createAlternateNamesDialog(team) {
 	var newFunc = function() {
 		var newId = newIdInput.val();
 		var newName = newNameInput.val();
-		team.$sb("AlternateName("+newId+").Name").$sbSet(newName);
+		team.$sb("AlternateName("+newId+")").$sbSet(newName);
 		newNameInput.val("");
 		newIdInput.val("").focus();
 	};
@@ -1677,7 +1677,7 @@ function createAlternateNamesDialog(team) {
 			.click(function() { node.$sbRemove(); })
 			.appendTo(tr.children("td.X"));
 		tr.children("td.Id").text(node.$sbId);
-		node.$sb("Name").$sbControl("<input type='text' size='20'>").appendTo(tr.children("td.Name"));
+		node.$sbControl("<input type='text' size='20'>").appendTo(tr.children("td.Name"));
 		tr.appendTo(table);
 	};
 	var removeFunc = function(event, node) {
@@ -1717,9 +1717,9 @@ function createColorsDialog(team) {
 	var newFunc = function() {
 		var newId = newIdInput.val();
 
-		team.$sb("Color(" + newId + "_fg).Color").$sbSet("");
-		team.$sb("Color(" + newId + "_bg).Color").$sbSet("");
-		team.$sb("Color(" + newId + "_glow).Color").$sbSet("");
+		team.$sb("Color(" + newId + "_fg)").$sbSet("");
+		team.$sb("Color(" + newId + "_bg)").$sbSet("");
+		team.$sb("Color(" + newId + "_glow)").$sbSet("");
 
 		newIdInput.val("").focus();
 	};
@@ -1761,19 +1761,19 @@ function createColorsDialog(team) {
 			var fg = team.$sb("Color(" + colorId + "_fg)");
 			var bg = team.$sb("Color(" + colorId + "_bg)");
 			var gl = team.$sb("Color(" + colorId + "_glow)");
-			var fgInput = fg.$sb("Color")
+			var fgInput = fg
 				.$sbControl("<input type='text' size='5'>", { sbcontrol: {
 					colorpicker: true
 				} })
 				.appendTo(tr.children("td.Foreground"))
 				.addClass("ColorPicker");
-			var bgInput = bg.$sb("Color")
+			var bgInput = bg
 				.$sbControl("<input type='text' size='5'>", { sbcontrol: {
 					colorpicker: true
 				} })
 				.appendTo(tr.children("td.Background"))
 				.addClass("ColorPicker");
-			var glInput = gl.$sb("Color")
+			var glInput = gl
 				.$sbControl("<input type='text' size='5'>", { sbcontrol: {
 					colorpicker: true
 				} })

--- a/html/controls/plt/plt-input.js
+++ b/html/controls/plt/plt-input.js
@@ -48,11 +48,11 @@ function preparePltInputTable(element, teamId, mode, statsbookPeriod, alternateN
 		tbody = $('<tbody>').appendTo(table);
 
 		WS.Register(['ScoreBoard.Team(' + teamId + ').Name'], function () { teamNameUpdate(); });
-		WS.Register(['ScoreBoard.Team(' + teamId + ').AlternateName(' + alternateName + ').Name'], function () { teamNameUpdate(); });
+		WS.Register(['ScoreBoard.Team(' + teamId + ').AlternateName(' + alternateName + ')'], function () { teamNameUpdate(); });
 
 		WS.Register(['ScoreBoard.Team(' + teamId + ').Color'], function (k, v) {
-			element.find('#head').css('background-color', WS.state['ScoreBoard.Team(' + teamId + ').Color(' + alternateName + '_bg).Color'] || '');
-			element.find('#head').css('color', WS.state['ScoreBoard.Team(' + teamId + ').Color(' + alternateName + '_fg).Color'] || '');
+			element.find('#head').css('background-color', WS.state['ScoreBoard.Team(' + teamId + ').Color(' + alternateName + '_bg)'] || '');
+			element.find('#head').css('color', WS.state['ScoreBoard.Team(' + teamId + ').Color(' + alternateName + '_fg)'] || '');
 		});
 		WS.Register(['ScoreBoard.Clock(Period).Number'], updatePeriod);
 		WS.Register(['ScoreBoard.Clock(Jam).Number'], updateJam);
@@ -246,8 +246,8 @@ function preparePltInputTable(element, teamId, mode, statsbookPeriod, alternateN
 		var head = element.find('#head');
 		var teamName = WS.state['ScoreBoard.Team(' + teamId + ').Name'];
 
-		if (WS.state['ScoreBoard.Team(' + teamId + ').AlternateName(' + alternateName + ').Name'] != null) {
-			teamName = WS.state['ScoreBoard.Team(' + teamId + ').AlternateName(' + alternateName + ').Name']
+		if (WS.state['ScoreBoard.Team(' + teamId + ').AlternateName(' + alternateName + ')'] != null) {
+			teamName = WS.state['ScoreBoard.Team(' + teamId + ').AlternateName(' + alternateName + ')']
 		}
 
 		head.text(teamName);
@@ -341,7 +341,7 @@ function preparePltInputTable(element, teamId, mode, statsbookPeriod, alternateN
 
 function openPenaltyEditor(t, id, which) {
 	var prefix = 'ScoreBoard.Team(' + t + ')';
-		teamName = WS.state[prefix + '.AlternateName(operator).Name'];
+		teamName = WS.state[prefix + '.AlternateName(operator)'];
 	if (teamName == null)
 		teamName = WS.state[prefix + '.Name'];
 

--- a/html/controls/sk/sk-sheet.js
+++ b/html/controls/sk/sk-sheet.js
@@ -12,11 +12,11 @@ function prepareSkSheetTable(element, teamId, mode) {
 	function initialize() {
 		if (mode != 'operator') {
 			WS.Register(['ScoreBoard.Team(' + teamId + ').Name'], function () { teamNameUpdate(); });
-			WS.Register(['ScoreBoard.Team(' + teamId + ').AlternateName(operator).Name'], function () { teamNameUpdate(); });
+			WS.Register(['ScoreBoard.Team(' + teamId + ').AlternateName(operator)'], function () { teamNameUpdate(); });
 
 			WS.Register(['ScoreBoard.Team(' + teamId + ').Color'], function (k, v) {
-				element.find('#head').css('background-color', WS.state['ScoreBoard.Team(' + teamId + ').Color(operator_bg).Color']);
-				element.find('#head').css('color', WS.state['ScoreBoard.Team(' + teamId + ').Color(operator_fg).Color']);
+				element.find('#head').css('background-color', WS.state['ScoreBoard.Team(' + teamId + ').Color(operator_bg)']);
+				element.find('#head').css('color', WS.state['ScoreBoard.Team(' + teamId + ').Color(operator_fg)']);
 			});
 		}
 
@@ -26,8 +26,8 @@ function prepareSkSheetTable(element, teamId, mode) {
 	function teamNameUpdate() {
 		teamName = WS.state['ScoreBoard.Team(' + teamId + ').Name'];
 
-		if (WS.state['ScoreBoard.Team(' + teamId + ').AlternateName(operator).Name'] != null) {
-			teamName = WS.state['ScoreBoard.Team(' + teamId + ').AlternateName(operator).Name']
+		if (WS.state['ScoreBoard.Team(' + teamId + ').AlternateName(operator)'] != null) {
+			teamName = WS.state['ScoreBoard.Team(' + teamId + ').AlternateName(operator)']
 		}
 
 		element.find('#head .Team').text(teamName);

--- a/html/javascript/utils.js
+++ b/html/javascript/utils.js
@@ -359,15 +359,15 @@ _crgUtils = {
 				var id = $sb(node).$sbId;
 				if (map == null) {
 					if (id == fg) {
-						node.$sb("Color").$sbBindAndRun("sbchange", function(event,val) {
+						node.$sbBindAndRun("sbchange", function(event,val) {
 							$(fg_elem).css('color', $.trim(val));
 						});
 					} else if (id == bg) {
-						node.$sb("Color").$sbBindAndRun("sbchange", function(event,val) {
+						node.$sbBindAndRun("sbchange", function(event,val) {
 							$(bg_elem).css('background-color', $.trim(val));
 						});
 					} else if (id == gl) {
-						node.$sb("Color").$sbBindAndRun("sbchange", function(event,val) {
+						node.$sbBindAndRun("sbchange", function(event,val) {
 							var shadow = '';
 							if ($.trim(val) != "") {
 								shadow = '0 0 0.2em ' + val;
@@ -378,15 +378,15 @@ _crgUtils = {
 					}
 				} else {
 					if (map.fg != null && id == fg) {
-						node.$sb("Color").$sbBindAndRun("sbchange", function(event,val) {
+						node.$sbBindAndRun("sbchange", function(event,val) {
 							$(fg_elem).css(map.fg, $.trim(val));
 						});
 					} else if (map.bg != null && id == bg) {
-						node.$sb("Color").$sbBindAndRun("sbchange", function(event,val) {
+						node.$sbBindAndRun("sbchange", function(event,val) {
 							$(fg_elem).css(map.bg, $.trim(val));
 						});
 					} else if (map.glow != null && id == gl) {
-						node.$sb("Color").$sbBindAndRun("sbchange", function(event,val) {
+						node.$sbBindAndRun("sbchange", function(event,val) {
 							$(fg_elem).css(map.glow, $.trim(val));
 						});
 					}

--- a/html/views/overlays/interactive/admin.html
+++ b/html/views/overlays/interactive/admin.html
@@ -70,13 +70,13 @@
 		<div id="TeamOptions" class="Panel" sbContext="ScoreBoard">
 			<h2>Team Display</h2>
 			<label>1 - Name/FG/BG</label>
-			<input data-setting="ScoreBoard.Team(1).AlternateName(overlay).Name" type="text"/><br/>
-			<input data-setting="ScoreBoard.Team(1).Color(overlay_fg).Color" type="color"/><button class="ClearPrev">X</button></br>
-			<input data-setting="ScoreBoard.Team(1).Color(overlay_bg).Color" type="color"/><button class="ClearPrev">X</button></br>
+			<input data-setting="ScoreBoard.Team(1).AlternateName(overlay)" type="text"/><br/>
+			<input data-setting="ScoreBoard.Team(1).Color(overlay_fg)" type="color"/><button class="ClearPrev">X</button></br>
+			<input data-setting="ScoreBoard.Team(1).Color(overlay_bg)" type="color"/><button class="ClearPrev">X</button></br>
 			<label>2 - Name/FG/BG</label>
-			<input data-setting="ScoreBoard.Team(2).AlternateName(overlay).Name" type="text"/><br/>
-			<input data-setting="ScoreBoard.Team(2).Color(overlay_fg).Color" type="color"/><button class="ClearPrev">X</button></br>
-			<input data-setting="ScoreBoard.Team(2).Color(overlay_bg).Color" type="color"/><button class="ClearPrev">X</button></br>
+			<input data-setting="ScoreBoard.Team(2).AlternateName(overlay)" type="text"/><br/>
+			<input data-setting="ScoreBoard.Team(2).Color(overlay_fg)" type="color"/><button class="ClearPrev">X</button></br>
+			<input data-setting="ScoreBoard.Team(2).Color(overlay_bg)" type="color"/><button class="ClearPrev">X</button></br>
 		</div>
 
 	</div>

--- a/html/views/overlays/interactive/admin.js
+++ b/html/views/overlays/interactive/admin.js
@@ -62,14 +62,14 @@ function initialize() {
 	});
 
 	WS.Register(['ScoreBoard.Settings.Setting(Overlay.Interactive.LowerThird.Line',
-	'ScoreBoard.Team(1).AlternateName(overlay).Name',
-	'ScoreBoard.Team(2).AlternateName(overlay).Name'],
+	'ScoreBoard.Team(1).AlternateName(overlay)',
+	'ScoreBoard.Team(2).AlternateName(overlay)'],
 				function(k,v) { $('input[data-setting="'+k+'"]').val(v); });
 
-	WS.Register(['ScoreBoard.Team(1).Color(overlay_fg).Color',
-	'ScoreBoard.Team(1).Color(overlay_bg).Color',
-	'ScoreBoard.Team(2).Color(overlay_fg).Color',
-	'ScoreBoard.Team(2).Color(overlay_bg).Color'],
+	WS.Register(['ScoreBoard.Team(1).Color(overlay_fg)',
+	'ScoreBoard.Team(1).Color(overlay_bg)',
+	'ScoreBoard.Team(2).Color(overlay_fg)',
+	'ScoreBoard.Team(2).Color(overlay_bg)'],
 				function(k,v) {
 					if (v == null || v == "") {
 						$('input[data-setting="'+k+'"]').attr("cleared", "true");
@@ -132,7 +132,7 @@ $('select#Skaters').change(function(e) {
 	v = $t.val();
 	team = $( 'option[value=' + v + ']', $t ).attr('data-team');
 	name = $( 'option[value=' + v + ']', $t ).attr('data-name');
-	tnam = WS.state['ScoreBoard.Team(' + team + ').AlternateName(overlay).Name'];
+	tnam = WS.state['ScoreBoard.Team(' + team + ').AlternateName(overlay)'];
 	tnam = tnam ? tnam : WS.state['ScoreBoard.Team(' + team + ').Name'];
 	f = $( '#LowerThirdStyle option[value=ColourTeam' + team + ']').attr('selected', 'selected').change();
 	$('input[data-setting="ScoreBoard.Settings.Setting(Overlay.Interactive.LowerThird.Line1)"]').val(name).change();

--- a/html/views/overlays/interactive/index.html
+++ b/html/views/overlays/interactive/index.html
@@ -19,7 +19,7 @@
 					<div class="Team1" sbContext="Team(1)">	
 					<div class="Team Row Wrapper barBackgroundTop"> 
 						<div class="Indicator ColourTeam1 Box">&nbsp;</div>
-						<div class="Name  VerticalCenter Box" sbDisplay="AlternateName(overlay).Name,Name"></div>
+						<div class="Name  VerticalCenter Box" sbDisplay="AlternateName(overlay),Name"></div>
 						<div class="Score VerticalCenter Box" sbDisplay="Score"></div>
 						<div class="Mini Box">
 							<div class="JamScore" sbDisplay="JamScore"></div>
@@ -39,7 +39,7 @@
 					<div class="Team2" sbContext="Team(2)">
 						<div class="Team Row Wrapper barBackgroundBottom">
 							<div class="Indicator ColourTeam2 Box">&nbsp;</div>
-							<div class="Name Box" sbDisplay="AlternateName(overlay).Name,Name"></div>
+							<div class="Name Box" sbDisplay="AlternateName(overlay),Name"></div>
 							<div class="Score Box" sbDisplay="Score"></div>
 							<div class="Mini Box"><div class="JamScore" sbDisplay="JamScore"></div><div class="LeadJammer Lead">&#9733;</div></div>
 							<div class="DotTimeouts Box"><div class="Dot Timeout1"></div><div class="Dot Timeout2"></div><div class="Dot Timeout3"></div><div class="Dot OfficialReview1"></div></div>
@@ -83,7 +83,7 @@
 
 				<div class="PPJBox Wrapper PanelHideLeft OverlayPanel LargePanel AnimatedPanel">
 					<h1 class="NoLogo">Points Per Jam</h1>
-					<h4 class="htop ColourTeam1" sbDisplay="AlternateName(overlay).Name,Name" sbContext="Team(1)"></h4>	
+					<h4 class="htop ColourTeam1" sbDisplay="AlternateName(overlay),Name" sbContext="Team(1)"></h4>	
 					<div class="PPJContainer Wrapper">
 						<div class="Wrapper Team Team1">
 							<div class="Period Period1"></div><div class="Period Period2"></div>
@@ -91,13 +91,13 @@
 						<div class="Wrapper Team Team2">
 							<div class="Period Period1"></div><div class="Period Period2"></div>
 						</div> </div>
-					<h4 class="hbottom ColourTeam2" sbDisplay="AlternateName(overlay).Name,Name" sbContext="Team(2)"></h4>	
+					<h4 class="hbottom ColourTeam2" sbDisplay="AlternateName(overlay),Name" sbContext="Team(2)"></h4>	
 				</div>
 
 
 				<div class="RosterTeam1 RosterTeam PanelHideLeft Wrapper OverlayPanel LargePanel AnimatedPanel">
 					<img class="TeamLogo TeamLogo1" src="" />
-					<h1 class="ColourTeam1" sbDisplay="AlternateName(overlay).Name,Name" sbContext="Team(1)"></h1>
+					<h1 class="ColourTeam1" sbDisplay="AlternateName(overlay),Name" sbContext="Team(1)"></h1>
 					<h2>Team Roster</h2>
 				</div>
 				<div class="RosterTeam1 RosterTeam LowerPart AnimationDelay PanelHideLeft Wrapper OverlayPanel LargePanel AnimatedPanel">
@@ -107,7 +107,7 @@
 
 				<div class="RosterTeam2 RosterTeam PanelHideRight Wrapper OverlayPanel LargePanel AnimatedPanel">
 					<img class="TeamLogo TeamLogo2" src="" />
-					<h1 class="ColourTeam2" sbDisplay="AlternateName(overlay).Name,Name" sbContext="Team(2)"></h1>	
+					<h1 class="ColourTeam2" sbDisplay="AlternateName(overlay),Name" sbContext="Team(2)"></h1>	
 					<h2>Team Roster</h2>
 				</div>
 				<div class="RosterTeam2 RosterTeam LowerPart AnimationDelay PanelHideRight Wrapper OverlayPanel LargePanel AnimatedPanel">
@@ -118,7 +118,7 @@
 				<div class="PenaltyTeam1 PenaltyTeam PanelHideLeft Wrapper OverlayPanel LargePanel AnimatedPanel">
 					<img class="TeamLogo TeamLogo1" src="" />
 					<h1>Penalty Board</h1>
-					<h2 class="ColourTeam1" sbDisplay="AlternateName(overlay).Name,Name" sbContext="Team(1)"></h2>	
+					<h2 class="ColourTeam1" sbDisplay="AlternateName(overlay),Name" sbContext="Team(1)"></h2>	
 				</div>
 				<div class="PenaltyTeam1 PenaltyTeam AnimationDelay LowerPart PanelHideLeft Wrapper OverlayPanel LargePanel AnimatedPanel">
 					<div class="Wrapper Team Team1 SortBox">
@@ -128,7 +128,7 @@
 				<div class="PenaltyTeam2 PenaltyTeam PanelHideRight Wrapper OverlayPanel LargePanel AnimatedPanel">
 					<img class="TeamLogo TeamLogo2" src="" />
 					<h1>Penalty Board</h1>
-					<h2 class="ColourTeam2" sbDisplay="AlternateName(overlay).Name,Name" sbContext="Team(2)"></h2>	
+					<h2 class="ColourTeam2" sbDisplay="AlternateName(overlay),Name" sbContext="Team(2)"></h2>	
 				</div>
 				<div class="PenaltyTeam2 PenaltyTeam AnimationDelay LowerPart PanelHideRight Wrapper OverlayPanel LargePanel AnimatedPanel">
 					<div class="Wrapper Team Team2 SortBox">
@@ -138,12 +138,12 @@
 				<div class="Upcoming PanelHideLeft Wrapper OverlayPanel LargePanel AnimatedPanel">
 					<div>
 						<img class="TeamLogo TeamLogo1" src="" style="float: left;" />
-						<h1 class="ColourTeam1" sbDisplay="AlternateName(overlay).Name,Name" sbContext="Team(1)" style="margin-top: 2em; margin-left: 4em; margin-right: 0;"></h1>	
+						<h1 class="ColourTeam1" sbDisplay="AlternateName(overlay),Name" sbContext="Team(1)" style="margin-top: 2em; margin-left: 4em; margin-right: 0;"></h1>	
 					</div>
 					<div class="UpcomingVS">VS</div>
 					<div>
 						<img class="TeamLogo TeamLogo2" src="" style="float: right;" />
-						<h1 class="ColourTeam2" sbDisplay="AlternateName(overlay).Name,Name" sbContext="Team(2)" style="margin-top: 2em; margin-left: 0; margin-right: 4em;"></h1>	
+						<h1 class="ColourTeam2" sbDisplay="AlternateName(overlay),Name" sbContext="Team(2)" style="margin-top: 2em; margin-left: 0; margin-right: 4em;"></h1>	
 					</div>
 				</div>
 

--- a/html/views/overlays/interactive/index.js
+++ b/html/views/overlays/interactive/index.js
@@ -127,7 +127,7 @@ function teamData(team, k,v) {
 		}
 	}
 
-	var colourRegEx = /^ScoreBoard\.Team\((.+)\)\.Color\((.+)\).Color$/;
+	var colourRegEx = /^ScoreBoard\.Team\((.+)\)\.Color\((.+)\)$/;
 	var match = k.match(colourRegEx);
 	if(match) { 
 		var setting = match[2];

--- a/html/views/standard/index.html
+++ b/html/views/standard/index.html
@@ -13,7 +13,7 @@
 		<div class="DisplayPane" id="whiteboard"><iframe class="object" src="../wb/"></iframe></div>
 		<div class="DisplayPane Show" id="scoreboard" sbContext="ScoreBoard" class="JamScore">
 			<div class="Team Team1 Left" sbContext="Team(1)">
-				<div class="Name AutoFit" sbModify="nameUpdate" sbDisplay="AlternateName(scoreboard).Name,Name"></div>
+				<div class="Name AutoFit" sbModify="nameUpdate" sbDisplay="AlternateName(scoreboard),Name"></div>
 				<div class="Logo" sbTrigger="logoUpdate" sbTriggerOn="Logo">&nbsp;</div>
 				<div class="Score Box AutoFit" sbDisplay="Score"></div>
 				<div class="JamScore Box AutoFit" sbDisplay="JamScore"></div>
@@ -29,7 +29,7 @@
 			</div>
 
 			<div class="Team Team2 Right" sbContext="Team(2)">
-				<div class="Name AutoFit" sbModify="nameUpdate" sbDisplay="AlternateName(scoreboard).Name,Name"></div>
+				<div class="Name AutoFit" sbModify="nameUpdate" sbDisplay="AlternateName(scoreboard),Name"></div>
 				<div class="Logo" sbTrigger="logoUpdate" sbTriggerOn="Logo">&nbsp;</div>
 				<div class="Score Box AutoFit" sbDisplay="Score"></div>
 				<div class="JamScore Box AutoFit" sbDisplay="JamScore"></div>

--- a/html/views/standard/index.js
+++ b/html/views/standard/index.js
@@ -63,13 +63,13 @@ function initialize() {
 				v = '';
 			}
 			switch (String(k)){
-				case 'ScoreBoard.Team(' + t + ').Color(scoreboard_fg).Color':
+				case 'ScoreBoard.Team(' + t + ').Color(scoreboard_fg)':
 					$('.Team' + t + ' .Name').css('color', v);
 					break;
-				case 'ScoreBoard.Team(' + t + ').Color(scoreboard_bg).Color':
+				case 'ScoreBoard.Team(' + t + ').Color(scoreboard_bg)':
 					$('.Team' + t + ' .Name').css('background-color', v);
 					break;
-				case 'ScoreBoard.Team(' + t + ').Color(scoreboard_glow).Color':
+				case 'ScoreBoard.Team(' + t + ').Color(scoreboard_glow)':
 					var shadow = '0px 0px 0.2em ' + v;
 					var shadowCSS = shadow + ', ' + shadow + ', ' + shadow;
 					if (v === '') {
@@ -77,7 +77,7 @@ function initialize() {
 					}
 					$('.Team' + t + ' .Name').css('text-shadow',shadowCSS);
 					break;
-				case 'ScoreBoard.Team(' + t + ').Color(scoreboard_dots_fg).Color':
+				case 'ScoreBoard.Team(' + t + ').Color(scoreboard_dots_fg)':
 					var dotColor = v;
 					if (dotColor == '') {dotColor = '#000000';}
 					$('.Team' + t + ' .DotTimeouts .Dot').css('background', dotColor);

--- a/src/com/carolinarollergirls/scoreboard/core/Team.java
+++ b/src/com/carolinarollergirls/scoreboard/core/Team.java
@@ -15,6 +15,7 @@ import com.carolinarollergirls.scoreboard.event.ScoreBoardEvent.CommandProperty;
 import com.carolinarollergirls.scoreboard.event.ScoreBoardEvent.PermanentProperty;
 import com.carolinarollergirls.scoreboard.event.ScoreBoardEvent.ValueWithId;
 import com.carolinarollergirls.scoreboard.event.ScoreBoardEventProvider;
+import com.carolinarollergirls.scoreboard.utils.ValWithId;
 
 public interface Team extends ScoreBoardEventProvider, TimeoutOwner {
     public void reset();
@@ -27,11 +28,12 @@ public interface Team extends ScoreBoardEventProvider, TimeoutOwner {
     public TeamSnapshot snapshot();
     public void restoreSnapshot(TeamSnapshot s);
 
-    public AlternateName getAlternateName(String id);
+    public String getAlternateName(String id);
+    public String getAlternateName(AlternateNameId id);
     public void setAlternateName(String id, String name);
     public void removeAlternateName(String id);
 
-    public Color getColor(String id);
+    public String getColor(String id);
     public void setColor(String id, String color);
     public void removeColor(String id);
 
@@ -125,8 +127,8 @@ public interface Team extends ScoreBoardEventProvider, TimeoutOwner {
     public enum Child implements AddRemoveProperty {
         SKATER(Skater.class),
         POSITION(Position.class),
-        ALTERNATE_NAME(AlternateName.class),
-        COLOR(Color.class),
+        ALTERNATE_NAME(ValWithId.class),
+        COLOR(ValWithId.class),
         BOX_TRIP(BoxTrip.class);
 
         private Child(Class<? extends ValueWithId> t) { type = t; }
@@ -145,48 +147,16 @@ public interface Team extends ScoreBoardEventProvider, TimeoutOwner {
         public Class<Boolean> getType() { return Boolean.class; }
     }
 
-    public static interface AlternateName extends ScoreBoardEventProvider {
-        public String getName();
-        public void setName(String n);
+    public enum AlternateNameId {
+        OPERATOR("operator"),
+        OVERLAY("overlay"),
+        TWITTER("twitter");
+        
+        private AlternateNameId(String i) { id = i; }
+        @Override
+        public String toString() { return id; }
 
-        public Team getTeam();
-
-        public enum Value implements PermanentProperty {
-            ID(String.class, ""),
-            NAME(String.class, "");
-
-            private Value(Class<?> t, Object dv) { type = t; defaultValue = dv; }
-            private final Class<?> type;
-            private final Object defaultValue;
-            @Override
-            public Class<?> getType() { return type; }
-            @Override
-            public Object getDefaultValue() { return defaultValue; }
-       }
-
-        public static final String ID_OPERATOR = "operator";
-        public static final String ID_OVERLAY = "overlay";
-        public static final String ID_TWITTER = "twitter";
-    };
-
-    public static interface Color extends ScoreBoardEventProvider {
-        public String getColor();
-        public void setColor(String c);
-
-        public Team getTeam();
-
-        public enum Value implements PermanentProperty {
-            ID(String.class, ""),
-            COLOR(String.class, "");
-
-            private Value(Class<?> t, Object dv) { type = t; defaultValue = dv; }
-            private final Class<?> type;
-            private final Object defaultValue;
-            @Override
-            public Class<?> getType() { return type; }
-            @Override
-            public Object getDefaultValue() { return defaultValue; }
-        }
+        private String id;
     }
 
     public static interface TeamSnapshot {

--- a/src/com/carolinarollergirls/scoreboard/core/impl/TeamImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/impl/TeamImpl.java
@@ -32,6 +32,7 @@ import com.carolinarollergirls.scoreboard.event.ScoreBoardEvent.PermanentPropert
 import com.carolinarollergirls.scoreboard.event.ScoreBoardEvent.ValueWithId;
 import com.carolinarollergirls.scoreboard.event.ScoreBoardListener;
 import com.carolinarollergirls.scoreboard.rules.Rule;
+import com.carolinarollergirls.scoreboard.utils.ValWithId;
 
 public class TeamImpl extends ScoreBoardEventProviderImpl implements Team {
     public TeamImpl(ScoreBoard sb, String i) {
@@ -122,18 +123,13 @@ public class TeamImpl extends ScoreBoardEventProviderImpl implements Team {
     public ValueWithId create(AddRemoveProperty prop, String id) {
         synchronized (coreLock) {
             switch((Child)prop) {
-            case ALTERNATE_NAME:
-                return new AlternateNameImpl(this, id, "");
-            case COLOR:
-                return new ColorImpl(this, id, "");
             case SKATER:
                 return new SkaterImpl(this, id, "", "", "");
-            case POSITION:
-                return null;
             case BOX_TRIP:
                 return new BoxTripImpl(this, id);
+            default:
+                return null;
             }
-            return null;
         }
     }
 
@@ -262,30 +258,32 @@ public class TeamImpl extends ScoreBoardEventProviderImpl implements Team {
     }
 
     @Override
-    public AlternateName getAlternateName(String i) { return (AlternateName)get(Child.ALTERNATE_NAME, i); }
+    public String getAlternateName(String i) { return get(Child.ALTERNATE_NAME, i).getValue(); }
+    @Override
+    public String getAlternateName(AlternateNameId id) { return getAlternateName(id.toString()); }
     @Override
     public void setAlternateName(String i, String n) {
         synchronized (coreLock) {
             requestBatchStart();
-            ((AlternateName)getOrCreate(Child.ALTERNATE_NAME, i)).setName(n);
+            add(Child.ALTERNATE_NAME, new ValWithId(i, n));
             requestBatchEnd();
         }
     }
     @Override
-    public void removeAlternateName(String i) { remove(Child.ALTERNATE_NAME, getAlternateName(i)); }
+    public void removeAlternateName(String i) { remove(Child.ALTERNATE_NAME, i); }
 
     @Override
-    public Color getColor(String i) { return (Color)get(Child.COLOR, i); }
+    public String getColor(String i) { return get(Child.COLOR, i).getValue(); }
     @Override
     public void setColor(String i, String c) {
         synchronized (coreLock) {
             requestBatchStart();
-            ((Color)getOrCreate(Child.COLOR, i)).setColor(c);
+            add(Child.COLOR, new ValWithId(i, c));
             requestBatchEnd();
         }
     }
     @Override
-    public void removeColor(String i) { remove(Child.COLOR, getColor(i)); }
+    public void removeColor(String i) { remove(Child.COLOR, i); }
 
     @Override
     public String getLogo() { return (String)get(Value.LOGO); }
@@ -533,40 +531,6 @@ public class TeamImpl extends ScoreBoardEventProviderImpl implements Team {
 
     public static final String DEFAULT_NAME_PREFIX = "Team ";
     public static final String DEFAULT_LOGO = "";
-
-    public class AlternateNameImpl extends ScoreBoardEventProviderImpl implements AlternateName {
-        public AlternateNameImpl(Team t, String i, String n) {
-            super(t, Value.ID, i, Team.Child.ALTERNATE_NAME, AlternateName.class, Value.class);
-            team = t;
-            setName(n);
-        }
-        @Override
-        public String getName() { return (String)get(Value.NAME); }
-        @Override
-        public void setName(String n) { set(Value.NAME, n); }
-
-        @Override
-        public Team getTeam() { return team; }
-
-        protected Team team;
-    }
-
-    public class ColorImpl extends ScoreBoardEventProviderImpl implements Color {
-        public ColorImpl(Team t, String i, String c) {
-            super(t, Value.ID, i, Team.Child.COLOR, Color.class, Value.class);
-            team = t;
-            setColor(c);
-        }
-        @Override
-        public String getColor() { return (String)get(Value.COLOR); }
-        @Override
-        public void setColor(String c) { set(Value.COLOR, c); }
-
-        @Override
-        public Team getTeam() { return team; }
-
-        protected Team team;
-    }
 
     public static class TeamSnapshotImpl implements TeamSnapshot {
         private TeamSnapshotImpl(Team team) {

--- a/src/com/carolinarollergirls/scoreboard/viewer/FormatSpecifierViewer.java
+++ b/src/com/carolinarollergirls/scoreboard/viewer/FormatSpecifierViewer.java
@@ -208,11 +208,11 @@ public class FormatSpecifierViewer {
             @Override
             public String getValue() { return getTeam(id).getName(); }
         };
-        new ScoreBoardValue("%t"+t+"Nt", "Team "+t+" Twitter Name", Team.AlternateName.class, Team.AlternateName.ID_TWITTER, Team.AlternateName.Value.NAME) {
+        new ScoreBoardValue("%t"+t+"Nt", "Team "+t+" Twitter Name", getTeam(id), Team.Child.ALTERNATE_NAME) {
             @Override
             public String getValue() {
                 try {
-                    return getTeam(id).getAlternateName(Team.AlternateName.ID_TWITTER).getName();
+                    return getTeam(id).getAlternateName(Team.AlternateNameId.TWITTER);
                 } catch ( NullPointerException npE ) {
                     return getTeam(id).getName();
                 }

--- a/src/com/carolinarollergirls/scoreboard/xml/TeamsXmlDocumentManager.java
+++ b/src/com/carolinarollergirls/scoreboard/xml/TeamsXmlDocumentManager.java
@@ -18,6 +18,7 @@ import org.jdom.xpath.XPath;
 
 import com.carolinarollergirls.scoreboard.core.Skater;
 import com.carolinarollergirls.scoreboard.core.Team;
+import com.carolinarollergirls.scoreboard.event.ScoreBoardEvent.ValueWithId;
 
 /**
  * This allows storing team info, e.g. name, logo, roster, etc., separate from the actual teams
@@ -127,17 +128,11 @@ public class TeamsXmlDocumentManager extends DefaultXmlDocumentManager implement
         if (null == alternateNameId || "".equals(alternateNameId.trim())) {
             return;
         }
-        Element newAlternateName = editor.addElement(newTeam, "AlternateName", alternateNameId);
+        Element newAlternateName = editor.addElement(newTeam, "AlternateName", alternateNameId, editor.getText(alternateName));
 
         if (editor.hasRemovePI(alternateName)) {
             Element removeAlternateNameTeam = editor.addElement(createXPathElement(), "Team", newTeam.getAttributeValue("Id"));
             update(removeAlternateNameTeam.addContent(editor.setRemovePI((Element)newAlternateName.detach())));
-            return;
-        }
-
-        Element aName = alternateName.getChild("Name");
-        if (null != aName) {
-            editor.addElement(newAlternateName, "Name", null, editor.getText(aName));
         }
     }
 
@@ -146,17 +141,11 @@ public class TeamsXmlDocumentManager extends DefaultXmlDocumentManager implement
         if (null == colorId || "".equals(colorId.trim())) {
             return;
         }
-        Element newColor = editor.addElement(newTeam, "Color", colorId);
+        Element newColor = editor.addElement(newTeam, "Color", colorId, editor.getText(color));
 
         if (editor.hasRemovePI(color)) {
             Element removeColorTeam = editor.addElement(createXPathElement(), "Team", newTeam.getAttributeValue("Id"));
             update(removeColorTeam.addContent(editor.setRemovePI((Element)newColor.detach())));
-            return;
-        }
-
-        Element cColor = color.getChild("Color");
-        if (null != cColor) {
-            editor.addElement(newColor, "Color", null, editor.getText(cColor));
         }
     }
 
@@ -229,7 +218,7 @@ public class TeamsXmlDocumentManager extends DefaultXmlDocumentManager implement
                 continue;
             }
             String aName = "";
-            aName = editor.getText(alternateName.getChild("Name"));
+            aName = editor.getText(alternateName);
             team.setAlternateName(aId, aName);
         }
         Iterator<?> colors = newTeam.getChildren("Color").iterator();
@@ -240,7 +229,7 @@ public class TeamsXmlDocumentManager extends DefaultXmlDocumentManager implement
                 continue;
             }
             String cColor = "";
-            cColor = editor.getText(color.getChild("Color"));
+            cColor = editor.getText(color);
             team.setColor(cId, cColor);
         }
         Iterator<?> skaters = newTeam.getChildren("Skater").iterator();
@@ -274,17 +263,11 @@ public class TeamsXmlDocumentManager extends DefaultXmlDocumentManager implement
         createXPathElement().addContent(newTeam);
         editor.addElement(newTeam, "Name", null, team.getName());
         editor.addElement(newTeam, "Logo", null, team.getLogo());
-        Iterator<?> alternateNames = team.getAll(Team.Child.ALTERNATE_NAME).iterator();
-        while (alternateNames.hasNext()) {
-            Team.AlternateName alternateName = (Team.AlternateName)alternateNames.next();
-            Element newAlternateName = editor.addElement(newTeam, "AlternateName", alternateName.getId());
-            editor.addElement(newAlternateName, "Name", null, alternateName.getName());
+        for (ValueWithId alternateName : team.getAll(Team.Child.ALTERNATE_NAME)) {
+            editor.addElement(newTeam, "AlternateName", alternateName.getId(), alternateName.getValue());
         }
-        Iterator<?> colors = team.getAll(Team.Child.COLOR).iterator();
-        while (colors.hasNext()) {
-            Team.Color color = (Team.Color)colors.next();
-            Element newColor = editor.addElement(newTeam, "Color", color.getId());
-            editor.addElement(newColor, "Color", null, color.getColor());
+        for (ValueWithId color : team.getAll(Team.Child.COLOR)) {
+            editor.addElement(newTeam, "Color", color.getId(), color.getValue());
         }
         Iterator<?> skaters = team.getAll(Team.Child.SKATER).iterator();
         while (skaters.hasNext()) {

--- a/tests/com/carolinarollergirls/scoreboard/json/ScoreBoardJSONListenerTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/json/ScoreBoardJSONListenerTests.java
@@ -158,21 +158,21 @@ public class ScoreBoardJSONListenerTests {
 
         sb.getTeam("1").setAlternateName("overlay", "AT");
         advance(0);
-        assertEquals("AT", state.get("ScoreBoard.Team(1).AlternateName(overlay).Name"));
+        assertEquals("AT", state.get("ScoreBoard.Team(1).AlternateName(overlay)"));
 
         sb.getTeam("1").setAlternateName("overlay", "AT");
         advance(0);
-        assertEquals("AT", state.get("ScoreBoard.Team(1).AlternateName(overlay).Name"));
+        assertEquals("AT", state.get("ScoreBoard.Team(1).AlternateName(overlay)"));
         sb.getTeam("1").removeAlternateName("overlay");
         advance(0);
-        assertEquals(null, state.get("ScoreBoard.Team(1).AlternateName(overlay).Name"));
+        assertEquals(null, state.get("ScoreBoard.Team(1).AlternateName(overlay)"));
 
         sb.getTeam("1").setColor("overlay", "red");
         advance(0);
-        assertEquals("red", state.get("ScoreBoard.Team(1).Color(overlay).Color"));
+        assertEquals("red", state.get("ScoreBoard.Team(1).Color(overlay)"));
         sb.getTeam("1").removeColor("overlay");
         advance(0);
-        assertEquals(null, state.get("ScoreBoard.Team(1).Color(overlay).Color"));
+        assertEquals(null, state.get("ScoreBoard.Team(1).Color(overlay)"));
     }
 
     @Test


### PR DESCRIPTION
They are just key value pairs, no need to have an extra class for each.

This changes the API for the elements to what it was in WS in 3.9.5
(Team(t).AlternateName and Team(t).Color - the additional .Name resp.
.Color is removed)