### PR TITLE
Fix various corner cases around box trips.

### DIFF
--- a/html/controls/lt/lt-sheet.js
+++ b/html/controls/lt/lt-sheet.js
@@ -362,11 +362,9 @@ function prepareFieldingEditor(teamId) {
 					+ (afterSP?' after SP':''));
 		}
 		if (['EndJamNumber', 'EndBetweenJams', 'EndAfterSP'].includes(key)) {
-			var between = isTrue(WS.state[prefix+'EndBetweenJams']);
 			var afterSP = isTrue(WS.state[prefix+'EndAfterSP']);
 			var jam = WS.state[prefix+'EndJamNumber'];
-			row.find('.tripEndText').text((between?' Before ':' ') + (jam == 0 ? 'ongoing' : 'Jam ' + jam) 
-					+ (afterSP?' after SP ':' '));
+			row.find('.tripEndText').text((jam == 0 ? 'ongoing' : 'Jam ' + jam) + (afterSP?' after SP ':' '));
 		}
 		if (key == 'Fielding') {
 			row.addClass(v);

--- a/src/com/carolinarollergirls/scoreboard/core/BoxTrip.java
+++ b/src/com/carolinarollergirls/scoreboard/core/BoxTrip.java
@@ -10,6 +10,7 @@ public interface BoxTrip extends ScoreBoardEventProvider {
     public int compareTo(BoxTrip other);
     
     public void end();
+    public void endPastTrip();
     
     public Team getTeam();
     
@@ -19,7 +20,6 @@ public interface BoxTrip extends ScoreBoardEventProvider {
     public boolean startedBetweenJams();
     public boolean startedAfterSP();
     public Fielding getEndFielding();
-    public boolean endedBetweenJams();
     public boolean endedAfterSP();
     
     public enum Value implements PermanentProperty {
@@ -32,7 +32,6 @@ public interface BoxTrip extends ScoreBoardEventProvider {
         START_AFTER_S_P(Boolean.class, false),
         END_FIELDING(Fielding.class, null),
         END_JAM_NUMBER(Integer.class, 0),
-        END_BETWEEN_JAMS(Boolean.class, false),
         END_AFTER_S_P(Boolean.class, false),
         WALLTIME_START(Long.class, 0L),
         WALLTIME_END(Long.class, 0L),

--- a/src/com/carolinarollergirls/scoreboard/core/impl/FieldingImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/impl/FieldingImpl.java
@@ -88,7 +88,7 @@ public class FieldingImpl extends ParentOrderedScoreBoardEventProviderImpl<Field
 
     @Override
     protected void itemAdded(AddRemoveProperty prop, ValueWithId item) {
-        if (prop == Child.BOX_TRIP) { 
+        if (prop == Child.BOX_TRIP) {
             if (((BoxTrip)item).isCurrent()) {
                 set(Value.CURRENT_BOX_TRIP, item);
             }
@@ -104,16 +104,18 @@ public class FieldingImpl extends ParentOrderedScoreBoardEventProviderImpl<Field
             updateBoxTripSymbols();
         }
     }
-    
+
     @Override
     public void execute(CommandProperty prop) {
         if (prop == Command.ADD_BOX_TRIP && getSkater() != null) {
+            requestBatchStart();
             BoxTrip bt = new BoxTripImpl(this);
             if (!isCurrent()) {
-                bt.end();
+                bt.endPastTrip();
             }
             getTeamJam().getTeam().add(Team.Child.BOX_TRIP, bt);
             add(Child.BOX_TRIP, bt);
+            requestBatchEnd();
         }
     }
 
@@ -124,8 +126,9 @@ public class FieldingImpl extends ParentOrderedScoreBoardEventProviderImpl<Field
 
     @Override
     public boolean isCurrent() {
-        return (teamJam.isRunningOrUpcoming() && !teamJam.getTeam().hasFieldingAdvancePending()) 
-                || teamJam.isRunningOrEnded() && teamJam.getTeam().hasFieldingAdvancePending(); }
+        return (teamJam.isRunningOrUpcoming() && !teamJam.getTeam().hasFieldingAdvancePending())
+               || teamJam.isRunningOrEnded() && teamJam.getTeam().hasFieldingAdvancePending();
+    }
 
     @Override
     public Role getCurrentRole() { return getPosition().getFloorPosition().getRole(teamJam); }
@@ -152,7 +155,8 @@ public class FieldingImpl extends ParentOrderedScoreBoardEventProviderImpl<Field
             public int compare(BoxTrip b1, BoxTrip b2) {
                 if (b1 == b2) { return 0; }
                 if (b1 == null) { return 1; }
-                return b1.compareTo(b2); }
+                return b1.compareTo(b2);
+            }
         });
         StringBuilder beforeSP = new StringBuilder();
         StringBuilder afterSP = new StringBuilder();
@@ -185,11 +189,7 @@ public class FieldingImpl extends ParentOrderedScoreBoardEventProviderImpl<Field
                 }
             }
             if (this == trip.getEndFielding()) {
-                if (trip.endedBetweenJams()) {
-                    typeJam = 0;
-                    typeBeforeSP = 0;
-                    typeAfterSP = 0;
-                } else if (trip.endedAfterSP()) {
+                if (trip.endedAfterSP()) {
                     typeJam += 3;
                     typeAfterSP += 3;
                 } else {

--- a/tests/com/carolinarollergirls/scoreboard/core/impl/BoxTripImplTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/core/impl/BoxTripImplTests.java
@@ -1,0 +1,269 @@
+
+package com.carolinarollergirls.scoreboard.core.impl;
+
+import static org.junit.Assert.assertEquals;
+import java.util.LinkedList;
+import java.util.Queue;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.carolinarollergirls.scoreboard.core.Fielding;
+import com.carolinarollergirls.scoreboard.core.BoxTrip;
+import com.carolinarollergirls.scoreboard.core.Role;
+import com.carolinarollergirls.scoreboard.core.ScoreBoard;
+import com.carolinarollergirls.scoreboard.core.Skater;
+import com.carolinarollergirls.scoreboard.core.Team;
+import com.carolinarollergirls.scoreboard.event.ScoreBoardEvent;
+import com.carolinarollergirls.scoreboard.event.ScoreBoardListener;
+import com.carolinarollergirls.scoreboard.event.ScoreBoardEventProviderImpl.BatchEvent;
+import com.carolinarollergirls.scoreboard.utils.ScoreBoardClock;
+
+public class BoxTripImplTests {
+
+    private ScoreBoard sb;
+
+    private Team t;
+    private Skater s;
+    private BoxTrip bt;
+
+    private int batchLevel;
+    private ScoreBoardListener batchCounter = new ScoreBoardListener() {
+        @Override
+        public void scoreBoardChange(ScoreBoardEvent event) {
+            synchronized(batchCounter) {
+                if (event.getProperty() == BatchEvent.START) {
+                    batchLevel++;
+                } else if (event.getProperty() == BatchEvent.END) {
+                    batchLevel--;
+                }
+            }
+        }
+    };
+
+    @Before
+    public void setUp() throws Exception {
+        sb = new ScoreBoardImpl();
+        sb.addScoreBoardListener(batchCounter);
+
+        ScoreBoardClock.getInstance().stop();
+        t = sb.getTeam(Team.ID_1);
+        s = new SkaterImpl(t, (String)null);
+        t.addSkater(s);
+        sb.startJam();
+        sb.stopJamTO();
+        sb.startJam();
+        t.field(s, Role.PIVOT);
+        s.setPenaltyBox(true);
+        bt = (BoxTrip) s.getFielding(t.getRunningOrUpcomingTeamJam()).getAll(Fielding.Child.BOX_TRIP).iterator().next();
+        sb.stopJamTO();
+        sb.startJam();
+        s.setPenaltyBox(false);
+        sb.stopJamTO();
+        t.execute(Team.Command.ADVANCE_FIELDINGS);
+        // Now going into jam 3. Skater had a box trip that started in jam 1, and ended in jam 2.
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        ScoreBoardClock.getInstance().start(false);
+        // Check all started batches were ended.
+        assertEquals(0, batchLevel);
+    }
+
+    private String getBoxTripSymbols(int jam) {
+        Fielding f;
+        if (jam == 4) {
+            f = s.getFielding(t.getRunningOrUpcomingTeamJam());
+        } else {
+            f = s.getFielding(sb.getCurrentPeriod().getJam(jam).getTeamJam(Team.ID_1));
+        }
+        return f == null ? null : (String) f.get(Fielding.Value.BOX_TRIP_SYMBOLS);
+    }
+
+    @Test
+    public void testBaseCase() {
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals(" -", getBoxTripSymbols(2));
+        assertEquals(" $", getBoxTripSymbols(3));
+        assertEquals(null, getBoxTripSymbols(4));
+    }
+
+    @Test
+    public void testStartEarlier() {
+        // Start before jam.
+        bt.execute(BoxTrip.Command.START_EARLIER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals(" S", getBoxTripSymbols(2));
+        assertEquals(" $", getBoxTripSymbols(3));
+        assertEquals(null, getBoxTripSymbols(4));
+
+        // Can't go before the skater was present.
+        bt.execute(BoxTrip.Command.START_EARLIER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals(" S", getBoxTripSymbols(2));
+        assertEquals(" $", getBoxTripSymbols(3));
+        assertEquals(null, getBoxTripSymbols(4));
+    }
+
+    @Test
+    public void testStartLater() {
+        // Start between jams.
+        bt.execute(BoxTrip.Command.START_LATER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals("", getBoxTripSymbols(2));
+        assertEquals(" $", getBoxTripSymbols(3));
+        assertEquals(null, getBoxTripSymbols(4));
+
+        // Start in next jam.
+        bt.execute(BoxTrip.Command.START_LATER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals("", getBoxTripSymbols(2));
+        assertEquals(" +", getBoxTripSymbols(3));
+        assertEquals(null, getBoxTripSymbols(4));
+
+        // Can't go beyond end of penalty.
+        bt.execute(BoxTrip.Command.START_LATER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals("", getBoxTripSymbols(2));
+        assertEquals(" +", getBoxTripSymbols(3));
+        assertEquals(null, getBoxTripSymbols(4));
+    }
+
+    @Test
+    public void testEndEarlier() {
+        // End during previous.
+        bt.execute(BoxTrip.Command.END_EARLIER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals(" +", getBoxTripSymbols(2));
+        assertEquals("", getBoxTripSymbols(3));
+        assertEquals(null, getBoxTripSymbols(4));
+
+        // Can't go beyond start of penalty.
+        bt.execute(BoxTrip.Command.END_EARLIER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals(" +", getBoxTripSymbols(2));
+        assertEquals("", getBoxTripSymbols(3));
+        assertEquals(null, getBoxTripSymbols(4));
+    }
+
+
+    @Test
+    public void testEndLater() {
+        // Penalty is ongoing, but skater isn't in the upcoming jam.
+        bt.execute(BoxTrip.Command.END_LATER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals(" -", getBoxTripSymbols(2));
+        assertEquals(" $", getBoxTripSymbols(3));
+        assertEquals(null, getBoxTripSymbols(4));
+
+        // Field them in upcoming jam.
+        t.field(s, Role.PIVOT);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals(" -", getBoxTripSymbols(2));
+        assertEquals(" $", getBoxTripSymbols(3));
+        assertEquals("", getBoxTripSymbols(4));
+        assertEquals(false, s.getFielding(t.getRunningOrUpcomingTeamJam()).isInBox());
+
+        // Now can mark penalty as ongoing.
+        bt.execute(BoxTrip.Command.END_LATER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals(" -", getBoxTripSymbols(2));
+        assertEquals(" S", getBoxTripSymbols(3));
+        assertEquals(" S", getBoxTripSymbols(4));
+        assertEquals(true, s.getFielding(t.getRunningOrUpcomingTeamJam()).isInBox());
+
+        // Can't go beyond ongoing.
+        bt.execute(BoxTrip.Command.END_LATER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals(" -", getBoxTripSymbols(2));
+        assertEquals(" S", getBoxTripSymbols(3));
+        assertEquals(" S", getBoxTripSymbols(4));
+        assertEquals(true, s.getFielding(t.getRunningOrUpcomingTeamJam()).isInBox());
+    }
+
+    @Test
+    public void testAdvanceEndToUpcomingAndBack() {
+        t.field(s, Role.PIVOT);
+        bt.execute(BoxTrip.Command.END_LATER);
+        bt.execute(BoxTrip.Command.END_LATER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals(" -", getBoxTripSymbols(2));
+        assertEquals(" S", getBoxTripSymbols(3));
+        assertEquals(" S", getBoxTripSymbols(4));
+
+        bt.execute(BoxTrip.Command.END_EARLIER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals(" -", getBoxTripSymbols(2));
+        assertEquals(" $", getBoxTripSymbols(3));
+        assertEquals("", getBoxTripSymbols(4));
+
+        bt.execute(BoxTrip.Command.END_EARLIER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals(" +", getBoxTripSymbols(2));
+        assertEquals("", getBoxTripSymbols(3));
+        assertEquals("", getBoxTripSymbols(4));
+    }
+
+    @Test
+    public void testAdvanceStartToUpcomingAndBack() {
+        t.field(s, Role.PIVOT);
+        bt.execute(BoxTrip.Command.END_LATER);
+        bt.execute(BoxTrip.Command.END_LATER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals(" -", getBoxTripSymbols(2));
+        assertEquals(" S", getBoxTripSymbols(3));
+        assertEquals(" S", getBoxTripSymbols(4));
+
+        bt.execute(BoxTrip.Command.START_LATER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals("", getBoxTripSymbols(2));
+        assertEquals(" S", getBoxTripSymbols(3));
+        assertEquals(" S", getBoxTripSymbols(4));
+
+        bt.execute(BoxTrip.Command.START_LATER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals("", getBoxTripSymbols(2));
+        assertEquals(" -", getBoxTripSymbols(3));
+        assertEquals(" S", getBoxTripSymbols(4));
+
+        bt.execute(BoxTrip.Command.START_LATER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals("", getBoxTripSymbols(2));
+        assertEquals("", getBoxTripSymbols(3));
+        assertEquals(" S", getBoxTripSymbols(4));
+
+        // Can't go beyond upcoming jam.
+        bt.execute(BoxTrip.Command.START_LATER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals("", getBoxTripSymbols(2));
+        assertEquals("", getBoxTripSymbols(3));
+        assertEquals(" S", getBoxTripSymbols(4));
+
+        bt.execute(BoxTrip.Command.START_EARLIER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals("", getBoxTripSymbols(2));
+        assertEquals(" -", getBoxTripSymbols(3));
+        assertEquals(" S", getBoxTripSymbols(4));
+
+        bt.execute(BoxTrip.Command.START_EARLIER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals("", getBoxTripSymbols(2));
+        assertEquals(" S", getBoxTripSymbols(3));
+        assertEquals(" S", getBoxTripSymbols(4));
+
+        bt.execute(BoxTrip.Command.START_EARLIER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals(" -", getBoxTripSymbols(2));
+        assertEquals(" S", getBoxTripSymbols(3));
+        assertEquals(" S", getBoxTripSymbols(4));
+
+        bt.execute(BoxTrip.Command.START_EARLIER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals(" S", getBoxTripSymbols(2));
+        assertEquals(" S", getBoxTripSymbols(3));
+        assertEquals(" S", getBoxTripSymbols(4));
+    }
+
+}

--- a/tests/com/carolinarollergirls/scoreboard/core/impl/FieldingImplTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/core/impl/FieldingImplTests.java
@@ -8,11 +8,13 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.carolinarollergirls.scoreboard.core.BoxTrip;
 import com.carolinarollergirls.scoreboard.core.Fielding;
 import com.carolinarollergirls.scoreboard.core.Role;
 import com.carolinarollergirls.scoreboard.core.ScoreBoard;
 import com.carolinarollergirls.scoreboard.core.Skater;
 import com.carolinarollergirls.scoreboard.core.Team;
+import com.carolinarollergirls.scoreboard.event.OrderedScoreBoardEventProvider.IValue;
 import com.carolinarollergirls.scoreboard.event.ScoreBoardEvent;
 import com.carolinarollergirls.scoreboard.event.ScoreBoardListener;
 import com.carolinarollergirls.scoreboard.event.ScoreBoardEventProviderImpl.BatchEvent;
@@ -79,10 +81,59 @@ public class FieldingImplTests {
         sb.stopJamTO();
         sb.startJam();
         s.setPenaltyBox(false);
-        
+
         Fielding f = s.getFielding(sb.getOrCreatePeriod(1).getJam(2).getTeamJam(Team.ID_1));
         f.execute(Fielding.Command.ADD_BOX_TRIP);
-        
+
         assertEquals(" $ + -", f.get(Fielding.Value.BOX_TRIP_SYMBOLS));
+    }
+
+    @Test
+    public void testAddingPastBoxTripHasRightJamNumbers() {
+        Team t = sb.getTeam(Team.ID_1);
+        Skater s = new SkaterImpl(t, (String)null);
+        t.addSkater(s);
+        sb.startJam();
+        t.field(s, Role.PIVOT);
+        sb.stopJamTO();
+        sb.startJam();
+        sb.stopJamTO();
+
+        Fielding f = s.getFielding(sb.getOrCreatePeriod(1).getJam(1).getTeamJam(Team.ID_1));
+        f.execute(Fielding.Command.ADD_BOX_TRIP);
+        BoxTrip bt = (BoxTrip) f.getAll(Fielding.Child.BOX_TRIP).iterator().next();
+
+        assertEquals(1, bt.get(BoxTrip.Value.START_JAM_NUMBER));
+        assertEquals(1, bt.get(BoxTrip.Value.END_JAM_NUMBER));
+    }
+
+    @Test
+    public void testRemovingUpcomingBoxTripAfterAdvance() {
+        Team t = sb.getTeam(Team.ID_1);
+        Skater s = new SkaterImpl(t, (String)null);
+        t.addSkater(s);
+        sb.getTeam(Team.ID_1).field(s, Role.PIVOT);
+        sb.startJam();
+        s.setPenaltyBox(true);
+        sb.stopJamTO();
+        s.setPenaltyBox(false);
+        // Box trip from ended jam remains.
+        Fielding f1 = s.getFielding(t.getLastEndedTeamJam());
+        assertEquals(1, f1.getAll(Fielding.Child.BOX_TRIP).size());
+
+        t.execute(Team.Command.ADVANCE_FIELDINGS);
+        t.field(s, Role.PIVOT);
+        Fielding f2 = s.getFielding(t.getRunningOrUpcomingTeamJam());
+        assertEquals(0, f2.getAll(Fielding.Child.BOX_TRIP).size());
+
+        // Box trip added to upcoming jam.
+        s.setPenaltyBox(true);
+        assertEquals(1, f1.getAll(Fielding.Child.BOX_TRIP).size());
+        assertEquals(1, f2.getAll(Fielding.Child.BOX_TRIP).size());
+
+        // And remed again.
+        s.setPenaltyBox(false);
+        assertEquals(1, f1.getAll(Fielding.Child.BOX_TRIP).size());
+        assertEquals(0, f2.getAll(Fielding.Child.BOX_TRIP).size());
     }
 }


### PR DESCRIPTION
Handle adding past box trips seperate from new box trips via
PT controls. This fixes issues introduced around fielding advances
and box trip tracking against the LT Box button.

Remove notion of ending box trips between jams, this doesn't work as
it'd require released skaters to be fielded in the upcoming jam.
It's also not something I've ever seen needed.


We still need to remove the Submit and make all changes immediate, but this fixes all the other issues around this.