### PR TITLE
Attach new Jams to the upcoming period after half of intermission

### DIFF
--- a/src/com/carolinarollergirls/scoreboard/core/impl/ScoreBoardImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/impl/ScoreBoardImpl.java
@@ -548,9 +548,9 @@ public class ScoreBoardImpl extends ScoreBoardEventProviderImpl implements Score
         requestBatchStart();
         ic.stop();
         if (getCurrentPeriodNumber() == 0 || 
-                (ic.getTimeRemaining() < 60000 
+                (ic.getTimeRemaining() < ic.getTimeElapsed() 
                         && pc.getNumber() < getRulesets().getInt(Rule.NUMBER_PERIODS))) {
-            //If less than one minute of intermission is left and there is another period,
+            //If less than half of intermission is left and there is another period,
             // go to the next period. Otherwise extend the previous period.
             //Always start period 1 as there is no previous period to extend.
             _preparePeriod();


### PR DESCRIPTION
This is more natural than tipping over 1 minute before intermission is over.
(I wanted to go to the middle already when I moved to the 1 minute spot but determining the middle of intermission was not reliably possible with the code back then.)