### PR TITLE
Match full components of WS paths

### DIFF
--- a/html/json/WS.js
+++ b/html/json/WS.js
@@ -278,8 +278,9 @@ var WS = {
 	},
 
 	_addToTrie: function(t, key, value) {
-		for (var i = 0; i < key.length; i++) {
-			var c = key.charAt(i);
+		var p = key.split(/[.(]/);
+		for (var i = 0; i < p.length; i++) {
+			var c = p[i];
 			t[c] = t[c] || {};
 			t = t[c];
 		}
@@ -288,20 +289,25 @@ var WS = {
 	},
 
 	_getMatchesFromTrie: function(t, key) {
-		var result = t.values || [];
-		for (var i = 0; i < key.length; i++) {
-			var c = key.charAt(i);
-			t = t[c];
-			if (t == null) {
-				break;
+		function matches(t, p, i) {
+			var result = t.values || [];
+			for (; i < p.length; i++) {
+				if (t["*)"] != null) {
+					// Allow Blah(*) as a wildcard.
+					var j;
+					for (j = i; j < p.length && !p[j].endsWith(")"); j++);
+					result = result.concat(matches(t["*)"], p, j+1) || []);
+				}
+				t = t[p[i]];
+				if (t == null) {
+					break;
+				}
+				result = result.concat(t.values || []);
 			}
-			if (c == "(" && t["*"] != null) {
-				// Allow Blah(*) as a wildcard.
-				result = result.concat(WS._getMatchesFromTrie(t["*"], key.substring(key.indexOf(")", i))) || []);
-			}
-			result = result.concat(t.values || []);
-		}
-		return result;
+			return result;
+		};
+		
+		return matches(t, key.split(/[.(]/), 0);
 	},
 
 	getPaths: function(elem, attr) {

--- a/html/json/WS.js
+++ b/html/json/WS.js
@@ -295,6 +295,7 @@ var WS = {
 				if (t["*)"] != null) {
 					// Allow Blah(*) as a wildcard.
 					var j;
+					// id captured by * might contain . and thus be split - find the end
 					for (j = i; j < p.length && !p[j].endsWith(")"); j++);
 					result = result.concat(matches(t["*)"], p, j+1) || []);
 				}

--- a/html/views/overlays/interactive/admin.js
+++ b/html/views/overlays/interactive/admin.js
@@ -58,15 +58,16 @@ function initialize() {
 		}	
 	});
 
-	WS.Register(['ScoreBoard.Settings.Setting(Overlay.Interactive.LowerThird.Line',
-	'ScoreBoard.Team(1).AlternateName(overlay)',
-	'ScoreBoard.Team(2).AlternateName(overlay)'],
+	WS.Register(['ScoreBoard.Settings.Setting(Overlay.Interactive.LowerThird.Line1)',
+		'ScoreBoard.Settings.Setting(Overlay.Interactive.LowerThird.Line2)',
+		'ScoreBoard.Team(1).AlternateName(overlay)',
+		'ScoreBoard.Team(2).AlternateName(overlay)'],
 				function(k,v) { $('input[data-setting="'+k+'"]').val(v); });
 
 	WS.Register(['ScoreBoard.Team(1).Color(overlay_fg)',
-	'ScoreBoard.Team(1).Color(overlay_bg)',
-	'ScoreBoard.Team(2).Color(overlay_fg)',
-	'ScoreBoard.Team(2).Color(overlay_bg)'],
+		'ScoreBoard.Team(1).Color(overlay_bg)',
+		'ScoreBoard.Team(2).Color(overlay_fg)',
+		'ScoreBoard.Team(2).Color(overlay_bg)'],
 				function(k,v) {
 					if (v == null || v == "") {
 						$('input[data-setting="'+k+'"]').attr("cleared", "true");

--- a/html/views/overlays/interactive/index.js
+++ b/html/views/overlays/interactive/index.js
@@ -130,7 +130,8 @@ function initialize() {
 		$('.OverlayPanel.' + v).addClass('Show');
 	});
 
-	WS.Register([ 'ScoreBoard.Settings.Setting(Overlay.Interactive.LowerThird.Line' ] , function(k,v) {
+	WS.Register([ 'ScoreBoard.Settings.Setting(Overlay.Interactive.LowerThird.Line1)',
+		'ScoreBoard.Settings.Setting(Overlay.Interactive.LowerThird.Line2)' ] , function(k,v) {
 		sp = '.' + k.split('.').slice(4,6).join(' .').slice(0, -1);
 		$(sp).text(v);
 	});

--- a/src/com/carolinarollergirls/scoreboard/jetty/WS.java
+++ b/src/com/carolinarollergirls/scoreboard/jetty/WS.java
@@ -326,6 +326,7 @@ public class WS extends WebSocketServlet {
                 // Allow Blah(*).
                 if (head.trie.containsKey("*)")) {
                     int j;
+                    // id captured by * might contain . and thus be split - find the end
                     for (j = i; j < p.length && !p[j].endsWith(")"); j++);
                     if (head.trie.get("*)")._covers(p, j+1)) {
                         return true;

--- a/src/com/carolinarollergirls/scoreboard/jetty/WS.java
+++ b/src/com/carolinarollergirls/scoreboard/jetty/WS.java
@@ -289,56 +289,53 @@ public class WS extends WebSocketServlet {
     }
 
     protected static class PathTrie {
-      boolean exists = false;
-      Map<Character, PathTrie> trie = new HashMap<>();
+        boolean exists = false;
+        Map<String, PathTrie> trie = new HashMap<>();
 
-      public void addAll(Set<String> c) {
-        for (String p: c) {
-          add(p);
-        }
-      }
-      public void add(String p) {
-        PathTrie head = this;
-        for (int i = 0;; i++) {
-          if (head.exists) {
-            // Already covered.
-            return;
-          }
-          if (i >= p.length()) {
-            break;
-          }
-          if (head.trie.containsKey(p.charAt(i))) {
-             head = head.trie.get(p.charAt(i));
-          } else {
-             PathTrie child = new PathTrie();
-             head.trie.put(p.charAt(i), child);
-             head = child;
-          }
-        }
-        head.exists = true;
-      }
-      public boolean covers(String p) {
-        PathTrie head = this;
-        for (int i = 0;; i++) {
-          if (head.exists) {
-            return true;
-          }
-          if (i >= p.length()) {
-            return false;
-          }
-          Character c = p.charAt(i);
-          head = head.trie.get(c);
-          if (head == null) {
-            return false;
-          }
-          // Allow Blah(*).
-          if (c == '(' && head.trie.containsKey('*')) {
-            int closeIndex = p.indexOf(')', i);
-            if (closeIndex != -1 && head.trie.get('*').covers(p.substring(closeIndex))) {
-              return true;
+        public void addAll(Set<String> c) {
+            for (String p: c) {
+                add(p);
             }
-          }
         }
-      }
+        public void add(String path) {
+            String[] p = path.split("[.(]");
+            PathTrie head = this;
+            for (int i = 0; !head.exists && i < p.length; i++) {
+                if (head.trie.containsKey(p[i])) {
+                    head = head.trie.get(p[i]);
+                } else {
+                    PathTrie child = new PathTrie();
+                    head.trie.put(p[i], child);
+                    head = child;
+                }
+            }
+            head.exists = true;
+        }
+        public boolean covers(String p) {
+            return _covers(p.split("[.(]"), 0);
+        }
+        private boolean _covers(String[] p, int i) {
+            PathTrie head = this;
+            for (;; i++) {
+                if (head.exists) {
+                    return true;
+                }
+                if (i >= p.length) {
+                    return false;
+                }
+                // Allow Blah(*).
+                if (head.trie.containsKey("*)")) {
+                    int j;
+                    for (j = i; j < p.length && !p[j].endsWith(")"); j++);
+                    if (head.trie.get("*)")._covers(p, j+1)) {
+                        return true;
+                    }
+                }
+                head = head.trie.get(p[i]);
+                if (head == null) {
+                    return false;
+                }
+            }
+        }
     }
 }

--- a/tests/com/carolinarollergirls/scoreboard/jetty/WSTest.java
+++ b/tests/com/carolinarollergirls/scoreboard/jetty/WSTest.java
@@ -93,5 +93,11 @@ public class WSTest {
         assertFalse(pt.covers("ScoreBoard.Rulesets.Rule(Period.Direction)"));
         assertFalse(pt.covers("ScoreBoard.Rulesets.Rule(Jam)"));
         assertFalse(pt.covers("ScoreBoard.Rulesets.Rule(Intermission.Direction)"));
+        
+        pt.add("ScoreBoard.Rulesets.Rule(*)");
+        
+        assertTrue(pt.covers("ScoreBoard.Rulesets.Rule(Period.Direction)"));
+        assertTrue(pt.covers("ScoreBoard.Rulesets.Rule(Jam)"));
+        assertTrue(pt.covers("ScoreBoard.Rulesets.Rule(Intermission.Direction)"));
     }
 }

--- a/tests/com/carolinarollergirls/scoreboard/jetty/WSTest.java
+++ b/tests/com/carolinarollergirls/scoreboard/jetty/WSTest.java
@@ -21,8 +21,8 @@ public class WSTest {
         assertTrue(pt.covers("ScoreBoard.Period"));
         assertTrue(pt.covers("ScoreBoard.Period(1)"));
         assertTrue(pt.covers("ScoreBoard.Period.Jam"));
-        assertTrue(pt.covers("ScoreBoard.PeriodFoo"));
 
+        assertFalse(pt.covers("ScoreBoard.PeriodFoo"));
         assertFalse(pt.covers("ScoreBoard.Perioc"));
         assertFalse(pt.covers("ScoreBoard.Perioe"));
         assertFalse(pt.covers("ScoreBoard(1).Perioe"));
@@ -73,11 +73,25 @@ public class WSTest {
         pt.add("ScoreBoard.Period*");
 
         assertTrue(pt.covers("ScoreBoard.Period*"));
-        assertTrue(pt.covers("ScoreBoard.Period*a"));
 
+        assertFalse(pt.covers("ScoreBoard.Period*a"));
         assertFalse(pt.covers("ScoreBoard.Period"));
         assertFalse(pt.covers("ScoreBoard.Period("));
         assertFalse(pt.covers("ScoreBoard.Period(1).Jam(2).Foo(2).Bar"));
     }
 
+    @Test
+    public void path_trie_dot_in_id() {
+        pt.add("ScoreBoard.Rulesets.Rule(Period.Duration)");
+        pt.add("ScoreBoard.Rulesets.Rule(Jam.*)");
+        pt.add("ScoreBoard.Rulesets.Rule(Intermission*)");
+        
+        assertTrue(pt.covers("ScoreBoard.Rulesets.Rule(Period.Duration)"));
+        assertTrue(pt.covers("ScoreBoard.Rulesets.Rule(Jam.Foo)"));
+        assertTrue(pt.covers("ScoreBoard.Rulesets.Rule(Jam.Foo.Bar)"));
+        
+        assertFalse(pt.covers("ScoreBoard.Rulesets.Rule(Period.Direction)"));
+        assertFalse(pt.covers("ScoreBoard.Rulesets.Rule(Jam)"));
+        assertFalse(pt.covers("ScoreBoard.Rulesets.Rule(Intermission.Direction)"));
+    }
 }


### PR DESCRIPTION
This avoids getting e.g. updates for StarPassTrip when StarPass was
registered.
As a side effect it significantly reduces the number of trie lookups,
which should give a slight performance increase.