### PR TITLE
Don't show Lead after halftime

### DIFF
--- a/html/views/standard/common.js
+++ b/html/views/standard/common.js
@@ -8,9 +8,10 @@ function jammer(k, v) {
 	var pivotName = WS.state[prefix + "Skater(" + pivotId + ").Name"];
 	var leadJammer = isTrue(WS.state[prefix + "DisplayLead"]);
 	var starPass = isTrue(WS.state[prefix + "StarPass"]);
+	var inJam = isTrue(WS.state["ScoreBoard.InJam"]);
 
 	if (jammerName == null)
-		jammerName = leadJammer ? "Lead" : "";
+		jammerName = (leadJammer && inJam) ? "Lead" : "";
 	if (pivotName == null)
 		pivotName = "";
 
@@ -171,3 +172,4 @@ WS.Register( [
 	"ScoreBoard.Clock(Intermission).Running" ], function(k, v) { clockRunner(k,v); } );
 
 WS.Register( 'ScoreBoard.Rulesets.CurrentRule(Period.Number)' );
+WS.Register( 'ScoreBoard.InJam' );


### PR DESCRIPTION
When the intermission clock has run down and the new period hasn't
started, current HEAD shows "Lead" for the team that had it in the last
Jam of the previous period.