### PR TITLE
Make row colours on SK/LT match the paperwork.

### DIFF
--- a/html/controls/lt/lt-sheet.css
+++ b/html/controls/lt/lt-sheet.css
@@ -22,9 +22,13 @@ div.LT { font-size: 200%; text-align: center; background-color: #cccccc; color: 
 .LT.Period thead td { font-size: 95%; background-color: #cccccc; color: #333333; }
 .LT.Period td { text-align: center; vertical-align: middle; }
 .LT.Period tbody tr { background-color: #FFF; }
-.LT.Period tbody tr:nth-child(4n+0), .LT.Period tr:nth-child(4n-1) { background-color: #e7f3ff; }
+.LT.Period.Forewards tbody tr:nth-child(even) { background-color: #e7f3ff; }
+.LT.Period.Backwards tbody tr:nth-last-child(even) { background-color: #e7f3ff; }
 .LT.Period tbody tr .Darker { background-color: #e7f3ff; }
-.LT.Period tbody tr:nth-child(4n+0) .Darker, .LT.Period tr:nth-child(4n-1) .Darker { background-color: #cee7ff; }
+.LT.Period.Forewards tbody tr:nth-child(even) .Darker { background-color: #cee7ff; }
+.LT.Period.Backwards tbody tr:nth-last-child(even) .Darker { background-color: #cee7ff; }
+.LT.Period.Backwards tr.SP td { border-bottom-style: dotted; }
+.LT.Period.Forwards tr.SP td { border-top-style: dotted; }
 .LT.Period tbody .Box { background-color: #b6daff; }
 .LT.Period .JamNumber { width: 30px;}
 .LT.Period .NP { width: 25px; }

--- a/html/controls/lt/lt-sheet.js
+++ b/html/controls/lt/lt-sheet.js
@@ -84,7 +84,15 @@ function prepareLtSheetTable(element, teamId, mode) {
 		var jamRow = je[0];
 		var spRow = je[1];
 		if (k == prefix + 'StarPass') {
-			spRow.toggleClass('Hide', !isTrue(v));
+			if (isTrue(v)) {
+				if (mode == 'operator') {
+					jamRow.before(spRow);
+				} else {
+					jamRow.after(spRow);
+				}
+			} else {
+				spRow.detach();
+			}
 		}
 
 		// Everything after here is team specific.
@@ -124,9 +132,9 @@ function prepareLtSheetTable(element, teamId, mode) {
 			var table = $('<table cellpadding="0" cellspacing="0" border="1">')
 				.addClass('Period LT').attr('nr', nr);
 			if (mode == 'plt') {
-				table.prependTo(element);
+				table.prependTo(element).addClass("Backwards");
 			} else {
-				table.appendTo(element);
+				table.appendTo(element).addClass("Forewards");
 			}
 			if (mode != 'plt') {
 				$('<div class="LT">').html('<span class ="Team">' + teamName + '</span> P' + nr)
@@ -167,7 +175,6 @@ function prepareLtSheetTable(element, teamId, mode) {
 
 				});
 				jamRow.prependTo(body);
-				$('<tr>').addClass('Hide').prependTo(body); // even number of rows needed for coloring to fit
 			}
 		}
 	}
@@ -199,7 +206,7 @@ function prepareLtSheetTable(element, teamId, mode) {
 				}
 			});
 
-			var spRow = jamRow.clone(true).removeClass('Jam').addClass('SP Hide');
+			var spRow = jamRow.clone(true).removeClass('Jam').addClass('SP');
 			spRow.children('.Jammer').insertBefore(spRow.children('.Blocker1'));
 			spRow.children('.BoxJammer').insertAfter(spRow.children('.Jammer'));
 			spRow.children('.BoxJammer_3').insertAfter(spRow.children('.Jammer'));
@@ -213,9 +220,9 @@ function prepareLtSheetTable(element, teamId, mode) {
 			jamElements[p][nr] = [jamRow, spRow];
 
 			if (mode=='plt') {
-				table.find('#upcoming').after(jamRow).after(spRow);
+				table.find('#upcoming').after(jamRow);
 			} else {
-				table.append(jamRow).append(spRow);
+				table.append(jamRow);
 			}
 		}
 	}

--- a/html/controls/sk/sk-sheet.css
+++ b/html/controls/sk/sk-sheet.css
@@ -22,9 +22,13 @@ body:not(.AllowSelect) .SK {
 .SK.Period .SmallHead>div { font-size: 75%; transform: rotate(270deg); }
 .SK.Period td { text-align: center; vertical-align: middle; }
 .SK.Period tr { background-color: #FFF; }
-.SK.Period tr:nth-child(4n+0), .SK.Period tr:nth-child(4n-1) { background-color: #e9f6da; }
+.SK.Period.Forwards tr:nth-child(even) { background-color: #e9f6da; }
+.SK.Period.Backwards tr:nth-last-child(even) { background-color: #e9f6da; }
 .SK.Period tr .Darker { background-color: #e9f6da; }
-.SK.Period tr:nth-child(4n+0) .Darker, .SK.Period tr:nth-child(4n-1) .Darker { background-color: #d3ecb6; }
+.SK.Period.Forwards tr:nth-child(even) .Darker { background-color: #d3ecb6; }
+.SK.Period.Backwards tr:nth-last-child(even) .Darker { background-color: #d3ecb6; }
+.SK.Period.Backwards tr.SP td { border-bottom-style: dotted; }
+.SK.Period.Forwards tr.SP td { border-top-style: dotted; }
 .SK.Period .JamNumber { width: 30px; }
 .SK.Period .Jammer { width: 50px; }
 .SK.Period .Narrow, .Period .SmallHead { width: 14px; }

--- a/html/controls/sk/sk-sheet.js
+++ b/html/controls/sk/sk-sheet.js
@@ -74,7 +74,15 @@ function prepareSkSheetTable(element, teamId, mode) {
 		var jamRow = je[0];
 		var spRow = je[1];
 		if (k == prefix + 'StarPass') {
-			spRow.toggleClass('Hide', !isTrue(v));
+			if (isTrue(v)) {
+				if (mode == 'operator') {
+					jamRow.before(spRow);
+				} else {
+					jamRow.after(spRow);
+				}
+			} else {
+				spRow.detach();
+			}
 		}
 
 		// Everything after here is team specific.
@@ -186,9 +194,9 @@ function prepareSkSheetTable(element, teamId, mode) {
 			var table = $('<table cellpadding="0" cellspacing="0" border="1">')
 				.addClass('SK Period').attr('nr', nr);
 			if (mode == 'operator') {
-				table.prependTo(element);
+				table.prependTo(element).addClass("Backwards");
 			} else {
-				table.appendTo(element);
+				table.appendTo(element).addClass("Forwards");
 			}
 			if (mode != 'operator') {
 				var header = $('<thead><tr>').appendTo(table);
@@ -237,11 +245,11 @@ function prepareSkSheetTable(element, teamId, mode) {
 				$('<td>').addClass('GameTotal').appendTo(jamRow);
 			}
 
-			var spRow = jamRow.clone(true).removeClass('Jam').addClass('SP Hide');
+			var spRow = jamRow.clone(true).removeClass('Jam').addClass('SP');
 			if (mode == 'operator') {
-				table.prepend(jamRow).prepend(spRow);
+				table.prepend(jamRow)
 			} else {
-				table.append(jamRow).append(spRow);
+				table.append(jamRow);
 			}
 			jamElements[p][nr] = [jamRow, spRow];
 


### PR DESCRIPTION
Indicate which rows are related by starpasses by using
border styles.

As a side benefit, this approach means the Copy to Statsbook page now
works for star passes if you've saved a copy without the CSS.

Fixes #325 