### PR TITLE
Don't show no more jams at start of P2 lineup

### DIFF
--- a/src/com/carolinarollergirls/scoreboard/core/impl/ScoreBoardImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/impl/ScoreBoardImpl.java
@@ -92,6 +92,7 @@ public class ScoreBoardImpl extends ScoreBoardEventProviderImpl implements Score
         } else if (prop == Value.NO_MORE_JAM) {
             if (isInJam() || !isInPeriod()) { return false; }
             if (!getRulesets().getBoolean(Rule.PERIOD_END_BETWEEN_JAMS)) { return false; }
+            if (getClock(Clock.ID_PERIOD).isTimeAtStart()) { return false; }
             Jam lastJam = getCurrentPeriod().getCurrentJam();
             long pcRemaining = getClock(Clock.ID_PERIOD).getMaximumTime() - lastJam.getPeriodClockElapsedEnd();
             if (pcRemaining >= getRulesets().getLong(Rule.LINEUP_DURATION)) { return false; }

--- a/tests/com/carolinarollergirls/scoreboard/core/impl/ScoreboardImplTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/core/impl/ScoreboardImplTests.java
@@ -1382,6 +1382,34 @@ public class ScoreboardImplTests {
     }
 
     @Test
+    public void testP2StartLineupAfter() {
+        // jam ended after 30s mark, no more jams.
+        assertTrue(pc.isCountDirectionDown());
+        sb.startJam();
+        pc.setTime(2000);
+        sb.stopJamTO();
+        assertTrue((Boolean)sb.get(ScoreBoard.Value.NO_MORE_JAM));
+        assertTrue(pc.isRunning());
+        assertTrue(lc.isRunning());
+        assertFalse(ic.isRunning());
+
+        // End of jam, start intermission.
+        advance(2000);
+        assertFalse(pc.isRunning());
+        assertFalse(lc.isRunning());
+        assertTrue(ic.isRunning());
+
+        // End intermission, go to lineup.
+        ic.setTime(1000);
+        advance(2000);
+        sb.stopJamTO();
+        assertFalse((Boolean)sb.get(ScoreBoard.Value.NO_MORE_JAM));
+        assertFalse(pc.isRunning());
+        assertTrue(lc.isRunning());
+        assertFalse(ic.isRunning());
+    }
+
+    @Test
     public void testTimeoutsThatDontAlwaysStopPc() {
         sb.getRulesets().set(Rule.STOP_PC_ON_TO, "false");
         sb.getRulesets().set(Rule.STOP_PC_ON_OTO, "false");


### PR DESCRIPTION
If you ended P1 in a no more jams state,
a lineup at the start of P2 shouldn't be
considered no more jams.