### PR TITLE
Ignore accidental double clicks on Jam/TO controls

### DIFF
--- a/tests/com/carolinarollergirls/scoreboard/core/impl/ScoreboardImplTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/core/impl/ScoreboardImplTests.java
@@ -706,9 +706,16 @@ public class ScoreboardImplTests {
         assertFalse(tc.isRunning());
         assertTrue(ic.isCountDirectionDown());
         ic.setMaximumTime(900000);
-        ic.setTime(880000);
+        ic.setTime(ic.getMaximumTime() - 500);
         assertTrue(ic.isRunning());
 
+        sb.stopJamTO();
+        
+        // less than 1s of intermission has passed, stopJamTO should be ignored
+        assertFalse(lc.isRunning());
+        assertTrue(ic.isRunning());
+        
+        advance(20000);
         sb.stopJamTO();
 
         assertEquals(ScoreBoard.ACTION_LINEUP, sb.snapshot.getType());
@@ -866,7 +873,7 @@ public class ScoreboardImplTests {
         tc.setTime(24000);
         tc.setNumber(7);
         assertFalse(ic.isRunning());
-        sb.setTimeoutOwner(TimeoutOwners.NONE);
+        sb.setTimeoutOwner(TimeoutOwners.OTO);
 
         sb.timeout();
 
@@ -881,8 +888,18 @@ public class ScoreboardImplTests {
         assertEquals(TimeoutOwners.NONE, sb.getTimeoutOwner());
         checkLabels(ScoreBoard.ACTION_START_JAM, ScoreBoard.ACTION_STOP_TO, ScoreBoard.ACTION_RE_TIMEOUT, ScoreBoard.UNDO_PREFIX + ScoreBoard.ACTION_RE_TIMEOUT);
 
+        sb.setTimeoutOwner(TimeoutOwners.OTO);
         sb.timeout();
 
+        // timeout was entered with less than 1s on the TO clock
+        // and should be ignored
+        assertEquals(8, tc.getNumber());
+        assertEquals(TimeoutOwners.OTO, sb.getTimeoutOwner());
+        
+        advance(1500);
+        sb.timeout();
+        
+        assertEquals(9, tc.getNumber());
         assertEquals(TimeoutOwners.NONE, sb.getTimeoutOwner());
     }
 


### PR DESCRIPTION
They mess up undo and confuse people.
This also prevents the lineup clock from starting when the operator
tries to end the last jam after the software already did so.