### PR TITLE
Restructure SkaterImpl constructor

### DIFF
--- a/src/com/carolinarollergirls/scoreboard/core/Team.java
+++ b/src/com/carolinarollergirls/scoreboard/core/Team.java
@@ -66,7 +66,6 @@ public interface Team extends ScoreBoardEventProvider, TimeoutOwner {
 
     public Skater getSkater(String id);
     public void addSkater(Skater skater);
-    public Skater addSkater(String id, String name, String number, String flag);
     public void removeSkater(String id);
 
     public Position getPosition(FloorPosition fp);

--- a/src/com/carolinarollergirls/scoreboard/core/impl/SkaterImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/impl/SkaterImpl.java
@@ -18,6 +18,7 @@ import com.carolinarollergirls.scoreboard.core.Fielding;
 import com.carolinarollergirls.scoreboard.core.FloorPosition;
 import com.carolinarollergirls.scoreboard.core.Penalty;
 import com.carolinarollergirls.scoreboard.core.Position;
+import com.carolinarollergirls.scoreboard.core.PreparedTeam.PreparedTeamSkater;
 import com.carolinarollergirls.scoreboard.core.Role;
 import com.carolinarollergirls.scoreboard.core.Skater;
 import com.carolinarollergirls.scoreboard.core.Team;
@@ -28,13 +29,22 @@ import com.carolinarollergirls.scoreboard.event.ScoreBoardEvent.PermanentPropert
 import com.carolinarollergirls.scoreboard.event.ScoreBoardEvent.ValueWithId;
 
 public class SkaterImpl extends ScoreBoardEventProviderImpl implements Skater {
-    public SkaterImpl(Team t, String i, String n, String num, String flags) {
+    public SkaterImpl(Team t, String i) {
         super(t, Value.ID, (i == null ? UUID.randomUUID().toString() : i),
                 Team.Child.SKATER, Skater.class, Value.class, Child.class, NChild.class);
         team = t;
-        setName(n);
-        setNumber(num);
-        setFlags(flags);
+        initialize();
+    }
+    public SkaterImpl(Team t, PreparedTeamSkater pts) {
+        super(t, Value.ID, pts.getId(),
+                Team.Child.SKATER, Skater.class, Value.class, Child.class, NChild.class);
+        team = t;
+        setName((String)pts.get(PreparedTeamSkater.Value.NAME));
+        setNumber((String)pts.get(PreparedTeamSkater.Value.NUMBER));
+        setFlags((String)pts.get(PreparedTeamSkater.Value.FLAGS));
+        initialize();
+    }
+    private void initialize() {
         set(Value.BASE_ROLE, Role.BENCH);
         set(Value.ROLE, Role.BENCH);
         setInverseReference(Child.FIELDING, Fielding.Value.SKATER);

--- a/src/com/carolinarollergirls/scoreboard/core/impl/TeamImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/impl/TeamImpl.java
@@ -152,7 +152,7 @@ public class TeamImpl extends ScoreBoardEventProviderImpl implements Team {
         synchronized (coreLock) {
             switch((Child)prop) {
             case SKATER:
-                return new SkaterImpl(this, id, "", "", "");
+                return new SkaterImpl(this, id);
             case BOX_TRIP:
                 return new BoxTripImpl(this, id);
             default:
@@ -338,11 +338,7 @@ public class TeamImpl extends ScoreBoardEventProviderImpl implements Team {
                 setColor(v.getId(), v.getValue());
             }
             for (ValueWithId v : pt.getAll(PreparedTeam.Child.SKATER)) {
-              PreparedTeamSkater s = (PreparedTeamSkater)v;
-                addSkater(s.getId(), 
-                    (String)s.get(PreparedTeamSkater.Value.NAME),
-                    (String)s.get(PreparedTeamSkater.Value.NUMBER),
-                    (String)s.get(PreparedTeamSkater.Value.FLAGS));
+                addSkater(new SkaterImpl(this, (PreparedTeamSkater)v));
             }
             requestBatchEnd();
         }
@@ -451,14 +447,6 @@ public class TeamImpl extends ScoreBoardEventProviderImpl implements Team {
     @Override
     public Skater getSkater(String id) { return (Skater)get(Child.SKATER, id); }
     public Skater addSkater(String id) { return (Skater)getOrCreate(Child.SKATER, id); }
-    @Override
-    public Skater addSkater(String id, String n, String num, String flags) {
-        synchronized (coreLock) {
-            Skater s = new SkaterImpl(this, id, n, num, flags);
-            addSkater(s);
-            return s;
-        }
-    }
     @Override
     public void addSkater(Skater skater) { add(Child.SKATER, skater); }
     @Override

--- a/tests/com/carolinarollergirls/scoreboard/core/impl/FieldingImplTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/core/impl/FieldingImplTests.java
@@ -66,7 +66,9 @@ public class FieldingImplTests {
 
     @Test
     public void testSortBoxTripSymbols() {
-        Skater s = sb.getTeam(Team.ID_1).addSkater("SkaterId", "Name", "3", null);
+        Team t = sb.getTeam(Team.ID_1);
+        Skater s = new SkaterImpl(t, (String)null);
+        t.addSkater(s);
         sb.startJam();
         sb.getTeam(Team.ID_1).field(s, Role.PIVOT);
         s.setPenaltyBox(true);

--- a/tests/com/carolinarollergirls/scoreboard/core/impl/PositionImplTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/core/impl/PositionImplTests.java
@@ -33,9 +33,9 @@ public class PositionImplTests {
 
         team = sb.getTeam(Team.ID_1);
 
-        first = new SkaterImpl(team, firstId, "First","123", "");
-        second = new SkaterImpl(team, secondId, "Second","456", "");
-        third = new SkaterImpl(team, thirdId, "Third","789","");
+        first = new SkaterImpl(team, firstId);
+        second = new SkaterImpl(team, secondId);
+        third = new SkaterImpl(team, thirdId);
 
         team.addSkater(first);
         team.addSkater(second);

--- a/tests/com/carolinarollergirls/scoreboard/core/impl/SkaterImplTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/core/impl/SkaterImplTests.java
@@ -31,7 +31,7 @@ public class SkaterImplTests {
         team = sb.getTeam(Team.ID_1);
         skaterId = UUID.randomUUID();
 
-        skater = new SkaterImpl(team, skaterId.toString(), "Test Skater", "123", "");
+        skater = new SkaterImpl(team, skaterId.toString());
         sb.getOrCreatePeriod(1).getOrCreate(Period.NChild.JAM, "2");
         sb.getOrCreatePeriod(1).getOrCreate(Period.NChild.JAM, "3");
         sb.getOrCreatePeriod(1).getOrCreate(Period.NChild.JAM, "4");

--- a/tests/com/carolinarollergirls/scoreboard/core/impl/StatsImplTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/core/impl/StatsImplTests.java
@@ -42,7 +42,7 @@ public class StatsImplTests {
             Team t = sb.getTeam(tid);
             for (int i = 0; i <= 15; i++) {
                 String number = String.format("%s%02d", tid, i);
-                t.addSkater(ID_PREFIX + number, "name-" + number, number, "");
+                t.addSkater(new SkaterImpl(t, ID_PREFIX + number));
             }
         }
         team1 = sb.getTeam(Team.ID_1);

--- a/tests/com/carolinarollergirls/scoreboard/core/impl/TeamImplTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/core/impl/TeamImplTests.java
@@ -271,13 +271,19 @@ public class TeamImplTests {
     @Test
     public void testField() {
         team.execute(Team.Command.ADVANCE_FIELDINGS);
-        Skater skater1 = team.addSkater("S1", "One", "1", "");
-        Skater skater2 = team.addSkater("S2", "Two", "2", "");
-        Skater skater3 = team.addSkater("S3", "Three", "3", "");
-        Skater skater4 = team.addSkater("S4", "Four", "4", "");
-        Skater skater5 = team.addSkater("S5", "Five", "5", "");
-        Skater skater6 = team.addSkater("S6", "Six", "6", "");
-
+        Skater skater1 = new SkaterImpl(team, "S1");
+        Skater skater2 = new SkaterImpl(team, "S2");
+        Skater skater3 = new SkaterImpl(team, "S3");
+        Skater skater4 = new SkaterImpl(team, "S4");
+        Skater skater5 = new SkaterImpl(team, "S5");
+        Skater skater6 = new SkaterImpl(team, "S6");
+        team.addSkater(skater1);
+        team.addSkater(skater2);
+        team.addSkater(skater3);
+        team.addSkater(skater4);
+        team.addSkater(skater5);
+        team.addSkater(skater6);
+        
         team.field(skater1, Role.JAMMER);
         team.field(skater2, Role.PIVOT);
         team.field(skater3, Role.BLOCKER);
@@ -453,7 +459,8 @@ public class TeamImplTests {
 
     @Test
     public void testFieldPivot() {
-        Skater skater1 = team.addSkater("S1", "One", "1", "");
+        Skater skater1 = new SkaterImpl(team, "S1");
+        team.addSkater(skater1);
         
         sb.startJam();
         sb.stopJamTO();

--- a/tests/com/carolinarollergirls/scoreboard/json/ScoreBoardJSONListenerTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/json/ScoreBoardJSONListenerTests.java
@@ -26,6 +26,7 @@ import com.carolinarollergirls.scoreboard.core.Team.Value;
 import com.carolinarollergirls.scoreboard.core.Penalty;
 import com.carolinarollergirls.scoreboard.core.impl.RulesetsImpl;
 import com.carolinarollergirls.scoreboard.core.impl.ScoreBoardImpl;
+import com.carolinarollergirls.scoreboard.core.impl.SkaterImpl;
 import com.carolinarollergirls.scoreboard.event.ScoreBoardEvent.ValueWithId;
 import com.carolinarollergirls.scoreboard.rules.Rule;
 import com.carolinarollergirls.scoreboard.utils.ScoreBoardClock;
@@ -184,7 +185,11 @@ public class ScoreBoardJSONListenerTests {
 
         String id = "00000000-0000-0000-0000-000000000001";
 
-        sb.getTeam("1").addSkater(id, "Uno", "01", "");
+        Team t = sb.getTeam("1");
+        Skater s = new SkaterImpl(t, id);
+        s.setName("Uno");
+        s.setNumber("01");
+        t.addSkater(s);
         advance(0);
         assertEquals("Uno", state.get("ScoreBoard.Team(1).Skater(00000000-0000-0000-0000-000000000001).Name"));
         assertEquals("01", state.get("ScoreBoard.Team(1).Skater(00000000-0000-0000-0000-000000000001).Number"));
@@ -193,8 +198,8 @@ public class ScoreBoardJSONListenerTests {
         assertEquals("Bench", state.get("ScoreBoard.Team(1).Skater(00000000-0000-0000-0000-000000000001).Role"));
         assertEquals(false, state.get("ScoreBoard.Team(1).Skater(00000000-0000-0000-0000-000000000001).PenaltyBox"));
 
-        sb.getTeam("1").field(sb.getTeam("1").getSkater(id), Role.JAMMER);
-        sb.getTeam("1").getSkater(id).setPenaltyBox(true);
+        t.field(s, Role.JAMMER);
+        s.setPenaltyBox(true);
         advance(0);
         assertEquals("1_Jammer", state.get("ScoreBoard.Team(1).Skater(00000000-0000-0000-0000-000000000001).Position"));
         assertEquals("Jammer", state.get("ScoreBoard.Team(1).Skater(00000000-0000-0000-0000-000000000001).Role"));
@@ -202,7 +207,7 @@ public class ScoreBoardJSONListenerTests {
         assertEquals("00000000-0000-0000-0000-000000000001", state.get("ScoreBoard.Team(1).Position(Jammer).Skater"));
         assertEquals(true, state.get("ScoreBoard.Team(1).Position(Jammer).PenaltyBox"));
 
-        sb.getTeam("1").removeSkater(id);
+        t.removeSkater(id);
         advance(0);
         assertEquals(null, state.get("ScoreBoard.Team(1).Skater(00000000-0000-0000-0000-000000000001).Name"));
         assertEquals(null, state.get("ScoreBoard.Team(1).Skater(00000000-0000-0000-0000-000000000001).Number"));
@@ -219,8 +224,11 @@ public class ScoreBoardJSONListenerTests {
         String sid = "00000000-0000-0000-0000-000000000001";
         String pid;
 
-        sb.getTeam("1").addSkater(sid, "Uno", "01", "");
-        Skater s = sb.getTeam("1").getSkater(sid);
+        Team t = sb.getTeam("1");
+        Skater s = new SkaterImpl(t, sid);
+        s.setName("Uno");
+        s.setNumber("01");
+        t.addSkater(s);
         Penalty p = (Penalty)s.getOrCreate(NChild.PENALTY, "1");
         pid = p.getId();
         p.set(Penalty.Value.JAM, sb.getOrCreatePeriod(1).getOrCreate(Period.NChild.JAM, "2"));
@@ -257,8 +265,12 @@ public class ScoreBoardJSONListenerTests {
     public void testStatsEvents() {
         String id = "00000000-0000-0000-0000-000000000001";
 
-        sb.getTeam("1").addSkater(id, "Uno", "01", "");
-        sb.getTeam("1").field(sb.getTeam("1").getSkater(id), Role.JAMMER);
+        Team t = sb.getTeam("1");
+        Skater s = new SkaterImpl(t, id);
+        s.setName("Uno");
+        s.setNumber("01");
+        t.addSkater(s);
+        t.field(s, Role.JAMMER);
         sb.startJam();
         advance(2000);
 
@@ -271,16 +283,16 @@ public class ScoreBoardJSONListenerTests {
         assertEquals(false, state.get("ScoreBoard.Period(1).Jam(1).TeamJam(1).Fielding(Jammer).PenaltyBox"));
         assertEquals("1_Jammer", state.get("ScoreBoard.Period(1).Jam(1).TeamJam(1).Fielding(Jammer).Position"));
 
-        sb.getTeam("1").field(sb.getTeam("1").getSkater(id), Role.BENCH);
+        t.field(s, Role.BENCH);
         advance(0);
         assertEquals(null, state.get("ScoreBoard.Period(1).Jam(1).TeamJam(1).Fielding(Jammer).Skater"));
         assertEquals(false, state.get("ScoreBoard.Period(1).Jam(1).TeamJam(1).Fielding(Jammer).PenaltyBox"));
         assertEquals("1_Jammer", state.get("ScoreBoard.Period(1).Jam(1).TeamJam(1).Fielding(Jammer).Position"));
 
-        sb.getTeam("1").field(sb.getTeam("1").getSkater(id), Role.JAMMER);
+        t.field(s, Role.JAMMER);
         advance(0);
         assertEquals("00000000-0000-0000-0000-000000000001", state.get("ScoreBoard.Period(1).Jam(1).TeamJam(1).Fielding(Jammer).Skater"));
-        sb.getTeam("1").removeSkater(id);
+        t.removeSkater(id);
         advance(0);
         assertEquals(null, state.get("ScoreBoard.Period(1).Jam(1).TeamJam(1).Fielding(Jammer).Skater"));
         assertEquals(false, state.get("ScoreBoard.Period(1).Jam(1).TeamJam(1).Fielding(Jammer).PenaltyBox"));


### PR DESCRIPTION
They now follow the scheme of the other elments. (Previous structure was
differing in order to not break compatibility with XML team assignment which is now gone.)