### PR TITLE
Add support for penalty box substitutions

### DIFF
--- a/html/controls/lt/index.html
+++ b/html/controls/lt/index.html
@@ -19,6 +19,7 @@
 		<div id="input"></div>
 		<div id="sheet" width="100%"></div>
 		<div id="PenaltyEditor"></div>
+		<div id="AnnotationEditor"></div>
 		<div id="FieldingEditor"></div>
 	</body>
 </html>

--- a/html/controls/lt/index.html
+++ b/html/controls/lt/index.html
@@ -12,6 +12,7 @@
 		-->
 		<script type="text/javascript" src="/external/jquery/jquery.js"></script>
 		<script type="text/javascript" src="/json/core.js"></script>
+		<script type="text/javascript" src="/javascript/windowfunctions.js"></script>
 		<script type="text/javascript" src="/controls/plt/plt-input.js"></script>
 		<script type="text/javascript" src="lt-sheet.js"></script>
 	</head>

--- a/html/controls/lt/index.js
+++ b/html/controls/lt/index.js
@@ -8,8 +8,8 @@
 	
 	prepareLtSheetTable($('#sheet'), teamId, 'plt');
 	
-	preparePenaltyEditor();
-	
+	prepareAnnotationEditor(teamId);
+
 	prepareFieldingEditor(teamId);
 
 	WS.AutoRegister();

--- a/html/controls/lt/lt-sheet.css
+++ b/html/controls/lt/lt-sheet.css
@@ -34,6 +34,8 @@ div.LT { font-size: 200%; text-align: center; background-color: #cccccc; color: 
 .LT.Period .NP { width: 25px; }
 .LT.Period .Skater { width: 12%; }
 .LT.Period .Box { width: 8%; }
+.LT.Period .hasAnnotation { position: relative; }
+.LT.Period .hasAnnotation::after { position: absolute; right: 2px; top: 2px; height: 5px; width: 5px; background-color: red; content: ""; }
 
 #FieldingEditor .tripHeader { text-align: center; font-size: 95%; background-color: #222; color: #FFF; }
 #FieldingEditor .ButtonCell { text-align: center; }

--- a/html/controls/lt/lt-sheet.css
+++ b/html/controls/lt/lt-sheet.css
@@ -37,6 +37,7 @@ div.LT { font-size: 200%; text-align: center; background-color: #cccccc; color: 
 
 #FieldingEditor .tripHeader { text-align: center; font-size: 95%; background-color: #222; color: #FFF; }
 #FieldingEditor .ButtonCell { text-align: center; }
+#FieldingEditor .ui-button { font-size: 75%; }
 
 #FieldingEditor .BoxTrip>td, #FieldingEditor .Skater>td { padding: 0.5em 0em; }
 

--- a/html/controls/lt/lt-sheet.js
+++ b/html/controls/lt/lt-sheet.js
@@ -249,6 +249,7 @@ function openFieldingEditor(p, j, t, pos, upcoming) {
 	var notFieldedField = fieldingEditor.find('#notFielded').attr('checked', isTrue(WS.state[prefix+'NotFielded']));
 	var sitFor3Field = fieldingEditor.find('#sitFor3').attr('checked', isTrue(WS.state[prefix+'SitFor3']));
 	var annotationField = fieldingEditor.find('#annotation').val(WS.state[prefix+'Annotation']);
+	fieldingEditor.find('#notFielded').toggleClass('Hide', isTrue(upcoming));
 	fieldingEditor.find('.BoxTrip').addClass('Hide');
 	fieldingEditor.find('.'+WS.state[prefix+'Id']).removeClass('Hide');
 	fieldingEditor.data('prefix', prefix);

--- a/html/controls/lt/lt-sheet.js
+++ b/html/controls/lt/lt-sheet.js
@@ -281,9 +281,8 @@ function prepareFieldingEditor(teamId) {
 		
 		row = $('<tr>').addClass('Skater').appendTo(table);
 		$('<td>').attr('colspan', '3')
-			.append($('<input type="text">').attr('size', '35').attr('id', 'annotation'))
-			.append($('<button>').attr('id', 'setAnnotation').text('Set').button().click(function() {
-				WS.Set(fieldingEditor.data('prefix')+'Annotation', fieldingEditor.find('#annotation').val());
+			.append($('<input type="text">').attr('size', '40').attr('id', 'annotation').change(function() {
+				WS.Set(fieldingEditor.data('prefix')+'Annotation', $(this).val());
 			})).appendTo(row);
 		
 		row = $('<tr>').addClass('Skater').appendTo(table);

--- a/html/controls/lt/lt-sheet.js
+++ b/html/controls/lt/lt-sheet.js
@@ -120,6 +120,8 @@ function prepareLtSheetTable(element, teamId, mode) {
 						setBoxTripSymbols(jamRow, '.Box'+k.Fielding, v);
 					} else if (k.BoxTripSymbolsAfterSP != null) {
 						if (isTrue(WS.state[prefix+'StarPass'])) { setBoxTripSymbols(spRow, '.Box'+k.Fielding, v); }
+					} else if (k.Annotation != null) {
+						jamRow.children('.'+k.Fielding).toggleClass('hasAnnotation', v!= null && v != '');
 					}
 				}
 				break;

--- a/html/controls/lt/lt-sheet.js
+++ b/html/controls/lt/lt-sheet.js
@@ -41,11 +41,15 @@ function prepareLtSheetTable(element, teamId, mode) {
 				}
 			});
 
-			WS.Register(['ScoreBoard.Team('+teamId+').Position(*).Number', 'ScoreBoard.Team('+teamId+').Position(*).CurrentBoxSymbols'], function(k, v) {
+			WS.Register(['ScoreBoard.Team('+teamId+').Position(*).Number',
+				'ScoreBoard.Team('+teamId+').Position(*).CurrentBoxSymbols',
+				'ScoreBoard.Team('+teamId+').Position(*).Annotation'], function(k, v) {
 				if (k.field == "Number") {
 					element.find("#upcoming .Skater."+k.Position).text(v);
 				} else if (k.field == "CurrentBoxSymbols") {
 					element.find("#upcoming .Box.Box"+k.Position).text(v);
+				} else if (k.field == "Annotation") {
+					element.find("#upcoming .Skater."+k.Position).toggleClass('hasAnnotation', v != '');
 				}
 			});
 		}

--- a/html/controls/lt/lt-sheet.js
+++ b/html/controls/lt/lt-sheet.js
@@ -252,6 +252,7 @@ function openFieldingEditor(p, j, t, pos, upcoming) {
 	var sitFor3Field = fieldingEditor.find('#sitFor3').attr('checked', isTrue(WS.state[prefix+'SitFor3']));
 	var annotationField = fieldingEditor.find('#annotation').val(WS.state[prefix+'Annotation']);
 	fieldingEditor.find('#notFielded').toggleClass('Hide', isTrue(upcoming));
+	fieldingEditor.find('.BoxTripComments').toggleClass('Hide', WS.state[prefix + 'CurrentBoxTrip'] == '');
 	fieldingEditor.find('.BoxTrip').addClass('Hide');
 	fieldingEditor.find('.'+WS.state[prefix+'Id']).removeClass('Hide');
 	fieldingEditor.data('prefix', prefix);
@@ -287,7 +288,7 @@ function prepareFieldingEditor(teamId) {
 				WS.Set(fieldingEditor.data('prefix')+'Annotation', $(this).val());
 			})).appendTo(row);
 		
-		row = $('<tr>').addClass('Skater').appendTo(table);
+		row = $('<tr>').addClass('Skater BoxTripComments').appendTo(table);
 		$('<td>').append($('<button>').text('No Penalty').button().click(function() { appendAnnotation('No Penalty');})).appendTo(row);
 		$('<td>').append($('<button>').text('Penalty Overturned').button().click(function() { appendAnnotation('Penalty Overturned');})).appendTo(row);
 		
@@ -378,15 +379,15 @@ function prepareFieldingEditor(teamId) {
 		if (['StartJamNumber', 'StartBetweenJams', 'StartAfterSP'].includes(key)) {
 			var between = isTrue(WS.state[prefix+'StartBetweenJams']);
 			var afterSP = isTrue(WS.state[prefix+'StartAfterSP']);
-			row.find('.tripStartText').text((between?'Before ':'') + 'Jam ' + WS.state[prefix+'StartJamNumber']
-					+ (afterSP?' after SP':''));
+			row.find('.tripStartText').text((between ? 'Before ' : '') + 'Jam ' + WS.state[prefix+'StartJamNumber']
+					+ (afterSP ? ' after SP' : ''));
 		}
 		if (['EndJamNumber', 'EndBetweenJams', 'EndAfterSP'].includes(key)) {
 			var between = isTrue(WS.state[prefix+'EndBetweenJams']);
 			var afterSP = isTrue(WS.state[prefix+'EndAfterSP']);
 			var jam = WS.state[prefix+'EndJamNumber'];
-			row.find('.tripEndText').text((between?' Before ':' ') + (jam == 0 ? 'ongoing' : 'Jam ' + jam) 
-					+ (afterSP?' after SP ':' '));
+			row.find('.tripEndText').text((between ? ' After ' : ' ') + (jam == 0 ? 'ongoing' : 'Jam ' + jam) 
+					+ (afterSP && !between ? ' after SP ' : ' '));
 		}
 		if (key == 'Fielding') {
 			row.addClass(v);

--- a/html/controls/lt/lt-sheet.js
+++ b/html/controls/lt/lt-sheet.js
@@ -251,18 +251,7 @@ function openFieldingEditor(p, j, t, pos, upcoming) {
 	var annotationField = fieldingEditor.find('#annotation').val(WS.state[prefix+'Annotation']);
 	fieldingEditor.find('.BoxTrip').addClass('Hide');
 	fieldingEditor.find('.'+WS.state[prefix+'Id']).removeClass('Hide');
-	fieldingEditor.find('#addTrip, #submit').unbind('click');
-	fieldingEditor.find('#addTrip').click(function() {
-		WS.Set(prefix+'AddBoxTrip', true);
-	});
-	fieldingEditor.find('#submit').click(function() {
-		WS.Set(prefix+'Skater', skaterField.val());
-		WS.Set(prefix+'NotFielded', notFieldedField.attr('checked') != null);
-		WS.Set(prefix+'SitFor3', sitFor3Field.attr('checked') != null);
-		WS.Set(prefix+'Annotation', annotationField.val());
-		fieldingEditor.dialog('close');
-	});
-	
+	fieldingEditor.data('prefix', prefix);
 	fieldingEditor.dialog('open');
 }
 
@@ -275,17 +264,26 @@ function prepareFieldingEditor(teamId) {
 		var table = $('<table>').appendTo($('#FieldingEditor'));
 		
 		var row = $('<tr>').addClass('Skater').appendTo(table);
-		$('<td>').append($('<select>').attr('id', 'skater').append($('<option>').attr('value', '').text('None/Unknown'))).appendTo(row);
-		var notFieldedField = $('<td>').append($('<button>').attr('id', 'notFielded').button().text('No Skater fielded')).appendTo(row).children('button');
-		notFieldedField.click(function(){notFieldedField.attr('checked', notFieldedField.attr('checked') == null);});
-		var sitFor3Field = $('<td>').append($('<button>').attr('id', 'sitFor3').button().text('Sit out next 3')).appendTo(row).children('button');
-		sitFor3Field.click(function(){sitFor3Field.attr('checked', sitFor3Field.attr('checked') == null);});
+		$('<td>').append($('<select>').attr('id', 'skater').append($('<option>').attr('value', '').text('None/Unknown')).change(function() {
+			WS.Set(fieldingEditor.data('prefix')+'Skater', $(this).val());
+		})).appendTo(row);
+		$('<td>').append($('<button>').attr('id', 'notFielded').button().text('No Skater fielded').click(function() {
+			var check = $(this).attr('checked') == null;
+			$(this).attr('checked', check);
+			WS.Set(fieldingEditor.data('prefix')+'NotFielded', check);
+		})).appendTo(row)
+		$('<td>').append($('<button>').attr('id', 'sitFor3').button().text('Sit out next 3').click(function() {
+			var check = $(this).attr('checked') == null;
+			$(this).attr('checked', check);
+			WS.Set(fieldingEditor.data('prefix')+'SitFor3', check);
+		})).appendTo(row);
 		
 		row = $('<tr>').addClass('Skater').appendTo(table);
 		$('<td>').attr('colspan', '3')
-			.append($('<input type="text">').attr('size', '40').attr('id', 'annotation'))
-			//.append($('button').attr('id', 'setAnnotation').text('Set').button())
-			.appendTo(row);
+			.append($('<input type="text">').attr('size', '35').attr('id', 'annotation'))
+			.append($('<button>').attr('id', 'setAnnotation').text('Set').button().click(function() {
+				WS.Set(fieldingEditor.data('prefix')+'Annotation', fieldingEditor.find('#annotation').val());
+			})).appendTo(row);
 		
 		row = $('<tr>').addClass('tripHeader').appendTo(table);
 		$('<td>').attr('colspan', '2').text('Box Trips').appendTo(row);
@@ -297,11 +295,13 @@ function prepareFieldingEditor(teamId) {
 		$('<td>').appendTo(row);
 		
 		row = $('<tr>').attr('id', 'tripFooter').appendTo(table);
-		$('<td>').append($('<button>').attr('id', 'addTrip').text('Add Box Trip').button()).appendTo(row);
-		$('<td>').addClass('ButtonCell').append($('<button>').attr('id', 'abort').text('Abort').button()).click(function() {
+		$('<td>').append($('<button>').attr('id', 'addTrip').text('Add Box Trip').button().click(function() {
+			WS.Set(fieldingEditor.data('prefix')+'AddBoxTrip', true);
+		})).appendTo(row);
+		$('<td>').appendTo(row);
+		$('<td>').addClass('ButtonCell').append($('<button>').attr('id', 'close').text('Close').button()).click(function() {
 			fieldingEditor.dialog('close');
 		}).appendTo(row);
-		$('<td>').addClass('ButtonCell').append($('<button>').attr('id', 'submit').text('Submit').button()).appendTo(row);
 
 		WS.Register(['ScoreBoard.Team('+teamId+').Skater(*).Role',
 			'ScoreBoard.Team('+teamId+').Skater(*).Number'], function(k,v) { processSkater(k,v); })

--- a/html/controls/lt/lt-sheet.js
+++ b/html/controls/lt/lt-sheet.js
@@ -286,6 +286,10 @@ function prepareFieldingEditor(teamId) {
 				WS.Set(fieldingEditor.data('prefix')+'Annotation', fieldingEditor.find('#annotation').val());
 			})).appendTo(row);
 		
+		row = $('<tr>').addClass('Skater').appendTo(table);
+		$('<td>').append($('<button>').text('No Penalty').button().click(function() { appendAnnotation('No Penalty');})).appendTo(row);
+		$('<td>').append($('<button>').text('Penalty Overturned').button().click(function() { appendAnnotation('Penalty Overturned');})).appendTo(row);
+		
 		row = $('<tr>').addClass('tripHeader').appendTo(table);
 		$('<td>').attr('colspan', '2').text('Box Trips').appendTo(row);
 		$('<td>').appendTo(row);
@@ -315,29 +319,25 @@ function prepareFieldingEditor(teamId) {
 			autoOpen: false,
 			width: '450px',
 		});
-	}		
+	}
+	
+	function appendAnnotation(annotation) {
+		var annotationField = fieldingEditor.find('#annotation');
+		if (annotationField.val() != '') {
+			annotation = '; ' + annotation;
+		}
+		annotationField.val(annotationField.val() + annotation);
+		WS.Set(fieldingEditor.data('prefix') + 'Annotation', annotationField.val());
+	}
 	
 	function processSkater(k, v) {
-		var role = WS.state['ScoreBoard.Team('+teamId+').Skater('+k.Skater+').Role'];
-		var number = WS.state['ScoreBoard.Team('+teamId+').Skater('+k.Skater+').Number'];
-		var playing = (role != null && role != 'NotInGame'); 
-
-		var option = $("#FieldingEditor #skater option[value='"+k.Skater+"']");
-		var inserted = false;
-		if (number != null && option.length == 0) {
-			var option = $('<option>').attr('value', k.Skater).text(number);
-			$('#FieldingEditor #skater').children().each(function (idx, s) {
-				if (s.text > number && idx > 0) {
-					$(s).before(option);
-					inserted = true;
-					return false;
-				}
-			});
-			if (!inserted) option.appendTo($('#FieldingEditor #skater'));
-		} else if (!playing) {
-			option.remove();
-		} else {
-			option.text(number);
+		var select = $('#FieldingEditor #skater');
+		select.children('[value="'+k.Skater+'"]').remove();
+		var prefix = 'ScoreBoard.Team('+k.Team+').Skater('+k.Skater+').';
+		if (v != null && WS.state[prefix + 'Role'] != 'NotInGame') {
+			var number = WS.state[prefix + 'Number'];
+			var option = $('<option>').attr('number', number).val(k.Skater).text(number);
+			_windowFunctions.appendAlphaSortedByAttr(select, option, 'number', 1);
 		}
 	}
 	

--- a/html/controls/operator.js
+++ b/html/controls/operator.js
@@ -799,17 +799,17 @@ function createTeamTable() {
 			.attr("id", "Team"+team+"NoPivot").addClass("KeyControl").button().appendTo(starPassTd);
 
 		var makeSkaterDropdown = function(pos, elem, sort) {
-			var select = $("<select>").append($("<option value=''>?</option>"));
-			WS.Register([prefix + ".Skater(*).Number", prefix + ".Skater(*).Role"], function(k, v) {
-				select.children("[value='"+k.Skater+"']").remove();
-				if (v != null && WS.state[prefix + ".Skater("+k.Skater+").Role"] != "NotInGame") {
-					var number = WS.state[prefix + ".Skater("+k.Skater+").Number"];
-					var option = $("<option>").attr("number", number).val(k.Skater).text(number);
-					_windowFunctions.appendAlphaSortedByAttr(select, option, "number", 1);
-					select.val(WS.state[prefix + ".Position("+pos+").Skater"]);
+			var select = $('<select>').append($('<option value="">?</option>'));
+			WS.Register([prefix + '.Skater(*).Number', prefix + '.Skater(*).Role'], function(k, v) {
+				select.children('[value="'+k.Skater+'"]').remove();
+				if (v != null && WS.state[prefix + '.Skater('+k.Skater+').Role'] != 'NotInGame') {
+					var number = WS.state[prefix + '.Skater('+k.Skater+').Number'];
+					var option = $('<option>').attr('number', number).val(k.Skater).text(number);
+					_windowFunctions.appendAlphaSortedByAttr(select, option, 'number', 1);
+					select.val(WS.state[prefix + '.Position('+pos+').Skater']);
 				}
 			});
-			WSControl(prefix + ".Position("+pos+").Skater", select);
+			WSControl(prefix + '.Position('+pos+').Skater', select);
 			return select;
 		};
 

--- a/html/controls/plt/index.html
+++ b/html/controls/plt/index.html
@@ -12,6 +12,7 @@
 		-->
 		<script type="text/javascript" src="/external/jquery/jquery.js"></script>
 		<script type="text/javascript" src="/json/core.js"></script>
+		<script type="text/javascript" src="/javascript/windowfunctions.js"></script>
 		<script type="text/javascript" src="plt-input.js"></script>
 		<script type="text/javascript" src="../lt/lt-sheet.js"></script>
 	</head>

--- a/html/controls/plt/index.html
+++ b/html/controls/plt/index.html
@@ -19,6 +19,7 @@
 		<div id="input"></div>
 		<div id="sheet" width="100%"></div>
 		<div id="PenaltyEditor"></div>
+		<div id="AnnotationEditor"></div>
 		<div id="FieldingEditor"></div>
 	</body>
 </html>

--- a/html/controls/plt/index.js
+++ b/html/controls/plt/index.js
@@ -11,6 +11,8 @@
 	
 	preparePenaltyEditor();
 	
+	prepareAnnotationEditor(teamId);
+	
 	prepareFieldingEditor(teamId);
 
 	WS.AutoRegister();

--- a/html/controls/plt/plt-input.css
+++ b/html/controls/plt/plt-input.css
@@ -72,6 +72,7 @@ body:not(.AllowSelect) .PLT {
 #PenaltyEditor .Codes>div .Description { font-size: 0.75em; }
 #PenaltyEditor .ui-button { font-size: 75%; }
 #PenaltyEditor .ui-button.checked { background: #3f3; }
+#PenaltyEditor .Hide { display: none; }
 
 #AnnotationEditor .Hide { display: none; }
 #AnnotationEditor .ui-button { font-size: 75%; }

--- a/html/controls/plt/plt-input.css
+++ b/html/controls/plt/plt-input.css
@@ -71,9 +71,10 @@ body:not(.AllowSelect) .PLT {
 #PenaltyEditor .Codes>div div { text-align: center; }
 #PenaltyEditor .Codes>div .Code { font-size: 1.2em; background-color: #FAA; color: #000; }
 #PenaltyEditor .Codes>div .Description { font-size: 0.75em; }
-#PenaltyEditor .ui-button { font-size: 75%; }
+#PenaltyEditor .ui-button.small { font-size: 75%; }
 #PenaltyEditor .ui-button.checked { background: #3f3; }
 #PenaltyEditor .Hide { display: none; }
+#PenaltyEditor td { text-align: center; }
 
 #AnnotationEditor .Hide { display: none; }
 #AnnotationEditor .ui-button { font-size: 75%; }

--- a/html/controls/plt/plt-input.css
+++ b/html/controls/plt/plt-input.css
@@ -20,6 +20,7 @@ body:not(.AllowSelect) .PLT {
 	width: 99%;
 	top: 0%;
 }
+.PLT.Team .Hide { display: none; }
 /* Colors are the same as the operator controls, so per-team colours look the same on both. */
 .PLT.Team thead td { font-size: 1em; font-weight: bold; background-color: #cccccc; color: #333333; }
 .PLT.Team #StarPass { background-color: #cee7ff; font-weight: normal; }
@@ -36,7 +37,7 @@ body:not(.AllowSelect) .PLT {
 .PLT.Team .Role { background-color: #FFF; }
 .PLT.Team tr:nth-child(4n-1) .Role:not(.OnTrack), .PLT.Team tr:nth-child(4n-1) .Advance:not(.Active) { background-color: #e7f3ff; }
 .PLT.Team .Sitting, .PLT.Team .Trips { background-color: #e7f3ff; }
-.PLT.Team tr:nth-child(4n-1) .Sitting:not(.inBox), .PLT.Team tr:nth-child(4n-1) .Trips { background-color: #cee7ff; }
+.PLT.Team tr:nth-child(4n-1) .Sitting:not(.inBox):not(.Unserved), .PLT.Team tr:nth-child(4n-1) .Trips { background-color: #cee7ff; }
 .PLT.Team .Number { font-weight: bold; background-color: #f4f4f4; }
 .PLT.Team tr:nth-child(4n-1) .Number:not(.OnTrack) { background-color: #E8E8E8; }
 .PLT.Team .Box0 { background-color: #ffd0ff; }

--- a/html/controls/plt/plt-input.css
+++ b/html/controls/plt/plt-input.css
@@ -34,7 +34,7 @@ body:not(.AllowSelect) .PLT {
 .PLT.Team tr { background-color: #FFF; height: 22px; }
 .PLT.Team tr:nth-child(4n+0), .PLT.Team tr:nth-child(4n-1) { background-color: #FFE8FF; }
 .PLT.Team .Role { background-color: #FFF; }
-.PLT.Team tr:nth-child(4n-1) .Role:not(.OnTrack), .PLT.Team .Advance:not(.Active) { background-color: #e7f3ff; }
+.PLT.Team tr:nth-child(4n-1) .Role:not(.OnTrack), .PLT.Team tr:nth-child(4n-1) .Advance:not(.Active) { background-color: #e7f3ff; }
 .PLT.Team .Sitting, .PLT.Team .Trips { background-color: #e7f3ff; }
 .PLT.Team tr:nth-child(4n-1) .Sitting:not(.inBox), .PLT.Team tr:nth-child(4n-1) .Trips { background-color: #cee7ff; }
 .PLT.Team .Number { font-weight: bold; background-color: #f4f4f4; }
@@ -55,17 +55,21 @@ body:not(.AllowSelect) .PLT {
 
 .PLT.Team .Unserved { background-color: #0FF; }
 .PLT.Team .Serving { background-color: #70ff70; }
-.PLT.Team .OnTrack { background-color: #70ff70; }
-.PLT.Team tr[role='Pivot'] .OnTrack { background-color: #00ee00; }
-.PLT.Team tr[role='Jammer'] .OnTrack { background-color: #00cc00; }
+.PLT.Team .OnTrack:not(.Advance) { background-color: #70ff70; }
+.PLT.Team tr[role='Pivot'] .OnTrack:not(.Advance) { background-color: #00ee00; }
+.PLT.Team tr[role='Jammer'] .OnTrack:not(.Advance) { background-color: #00cc00; }
 .PLT.Team .inBox { background-color: #ff4040; }
-.PLT.Team .Advance { border: none; }
-.PLT.Team .Advance.Active { background-color: #ff9010;  vertical-align: bottom; }
+.PLT.Team .Advance { }
+.PLT.Team .Advance.Active { border: none; background-color: #ff9010;  vertical-align: bottom; }
 .PLT.Team tr:nth-child(6n+1) .Advance.Active::after { content: "Go To"; }
 .PLT.Team tr:nth-child(6n+3) .Advance.Active::after { content: "Next Jam"; }
+.PLT.Team .Advance:not(.Active).OnTrack::after { content: "..."; }
 
 #PenaltyEditor .Codes>div { float: left; width: 150px; height: 90px; margin: 10px; border: 1px solid black; font-weight: bold; }
 #PenaltyEditor .Codes>div.Active { background-color: #F00; color: #FFF; }
 #PenaltyEditor .Codes>div div { text-align: center; }
 #PenaltyEditor .Codes>div .Code { font-size: 1.2em; background-color: #FAA; color: #000; }
 #PenaltyEditor .Codes>div .Description { font-size: 0.75em; }
+
+#AnnotationEditor .Hide { display: none; }
+#AnnotationEditor .ui-button { font-size: 75%; }

--- a/html/controls/plt/plt-input.css
+++ b/html/controls/plt/plt-input.css
@@ -70,6 +70,8 @@ body:not(.AllowSelect) .PLT {
 #PenaltyEditor .Codes>div div { text-align: center; }
 #PenaltyEditor .Codes>div .Code { font-size: 1.2em; background-color: #FAA; color: #000; }
 #PenaltyEditor .Codes>div .Description { font-size: 0.75em; }
+#PenaltyEditor .ui-button { font-size: 75%; }
+#PenaltyEditor .ui-button.checked { background: #3f3; }
 
 #AnnotationEditor .Hide { display: none; }
 #AnnotationEditor .ui-button { font-size: 75%; }

--- a/html/controls/plt/plt-input.js
+++ b/html/controls/plt/plt-input.js
@@ -430,6 +430,7 @@ function openPenaltyEditor(t, id, which) {
 		}
 	}
 	$('#PenaltyEditor #served').toggleClass('checked', wasServed);
+	$('#PenaltyEditor .set').toggleClass('Hide', isNew);
 	while (!isNaN(penaltyNumber) && penaltyNumber > 1 &&
 			WS.state[prefix + '.Penalty(' + (penaltyNumber-1) + ').Code'] == null) {
 		penaltyNumber--;
@@ -461,13 +462,13 @@ function preparePenaltyEditor() {
 			.append($('<select>').addClass('Period')).append($('<button>').addClass('period_plus').text('+1').button()).appendTo(tr);
 		$('<td width="35%">').append($('<span>').text('Jam: ')).append($('<button>').addClass('jam_minus').text('-1').button())
 			.append($('<select>').addClass('Jam')).append($('<button>').addClass('jam_plus').text('+1').button()).appendTo(tr);
-		$('<td width="15%">').append($('<button>').addClass('set').text('Set Jam').button()).appendTo(tr);
+		$('<td width="15%">').append($('<button>').addClass('set Hide').text('Set Period/Jam').button()).appendTo(tr);
 		$('<td width="15%">').append($('<button>').addClass('clear').text('Clear').button()).appendTo(tr);
 		
 		var tr2 = $('<tr>').appendTo(topTable);
 		$('<td>').append($('<button>').text('Served').attr('id', 'served').button().click(function() {
-			var active = $(this).hasClass('checked');
-			$(this).toggleClass('checked', !active);
+			var active = !$(this).hasClass('checked');
+			$(this).toggleClass('checked', active);
 			if (!isTrue(penaltyEditor.data('new'))) {
 				var teamId = penaltyEditor.data('team');
 				var skaterId = penaltyEditor.data('skater');
@@ -663,8 +664,8 @@ function prepareAnnotationEditor(teamId) {
 					WS.Set(prefix + 'Annotation', 'Substitute for #' + annotationEditor.data('skaterNumber'));
 					annotationEditor.dialog('close');
 				})).appendTo(row);
-		$('<td>').append($('<button>').text('Self Report').button().click(function() { leaveBox('Self Report');})).appendTo(row);
-		$('<td>').append($('<button>').text('Penalty Revoked').button().click(function() { leaveBox('Penalty Revoked');})).appendTo(row);
+		$('<td>').append($('<button>').text('No Penalty').button().click(function() { leaveBox('No Penalty');})).appendTo(row);
+		$('<td>').append($('<button>').text('Penalty Overturned').button().click(function() { leaveBox('Penalty Overturned');})).appendTo(row);
 		
 		row = $('<tr>').appendTo(table);
 		$('<td>').attr('colspan', '3').append(annotationField).append($('<button>').text('Set').button().click(function() {

--- a/html/controls/plt/plt-input.js
+++ b/html/controls/plt/plt-input.js
@@ -632,19 +632,21 @@ function openAnnotationEditor(teamId, skaterId) {
 	var prefix = 'ScoreBoard.Team('+teamId+').Skater('+skaterId+').';
 	var skaterNumber = WS.state[prefix + 'Number'];
 	var position = WS.state[prefix + 'Position'].slice(2);
-	var annotationPath = ').TeamJam('+teamId+').Fielding(' + position + ').Annotation';
+	var fieldingPrefix = ').TeamJam('+teamId+').Fielding(' + position + ').';
 	if (isTrue(WS.state['ScoreBoard.InJam'])) {
-		annotationPath = 'ScoreBoard.Period(' + WS.state['ScoreBoard.CurrentPeriodNumber'] +
+		fieldingPrefix = 'ScoreBoard.Period(' + WS.state['ScoreBoard.CurrentPeriodNumber'] +
 		').Jam(' + WS.state['ScoreBoard.Period('+WS.state['ScoreBoard.CurrentPeriodNumber']+').CurrentJamNumber']
-		+ annotationPath;
+		+ fieldingPrefix;
 	} else {
-		annotationPath = 'ScoreBoard.Jam(' + WS.state['ScoreBoard.UpcomingJamNumber'] + annotationPath;
+		fieldingPrefix = 'ScoreBoard.Jam(' + WS.state['ScoreBoard.UpcomingJamNumber'] + fieldingPrefix;
 	}
 	annotationEditor.data('skaterNumber', skaterNumber);
 	annotationEditor.data('position', position);
 	annotationEditor.find('#subDropdown').val(skaterId);
-	annotationEditor.find('#annotation').val(WS.state[annotationPath]);
-	annotationEditor.find('.Box').toggleClass('Hide', !isTrue(WS.state[prefix + 'PenaltyBox']));
+	annotationEditor.find('#annotation').val(WS.state[fieldingPrefix + 'Annotation']);
+	annotationEditor.find('.Box').toggleClass('Hide', WS.state[fieldingPrefix + 'CurrentBoxTrip'] == '');
+	annotationEditor.find('.Box .Current').toggleClass('Hide', !isTrue(WS.state[prefix + 'PenaltyBox']))
+	annotationEditor.find('.Box .Past').toggleClass('Hide', isTrue(WS.state[prefix + 'PenaltyBox']))
 	annotationEditor.dialog('open');
 }
 
@@ -658,8 +660,12 @@ function prepareAnnotationEditor(teamId) {
 	function initialize() {
 		var table = $('<table>').appendTo($('#AnnotationEditor'));
 		var row = $('<tr>').addClass('Box').appendTo(table);
-		$('<td>').append(subDropdown)
-				.append($('<button>').text('Substitute').button().click(function() {
+		$('<td>').append($('<button>').addClass('Past').text('Unend Box Trip').button().click(function() {
+					var prefix = jamPrefix + annotationEditor.data('position') + ').';
+					WS.Set(prefix + 'UnendBoxTrip', true);
+				}))
+				.append(subDropdown.addClass('Current'))
+				.append($('<button>').addClass('Current').text('Substitute').button().click(function() {
 					var prefix = jamPrefix + annotationEditor.data('position') + ').';
 					WS.Set(prefix + 'Skater', subDropdown.val());
 					WS.Set(prefix + 'Annotation', 'Substitute for #' + annotationEditor.data('skaterNumber'));

--- a/html/controls/plt/plt-input.js
+++ b/html/controls/plt/plt-input.js
@@ -40,12 +40,10 @@ function preparePltInputTable(element, teamId, mode, statsbookPeriod, alternateN
 		if (mode == 'plt' || mode == 'pt') {
 			$('<td>').text('#').appendTo(thead);
 		}
-		if (mode != 'lt') {
-			$('<td>').attr('colspan', '9').attr('id', 'head').text('Team ' + teamId).appendTo(thead);
-			$('<td>').text('FO_Ex').appendTo(thead);
-		}
+		$('<td>').attr('colspan', '9').attr('id', 'head').text('Team ' + teamId).toggleClass('Hide', mode == 'lt').appendTo(thead);
+		$('<td>').text('FO_Ex').toggleClass('Hide', mode == 'lt').appendTo(thead);
 		totalPenalties = $('<td>').attr('id', 'totalPenalties').text('Σ 0');
-		if (mode == 'plt' || mode == 'pt') {
+		if (mode != 'copyToStatsbook') {
 			totalPenalties.appendTo(thead);
 		}
 		tbody = $('<tbody>').appendTo(table);
@@ -131,12 +129,10 @@ function preparePltInputTable(element, teamId, mode, statsbookPeriod, alternateN
 
 			// New skater, or number has been updated.
 			makeSkaterRows(t, k.Skater, v);
-			if (mode != 'lt') {
-				for (var i = 1; i <= 9; i++) {
-					displayPenalty(t, k.Skater, i, null);
-				}
-				displayPenalty(t, k.Skater, 0, null);
+			for (var i = 1; i <= 9; i++) {
+				displayPenalty(t, k.Skater, i, null);
 			}
+			displayPenalty(t, k.Skater, 0, null);
 		} else if (field == 'Role') {
 			if (mode != 'copyToStatsbook' && v == 'NotInGame') {
 				tbody.children('.Skater.Penalty[id=' + k.Skater + ']').children('.Total').each( function(idx, elem) {
@@ -166,7 +162,7 @@ function preparePltInputTable(element, teamId, mode, statsbookPeriod, alternateN
 			.toggleClass('OnTrack', v == 'Jammer' || v == 'Pivot' || v == 'Blocker');
 		} else if (field == 'PenaltyBox') {
 			element.find('.Skater.Penalty[id=' + k.Skater + '] .Sitting').toggleClass('inBox', isTrue(v));
-		} else if (mode != 'lt'){
+		} else {
 			// Look for penalty
 			if (k.Penalty == null) return
 			displayPenalty(t, k.Skater, k.Penalty, k);
@@ -275,7 +271,11 @@ function preparePltInputTable(element, teamId, mode, statsbookPeriod, alternateN
 		if (field == "Served" || field == "") {
 			jamBox.toggleClass("Unserved", WS.state[prefix + ".Served"] == false);
 			penaltyBox.toggleClass("Unserved", WS.state[prefix + ".Served"] == false);
-			codeRow.children('.Sitting').toggleClass("Unserved", WS.state[prefix + ".Served"] == false);
+			var anyUnserved = false;
+			codeRow.children('.Box:not(.Box0)').each(function (idx, elem) {
+				anyUnserved = anyUnserved || ($(elem).hasClass('Unserved'));
+			});
+			codeRow.children('.Sitting').toggleClass("Unserved", anyUnserved);
 		}
 	}
 
@@ -360,18 +360,16 @@ function preparePltInputTable(element, teamId, mode, statsbookPeriod, alternateN
 			}
 			p.append(numberCell);
 		}
-		if (mode != 'lt') {
-			$.each(new Array(9), function (idx) {
-				var c = idx + 1;
-				p.append($('<td>').addClass('Box Box' + c).html('&nbsp;').click(function () { openPenaltyEditor(t, id, c); }));
-				j.append($('<td>').addClass('Box Box' + c).html('&nbsp;').click(function () { openPenaltyEditor(t, id, c); }));
-			});
-	
-			p.append($('<td>').addClass('Box Box0').html('&nbsp;').click(function () { openPenaltyEditor(t, id, 0); }));
-			j.append($('<td>').addClass('Box Box0').html('&nbsp;').click(function () { openPenaltyEditor(t, id, 0); }));
-			if (mode != 'copyToStatsbook') {
-				p.append($('<td>').attr('rowspan', 2).addClass('Total').text('0'));
-			}
+		$.each(new Array(9), function (idx) {
+			var c = idx + 1;
+			p.append($('<td>').addClass('Box Box' + c).toggleClass('Hide', mode == 'lt').html('&nbsp;').click(function () { openPenaltyEditor(t, id, c); }));
+			j.append($('<td>').addClass('Box Box' + c).toggleClass('Hide', mode == 'lt').html('&nbsp;').click(function () { openPenaltyEditor(t, id, c); }));
+		});
+
+		p.append($('<td>').addClass('Box Box0').toggleClass('Hide', mode == 'lt').html('&nbsp;').click(function () { openPenaltyEditor(t, id, 0); }));
+		j.append($('<td>').addClass('Box Box0').toggleClass('Hide', mode == 'lt').html('&nbsp;').click(function () { openPenaltyEditor(t, id, 0); }));
+		if (mode != 'copyToStatsbook') {
+			p.append($('<td>').attr('rowspan', 2).addClass('Total').text('0'));
 		}
 		
 		var inserted = false;

--- a/html/controls/plt/plt-input.js
+++ b/html/controls/plt/plt-input.js
@@ -427,6 +427,7 @@ function openPenaltyEditor(t, id, which) {
 			isNew = false;
 		}
 	}
+	$('#PenaltyEditor .clear').button();
 	$('#PenaltyEditor #served').toggleClass('checked', wasServed);
 	$('#PenaltyEditor .set').toggleClass('Hide', isNew);
 	while (!isNaN(penaltyNumber) && penaltyNumber > 1 &&
@@ -454,17 +455,19 @@ function preparePenaltyEditor() {
 
 	function initialize() {
 		
-		var topTable = $('<table width="100%">').appendTo($('#PenaltyEditor'));
+		var topTable = $('<table>').appendTo($('#PenaltyEditor'));
 		var tr = $('<tr>').appendTo(topTable);
-		$('<td width="35%">').append($('<span>').text('Period: ')).append($('<button>').addClass('period_minus').text('-1').button())
-			.append($('<select>').addClass('Period')).append($('<button>').addClass('period_plus').text('+1').button()).appendTo(tr);
-		$('<td width="35%">').append($('<span>').text('Jam: ')).append($('<button>').addClass('jam_minus').text('-1').button())
-			.append($('<select>').addClass('Jam')).append($('<button>').addClass('jam_plus').text('+1').button()).appendTo(tr);
-		$('<td width="15%">').append($('<button>').addClass('set Hide').text('Set Period/Jam').button()).appendTo(tr);
-		$('<td width="15%">').append($('<button>').addClass('clear').text('Clear').button()).appendTo(tr);
+		$('<td>').append($('<span>').text('Period: ')).append($('<button>').addClass('period_minus small').text('-1').button())
+			.append($('<select>').addClass('Period')).append($('<button>').addClass('period_plus small').text('+1').button()).appendTo(tr);
+		$('<td>').append($('<span>').text('Jam: ')).append($('<button>').addClass('jam_minus small').text('-1').button())
+			.append($('<select>').addClass('Jam')).append($('<button>').addClass('jam_plus small').text('+1').button()).appendTo(tr);
+		$('<td>').append($('<button>').addClass('set Hide').text('Set Period/Jam').button()).appendTo(tr);
 		
-		var tr2 = $('<tr>').appendTo(topTable);
-		$('<td>').append($('<button>').text('Served').attr('id', 'served').button().click(function() {
+		$('<div>').addClass('Codes').appendTo($('#PenaltyEditor'));
+
+		var bottomTable = $('<table width="100%">').appendTo($('#PenaltyEditor'));
+		var tr2 = $('<tr>').appendTo(bottomTable);
+		$('<td width="50%">').append($('<button>').text('Served').attr('id', 'served').button().click(function() {
 			var active = !$(this).hasClass('checked');
 			$(this).toggleClass('checked', active);
 			if (!isTrue(penaltyEditor.data('new'))) {
@@ -476,7 +479,7 @@ function preparePenaltyEditor() {
 				penaltyEditor.dialog('close');
 			}
 		})).appendTo(tr2);
-		$('<div>').addClass('Codes').appendTo($('#PenaltyEditor'));
+		$('<td width="50%">').append($('<button>').addClass('clear').text('Delete').button()).appendTo(tr2);
 
 		WS.Register(['ScoreBoard.PenaltyCodes.Code'], penaltyCode);
 		WS.Register(['ScoreBoard.Rulesets.CurrentRule(Period.Number)'], function (k, v) { setupPeriodSelect(v); });
@@ -708,26 +711,13 @@ function prepareAnnotationEditor(teamId) {
 	}
 	
 	function processSkater(k, v) {
-		var role = WS.state['ScoreBoard.Team('+teamId+').Skater('+k.Skater+').Role'];
-		var number = WS.state['ScoreBoard.Team('+teamId+').Skater('+k.Skater+').Number'];
-		var playing = (role != null && role != 'NotInGame'); 
-
-		var option = $("#AnnotationEditor #subDropdown option[value='"+k.Skater+"']");
-		var inserted = false;
-		if (number != null && option.length == 0) {
-			var option = $('<option>').attr('value', k.Skater).text(number);
-			$('#AnnotationEditor #subDropdown').children().each(function (idx, s) {
-				if (s.text > number && idx > 0) {
-					$(s).before(option);
-					inserted = true;
-					return false;
-				}
-			});
-			if (!inserted) option.appendTo($('#AnnotationEditor #subDropdown'));
-		} else if (!playing) {
-			option.remove();
-		} else {
-			option.text(number);
+		var select = $('#AnnotationEditor #subDropdown');
+		select.children('[value="'+k.Skater+'"]').remove();
+		var prefix = 'ScoreBoard.Team('+k.Team+').Skater('+k.Skater+').';
+		if (v != null && WS.state[prefix + 'Role'] != 'NotInGame') {
+			var number = WS.state[prefix + 'Number'];
+			var option = $('<option>').attr('number', number).val(k.Skater).text(number);
+			_windowFunctions.appendAlphaSortedByAttr(select, option, 'number');
 		}
 	}
 }

--- a/html/controls/plt/plt-input.js
+++ b/html/controls/plt/plt-input.js
@@ -652,7 +652,7 @@ function prepareAnnotationEditor(teamId) {
 	$(initialize);
 	
 	var subDropdown = $('<select>').attr('id', 'subDropdown');
-	var annotationField = $('<input type="text">').attr('size', '35').attr('id', 'annotation');
+	var annotationField = $('<input type="text">').attr('size', '40').attr('id', 'annotation');
 	var jamPrefix;
 	
 	function initialize() {
@@ -669,9 +669,9 @@ function prepareAnnotationEditor(teamId) {
 		$('<td>').append($('<button>').text('Penalty Overturned').button().click(function() { leaveBox('Penalty Overturned');})).appendTo(row);
 		
 		row = $('<tr>').appendTo(table);
-		$('<td>').attr('colspan', '3').append(annotationField).append($('<button>').text('Set').button().click(function() {
+		$('<td>').attr('colspan', '3').append(annotationField.change(function() {
 			var prefix = jamPrefix + annotationEditor.data('position') + ').';
-			WS.Set(prefix + 'Annotation', annotationField.val());
+			WS.Set(prefix + 'Annotation', $(this).val());
 			annotationEditor.dialog('close');
 			})).appendTo(row);
 		

--- a/html/controls/pt/index.html
+++ b/html/controls/pt/index.html
@@ -12,6 +12,7 @@
 		-->
 		<script type="text/javascript" src="/external/jquery/jquery.js"></script>
 		<script type="text/javascript" src="/json/core.js"></script>
+		<script type="text/javascript" src="/javascript/windowfunctions.js"></script>
 		<script type="text/javascript" src="/controls/plt/plt-input.js"></script>
 	</head>
 	<body>

--- a/html/controls/sk/sk-sheet.css
+++ b/html/controls/sk/sk-sheet.css
@@ -40,3 +40,5 @@ body:not(.AllowSelect) .SK {
 #TripEditor input[type="number"] { width: 50px; }
 #TripEditor td { padding-bottom: 0.5em; }
 #TripEditor .buttons td { text-align: center; }
+#TripEditor .ui-button { font-size: 75%; }
+#TripEditor .ui-button.checked { background: #3f3; }

--- a/html/controls/sk/sk-sheet.js
+++ b/html/controls/sk/sk-sheet.js
@@ -266,25 +266,7 @@ function setupTripEditor(p, j, teamId, t) {
 	tripEditor.dialog('option', 'title', 'Period ' + p + ' Jam ' + j + ' Trip ' + (t==1?'Initial':t));
 	var scoreField = tripEditor.find('#score').val(WS.state[prefix+'Score']);
 	var afterSPField = tripEditor.find('#afterSP').prop('checked', isTrue(WS.state[prefix+'AfterSP']));
-	tripEditor.find('#submit, #remove').unbind('click');
-	tripEditor.find('#submit').click(function() {
-		if (scoreField.val() == "") {
-			WS.Set(prefix+'Remove', true);
-		} else {
-			WS.Set(prefix+'Score', scoreField.val());
-			WS.Set(prefix+'AfterSP', afterSPField.prop('checked'));
-		}
-		tripEditor.dialog('close');
-	});
-	tripEditor.find('#insert_before').unbind("click").click(function() {
-		WS.Set(prefix+'InsertBefore', true);
-	});
-	tripEditor.find('#remove').click(function() {
-		WS.Set(prefix+'Remove', true);
-		tripEditor.dialog('close');
-	});
-	tripEditor.find(":input").keydown(function(event) { if (event.which == 13) tripEditor.find('#submit').click(); });
-
+	tripEditor.data('prefix', prefix);
 	tripEditor.dialog('open');
 }
 
@@ -306,13 +288,29 @@ function prepareTripEditor() {
 		tripEditor.append($('<table>')
 				.append($('<tr>')
 						.append($('<td colspan="3">')
-								.append($('<input type="number" min="0">').attr('id', 'score'))
-								.append($('<input type="checkbox">').attr('id', 'afterSP'))
-								.append($('<span>').addClass('Infotext').text('SP in this or prior trip'))))
+								.append($('<input type="number" min="0">').attr('id', 'score').keydown(function(event) {
+									if (event.which == 13) tripEditor.find('#submit').click(); }).change(function() {
+										WS.Set(tripEditor.data('prefix')+'Score', $(this).val());
+									}))
+								.append($('<button>').attr('id', 'afterSP').text('SP in this or prior trip').button().click(function() {
+									var check = !$(this).hasClass('checked');
+									$(this).toggleClass('checked', check);
+									WS.Set(tripEditor.data('prefix')+'AfterSP', check);
+								}))))
 				.append($('<tr class="buttons">')
-						.append($('<td width="30%">').append($('<button>').attr('id','submit').text('Submit')))
-						.append($('<td width="40%">').append($('<button>').attr('id','insert_before').text('Insert Before')))
-						.append($('<td width="30%">').append($('<button>').attr('id','remove').text('Remove')))));
+						.append($('<td width="30%">').append($('<button>').attr('id','submit').text('Submit').button().click(function() {
+							if (tripEditor.find('#score').val() == '') {
+								WS.Set(tripEditor.data('prefix')+'Remove', true);
+							}
+							tripEditor.dialog('close');
+						})))
+						.append($('<td width="40%">').append($('<button>').attr('id','insert_before').text('Insert Before').button().click(function() {
+							WS.Set(tripEditor.data('prefix')+'InsertBefore', true);
+						})))
+						.append($('<td width="30%">').append($('<button>').attr('id','remove').text('Remove').button().click(function() {
+							WS.Set(tripEditor.data('prefix')+'Remove', true);
+							tripEditor.dialog('close');
+						})))));
 	}
 }
 

--- a/html/controls/sk/sk-sheet.js
+++ b/html/controls/sk/sk-sheet.js
@@ -265,7 +265,7 @@ function setupTripEditor(p, j, teamId, t) {
 
 	tripEditor.dialog('option', 'title', 'Period ' + p + ' Jam ' + j + ' Trip ' + (t==1?'Initial':t));
 	var scoreField = tripEditor.find('#score').val(WS.state[prefix+'Score']);
-	var afterSPField = tripEditor.find('#afterSP').prop('checked', isTrue(WS.state[prefix+'AfterSP']));
+	var afterSPField = tripEditor.find('#afterSP').toggleClass('checked', isTrue(WS.state[prefix+'AfterSP']));
 	tripEditor.data('prefix', prefix);
 	tripEditor.dialog('open');
 }
@@ -287,29 +287,31 @@ function prepareTripEditor() {
 
 		tripEditor.append($('<table>')
 				.append($('<tr>')
-						.append($('<td colspan="3">')
+						.append($('<td>')
 								.append($('<input type="number" min="0">').attr('id', 'score').keydown(function(event) {
-									if (event.which == 13) tripEditor.find('#submit').click(); }).change(function() {
+									if (event.which == 13 && $(this).val() == '') {
+										WS.Set(tripEditor.data('prefix')+'Remove', true);
+										tripEditor.dialog('close');
+									}
+									}).change(function() {
 										WS.Set(tripEditor.data('prefix')+'Score', $(this).val());
-									}))
+									})))
+						.append($('<td colspan="2">')
 								.append($('<button>').attr('id', 'afterSP').text('SP in this or prior trip').button().click(function() {
 									var check = !$(this).hasClass('checked');
 									$(this).toggleClass('checked', check);
 									WS.Set(tripEditor.data('prefix')+'AfterSP', check);
 								}))))
 				.append($('<tr class="buttons">')
-						.append($('<td width="30%">').append($('<button>').attr('id','submit').text('Submit').button().click(function() {
-							if (tripEditor.find('#score').val() == '') {
-								WS.Set(tripEditor.data('prefix')+'Remove', true);
-							}
+						.append($('<td>').append($('<button>').attr('id','submit').text('Close').button().click(function() {
 							tripEditor.dialog('close');
 						})))
-						.append($('<td width="40%">').append($('<button>').attr('id','insert_before').text('Insert Before').button().click(function() {
-							WS.Set(tripEditor.data('prefix')+'InsertBefore', true);
-						})))
-						.append($('<td width="30%">').append($('<button>').attr('id','remove').text('Remove').button().click(function() {
+						.append($('<td>').append($('<button>').attr('id','remove').text('Remove').button().click(function() {
 							WS.Set(tripEditor.data('prefix')+'Remove', true);
 							tripEditor.dialog('close');
+						})))
+						.append($('<td>').append($('<button>').attr('id','insert_before').text('Insert Before').button().click(function() {
+							WS.Set(tripEditor.data('prefix')+'InsertBefore', true);
 						})))));
 	}
 }

--- a/src/com/carolinarollergirls/scoreboard/core/BoxTrip.java
+++ b/src/com/carolinarollergirls/scoreboard/core/BoxTrip.java
@@ -10,6 +10,7 @@ public interface BoxTrip extends ScoreBoardEventProvider {
     public int compareTo(BoxTrip other);
     
     public void end();
+    public void unend();
     
     public Team getTeam();
     

--- a/src/com/carolinarollergirls/scoreboard/core/Fielding.java
+++ b/src/com/carolinarollergirls/scoreboard/core/Fielding.java
@@ -51,7 +51,8 @@ public interface Fielding extends ParentOrderedScoreBoardEventProvider<Fielding>
         public Class<? extends ValueWithId> getType() { return type; }
     }
     public enum Command implements CommandProperty {
-        ADD_BOX_TRIP;
+        ADD_BOX_TRIP,
+        UNEND_BOX_TRIP;
         
         @Override
         public Class<Boolean> getType() { return Boolean.class; }

--- a/src/com/carolinarollergirls/scoreboard/core/Position.java
+++ b/src/com/carolinarollergirls/scoreboard/core/Position.java
@@ -29,6 +29,7 @@ public interface Position extends ScoreBoardEventProvider {
         ID(String.class, ""),
         CURRENT_FIELDING(Fielding.class, null),
         CURRENT_BOX_SYMBOLS(String.class, ""),
+        ANNOTATION(String.class, ""),
         SKATER(Skater.class, null),
         NAME(String.class, ""),
         NUMBER(String.class, ""),

--- a/src/com/carolinarollergirls/scoreboard/core/impl/BoxTripImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/impl/BoxTripImpl.java
@@ -231,7 +231,7 @@ public class BoxTripImpl extends ScoreBoardEventProviderImpl implements BoxTrip 
     public void end() {
         set(Value.IS_CURRENT, false);
         set(Value.WALLTIME_END, ScoreBoardClock.getInstance().getCurrentWalltime());
-        if (getTeam().hasFieldingAdvancePending()) {
+        if (getTeam().hasFieldingAdvancePending() && getCurrentFielding().getTeamJam().isRunningOrUpcoming()) {
             getCurrentFielding().setSkater(null);
             remove(Child.FIELDING, getCurrentFielding());
         }

--- a/src/com/carolinarollergirls/scoreboard/core/impl/BoxTripImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/impl/BoxTripImpl.java
@@ -24,8 +24,8 @@ public class BoxTripImpl extends ScoreBoardEventProviderImpl implements BoxTrip 
     public BoxTripImpl(Fielding f) {
         super(f.getTeamJam().getTeam(), Value.ID, UUID.randomUUID().toString(), Team.Child.BOX_TRIP, BoxTrip.class, Value.class, Child.class, Command.class);
         set(Value.WALLTIME_START, ScoreBoardClock.getInstance().getCurrentWalltime());
-        set(Value.START_AFTER_S_P, f.getTeamJam().isStarPass());
-        set(Value.START_BETWEEN_JAMS, !scoreBoard.isInJam() && !getTeam().hasFieldingAdvancePending());
+        set(Value.START_AFTER_S_P, f.getTeamJam().isStarPass() && f.isCurrent());
+        set(Value.START_BETWEEN_JAMS, !scoreBoard.isInJam() && !getTeam().hasFieldingAdvancePending() && f.isCurrent());
         set(Value.JAM_CLOCK_START, startedBetweenJams() ? 0L : scoreBoard.getClock(Clock.ID_JAM).getTimeElapsed());
         set(Value.IS_CURRENT, true);
         initReferences();
@@ -81,9 +81,10 @@ public class BoxTripImpl extends ScoreBoardEventProviderImpl implements BoxTrip 
     }
     @Override
     protected void valueChanged(PermanentProperty prop, Object value, Object last, Flag flag) {
-        if (prop == Value.IS_CURRENT && !(Boolean)value) {
+        if (prop == Value.IS_CURRENT) {
             for (ValueWithId f : getAll(Child.FIELDING)) {
-                ((Fielding)f).set(Fielding.Value.PENALTY_BOX, false);
+                ((Fielding)f).set(Fielding.Value.CURRENT_BOX_TRIP, this);
+                ((Fielding)f).set(Fielding.Value.PENALTY_BOX, value);
             }
         }
         if ((prop == Value.END_FIELDING || prop == Value.END_AFTER_S_P || prop == Value.END_BETWEEN_JAMS)
@@ -170,56 +171,58 @@ public class BoxTripImpl extends ScoreBoardEventProviderImpl implements BoxTrip 
                 break;
             case START_LATER:
                 if (getStartFielding() == null) { break; }
-                if (getStartFielding() == getEndFielding()) {
-                    if (startedBetweenJams() && !endedBetweenJams()) {
-                        set(Value.START_BETWEEN_JAMS, false);
-                    } else if (endedAfterSP() && !startedAfterSP()) {
+                if (getStartFielding().getTeamJam().isRunningOrUpcoming() && 
+                        !scoreBoard.isInJam()) { break; }
+                if (startedBetweenJams()) {
+                    set(Value.START_BETWEEN_JAMS, false);
+                } else if (getStartFielding() == getEndFielding()) {
+                    if (endedAfterSP() && !startedAfterSP()) {
                         set(Value.START_AFTER_S_P, true);
                     }
-                    break;
-                } else {
-                    if (startedBetweenJams()) {
-                        set(Value.START_BETWEEN_JAMS, false);
-                    } else if (!startedAfterSP() && getStartFielding().getTeamJam().isStarPass()) {
-                        set(Value.START_AFTER_S_P, true);
-                    } else {
-                        remove(Child.FIELDING, getStartFielding());
-                        set(Value.START_AFTER_S_P, false);
-                        set(Value.START_BETWEEN_JAMS, true);
-                    }
+                } else if (!startedAfterSP() && getStartFielding().getTeamJam().isStarPass()) {
+                    set(Value.START_AFTER_S_P, true);
+                } else if (getStartFielding() != getCurrentFielding()) {
+                    remove(Child.FIELDING, getStartFielding());
+                    set(Value.START_AFTER_S_P, false);
+                    set(Value.START_BETWEEN_JAMS, true);
                 }
                 break;
             case END_EARLIER:
-                if (getEndFielding() == null) { break; }
-                if (getStartFielding() == getEndFielding()) {
+                if (getEndFielding() == null) {
+                    end();
+                } else if (endedBetweenJams()) {
+                    set(Value.END_BETWEEN_JAMS, false);
+                } else if (getStartFielding() == getEndFielding()) {
                     if (endedAfterSP() && !startedAfterSP()) {
                         set(Value.END_AFTER_S_P, false);
                     }
-                    break;
+                } else if (endedAfterSP()) {
+                    set(Value.END_AFTER_S_P, false);
                 } else {
-                    if (endedAfterSP()) {
-                        set(Value.END_AFTER_S_P, false);
-                    } else if(!endedBetweenJams()) {
-                        set(Value.END_BETWEEN_JAMS, true);
-                    } else {
-                        remove(Child.FIELDING, getEndFielding());
-                        set(Value.END_BETWEEN_JAMS, false);
-                        if (getEndFielding().getTeamJam().isStarPass()) {
-                            set(Value.END_AFTER_S_P, true);
-                        }
+                    remove(Child.FIELDING, getEndFielding());
+                    set(Value.END_BETWEEN_JAMS, true);
+                    if (getEndFielding().getTeamJam().isStarPass()) {
+                        set(Value.END_AFTER_S_P, true);
                     }
                 }
                 break;
             case END_LATER:
                 if (getEndFielding() == null) { break; }
-                if (endedBetweenJams()) {
-                    set(Value.END_BETWEEN_JAMS, false);
-                } else if (!endedAfterSP() && getEndFielding().getTeamJam().isStarPass()) {
+                if (!endedAfterSP() && getEndFielding().getTeamJam().isStarPass()) {
                     set(Value.END_AFTER_S_P, true);
-                } else if (add(Child.FIELDING, getStartFielding().getSkater().getFielding(
-                        getStartFielding().getTeamJam().getNext()))) {
-                    set(Value.END_AFTER_S_P, false);
+                } else if (!endedBetweenJams()) {
                     set(Value.END_BETWEEN_JAMS, true);
+                } else if (add(Child.FIELDING, getEndFielding().getSkater().getFielding(
+                        getEndFielding().getTeamJam().getNext()))) {
+                    set(Value.END_AFTER_S_P, false);
+                    set(Value.END_BETWEEN_JAMS, false);
+                }
+                if (getEndFielding().getTeamJam().isRunningOrUpcoming() &&
+                        (endedBetweenJams() || !scoreBoard.isInJam())) {
+                    // moved end past the present point in the game -> make ongoing if possible
+                    if (!getEndFielding().isInBox()) {
+                        unend();
+                    }
                 }
                 break;
             }
@@ -231,19 +234,32 @@ public class BoxTripImpl extends ScoreBoardEventProviderImpl implements BoxTrip 
     public void end() {
         set(Value.IS_CURRENT, false);
         set(Value.WALLTIME_END, ScoreBoardClock.getInstance().getCurrentWalltime());
-        if (getTeam().hasFieldingAdvancePending() && getCurrentFielding().getTeamJam().isRunningOrUpcoming()) {
-            getCurrentFielding().setSkater(null);
+        if (!scoreBoard.isInJam() && getCurrentFielding().getTeamJam().isRunningOrUpcoming()) {
+            if (getTeam().hasFieldingAdvancePending()) {
+                getCurrentFielding().setSkater(null);
+            }
             remove(Child.FIELDING, getCurrentFielding());
         }
-        set(Value.END_FIELDING, get(Value.CURRENT_FIELDING));
-        set(Value.END_BETWEEN_JAMS, !scoreBoard.isInJam() && !getTeam().hasFieldingAdvancePending());
-        set(Value.END_AFTER_S_P, getEndFielding().getTeamJam().isStarPass());
-        set(Value.JAM_CLOCK_END, endedBetweenJams() ? 0L : scoreBoard.getClock(Clock.ID_JAM).getTimeElapsed());
-        getCurrentFielding().updateBoxTripSymbols();
-        if (getStartFielding() == getEndFielding() && endedBetweenJams()) {
-//            || ((Long)get(Value.DURATION) < 5000L && getAll(Child.PENALTY).size() == 0)) {
+        if (getCurrentFielding() == null) {
+            // trip ended in the same interjam as it started -> ignore it
             unlink();
+        } else {
+            set(Value.END_FIELDING, get(Value.CURRENT_FIELDING));
+            set(Value.END_BETWEEN_JAMS, !scoreBoard.isInJam() && !getTeam().hasFieldingAdvancePending()
+                    && getEndFielding().getTeamJam().isRunningOrEnded());
+            set(Value.END_AFTER_S_P, getEndFielding().getTeamJam().isStarPass() && getEndFielding().isCurrent());
+            set(Value.JAM_CLOCK_END, endedBetweenJams() ? 0L : scoreBoard.getClock(Clock.ID_JAM).getTimeElapsed());
+            getCurrentFielding().updateBoxTripSymbols();
         }
+    }
+    
+    @Override
+    public void unend() {
+        set(Value.END_FIELDING, null);
+        set(Value.END_BETWEEN_JAMS, false);
+        set(Value.END_AFTER_S_P, false);
+        set(Value.IS_CURRENT, true);
+        getCurrentFielding().updateBoxTripSymbols();
     }
     
     @Override

--- a/src/com/carolinarollergirls/scoreboard/core/impl/PositionImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/impl/PositionImpl.java
@@ -27,6 +27,7 @@ public class PositionImpl extends ScoreBoardEventProviderImpl implements Positio
         setCopy(Value.SKATER, this, Value.CURRENT_FIELDING, Fielding.Value.SKATER, false);
         setCopy(Value.PENALTY_BOX, this, Value.CURRENT_FIELDING, Fielding.Value.PENALTY_BOX, false);
         setCopy(Value.CURRENT_BOX_SYMBOLS, this, Value.CURRENT_FIELDING, Fielding.Value.BOX_TRIP_SYMBOLS, true);
+        setCopy(Value.ANNOTATION, this, Value.CURRENT_FIELDING, Fielding.Value.ANNOTATION, true);
     }
 
     @Override

--- a/tests/com/carolinarollergirls/scoreboard/core/impl/BoxTripImplTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/core/impl/BoxTripImplTests.java
@@ -1,0 +1,290 @@
+package com.carolinarollergirls.scoreboard.core.impl;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.carolinarollergirls.scoreboard.core.Fielding;
+import com.carolinarollergirls.scoreboard.core.BoxTrip;
+import com.carolinarollergirls.scoreboard.core.Role;
+import com.carolinarollergirls.scoreboard.core.ScoreBoard;
+import com.carolinarollergirls.scoreboard.core.Skater;
+import com.carolinarollergirls.scoreboard.core.Team;
+import com.carolinarollergirls.scoreboard.event.ScoreBoardEvent;
+import com.carolinarollergirls.scoreboard.event.ScoreBoardListener;
+import com.carolinarollergirls.scoreboard.event.ScoreBoardEventProviderImpl.BatchEvent;
+import com.carolinarollergirls.scoreboard.utils.ScoreBoardClock;
+
+public class BoxTripImplTests {
+
+    private ScoreBoard sb;
+
+    private Team t;
+    private Skater s;
+    private BoxTrip bt;
+
+    private int batchLevel;
+    private ScoreBoardListener batchCounter = new ScoreBoardListener() {
+        @Override
+        public void scoreBoardChange(ScoreBoardEvent event) {
+            synchronized(batchCounter) {
+                if (event.getProperty() == BatchEvent.START) {
+                    batchLevel++;
+                } else if (event.getProperty() == BatchEvent.END) {
+                    batchLevel--;
+                }
+            }
+        }
+    };
+
+    @Before
+    public void setUp() throws Exception {
+        sb = new ScoreBoardImpl();
+        sb.addScoreBoardListener(batchCounter);
+
+        ScoreBoardClock.getInstance().stop();
+        t = sb.getTeam(Team.ID_1);
+        s = new SkaterImpl(t, (String)null);
+        t.addSkater(s);
+        sb.startJam();
+        sb.stopJamTO();
+        sb.startJam();
+        t.field(s, Role.PIVOT);
+        s.setPenaltyBox(true);
+        bt = (BoxTrip) s.getFielding(t.getRunningOrUpcomingTeamJam()).getAll(Fielding.Child.BOX_TRIP).iterator().next();
+        sb.stopJamTO();
+        sb.startJam();
+        s.setPenaltyBox(false);
+        sb.stopJamTO();
+        t.execute(Team.Command.ADVANCE_FIELDINGS);
+        // Now going into jam 4. Skater had a box trip that started in jam 2, and ended in jam 3.
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        ScoreBoardClock.getInstance().start(false);
+        // Check all started batches were ended.
+        assertEquals(0, batchLevel);
+    }
+
+    private String getBoxTripSymbols(int jam) {
+        Fielding f;
+        if (jam == 4) {
+            f = s.getFielding(t.getRunningOrUpcomingTeamJam());
+        } else {
+            f = s.getFielding(sb.getCurrentPeriod().getJam(jam).getTeamJam(Team.ID_1));
+        }
+        return f == null ? null : (String) f.get(Fielding.Value.BOX_TRIP_SYMBOLS);
+    }
+
+    @Test
+    public void testBaseCase() {
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals(" -", getBoxTripSymbols(2));
+        assertEquals(" $", getBoxTripSymbols(3));
+        assertEquals(null, getBoxTripSymbols(4));
+    }
+
+    @Test
+    public void testStartEarlier() {
+        // Start before jam.
+        bt.execute(BoxTrip.Command.START_EARLIER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals(" S", getBoxTripSymbols(2));
+        assertEquals(" $", getBoxTripSymbols(3));
+        assertEquals(null, getBoxTripSymbols(4));
+
+        // Can't go before the skater was present.
+        bt.execute(BoxTrip.Command.START_EARLIER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals(" S", getBoxTripSymbols(2));
+        assertEquals(" $", getBoxTripSymbols(3));
+        assertEquals(null, getBoxTripSymbols(4));
+    }
+
+    @Test
+    public void testStartLater() {
+        // Start between jams.
+        bt.execute(BoxTrip.Command.START_LATER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals("", getBoxTripSymbols(2));
+        assertEquals(" $", getBoxTripSymbols(3));
+        assertEquals(null, getBoxTripSymbols(4));
+
+        // Start in next jam.
+        bt.execute(BoxTrip.Command.START_LATER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals("", getBoxTripSymbols(2));
+        assertEquals(" +", getBoxTripSymbols(3));
+        assertEquals(null, getBoxTripSymbols(4));
+
+        // Can't go beyond end of penalty.
+        bt.execute(BoxTrip.Command.START_LATER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals("", getBoxTripSymbols(2));
+        assertEquals(" +", getBoxTripSymbols(3));
+        assertEquals(null, getBoxTripSymbols(4));
+    }
+
+    @Test
+    public void testEndEarlier() {
+        // End between Jams
+        bt.execute(BoxTrip.Command.END_EARLIER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals(" -", getBoxTripSymbols(2));
+        assertEquals("", getBoxTripSymbols(3));
+        assertEquals(null, getBoxTripSymbols(4));
+
+        // End during previous.
+        bt.execute(BoxTrip.Command.END_EARLIER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals(" +", getBoxTripSymbols(2));
+        assertEquals("", getBoxTripSymbols(3));
+        assertEquals(null, getBoxTripSymbols(4));
+
+        // Can't go beyond start of penalty.
+        bt.execute(BoxTrip.Command.END_EARLIER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals(" +", getBoxTripSymbols(2));
+        assertEquals("", getBoxTripSymbols(3));
+        assertEquals(null, getBoxTripSymbols(4));
+    }
+
+
+    @Test
+    public void testEndLater() {
+        bt.execute(BoxTrip.Command.END_LATER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals(" -", getBoxTripSymbols(2));
+        assertEquals(" S", getBoxTripSymbols(3));
+        assertEquals(null, getBoxTripSymbols(4));
+
+        // Penalty is ongoing, but skater isn't in the upcoming jam.
+        bt.execute(BoxTrip.Command.END_LATER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals(" -", getBoxTripSymbols(2));
+        assertEquals(" S", getBoxTripSymbols(3));
+        assertEquals(null, getBoxTripSymbols(4));
+
+        // Field them in upcoming jam.
+        t.field(s, Role.PIVOT);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals(" -", getBoxTripSymbols(2));
+        assertEquals(" S", getBoxTripSymbols(3));
+        assertEquals("", getBoxTripSymbols(4));
+        assertEquals(false, s.getFielding(t.getRunningOrUpcomingTeamJam()).isInBox());
+
+        // Now can mark penalty as ongoing.
+        bt.execute(BoxTrip.Command.END_LATER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals(" -", getBoxTripSymbols(2));
+        assertEquals(" S", getBoxTripSymbols(3));
+        assertEquals(" S", getBoxTripSymbols(4));
+        assertEquals(true, s.getFielding(t.getRunningOrUpcomingTeamJam()).isInBox());
+
+        // Can't go beyond ongoing.
+        bt.execute(BoxTrip.Command.END_LATER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals(" -", getBoxTripSymbols(2));
+        assertEquals(" S", getBoxTripSymbols(3));
+        assertEquals(" S", getBoxTripSymbols(4));
+        assertEquals(true, s.getFielding(t.getRunningOrUpcomingTeamJam()).isInBox());
+    }
+
+    @Test
+    public void testAdvanceEndToUpcomingAndBack() {
+        t.field(s, Role.PIVOT);
+        bt.execute(BoxTrip.Command.END_LATER);
+        bt.execute(BoxTrip.Command.END_LATER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals(" -", getBoxTripSymbols(2));
+        assertEquals(" S", getBoxTripSymbols(3));
+        assertEquals(" S", getBoxTripSymbols(4));
+
+        bt.execute(BoxTrip.Command.END_EARLIER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals(" -", getBoxTripSymbols(2));
+        assertEquals(" S", getBoxTripSymbols(3));
+        assertEquals("", getBoxTripSymbols(4));
+
+        bt.execute(BoxTrip.Command.END_EARLIER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals(" -", getBoxTripSymbols(2));
+        assertEquals(" $", getBoxTripSymbols(3));
+        assertEquals("", getBoxTripSymbols(4));
+
+        bt.execute(BoxTrip.Command.END_EARLIER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals(" -", getBoxTripSymbols(2));
+        assertEquals("", getBoxTripSymbols(3));
+        assertEquals("", getBoxTripSymbols(4));
+
+        bt.execute(BoxTrip.Command.END_EARLIER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals(" +", getBoxTripSymbols(2));
+        assertEquals("", getBoxTripSymbols(3));
+        assertEquals("", getBoxTripSymbols(4));
+    }
+
+    @Test
+    public void testAdvanceStartToUpcomingAndBack() {
+        t.field(s, Role.PIVOT);
+        bt.execute(BoxTrip.Command.END_LATER);
+        bt.execute(BoxTrip.Command.END_LATER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals(" -", getBoxTripSymbols(2));
+        assertEquals(" S", getBoxTripSymbols(3));
+        assertEquals(" S", getBoxTripSymbols(4));
+
+        bt.execute(BoxTrip.Command.START_LATER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals("", getBoxTripSymbols(2));
+        assertEquals(" S", getBoxTripSymbols(3));
+        assertEquals(" S", getBoxTripSymbols(4));
+
+        bt.execute(BoxTrip.Command.START_LATER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals("", getBoxTripSymbols(2));
+        assertEquals(" -", getBoxTripSymbols(3));
+        assertEquals(" S", getBoxTripSymbols(4));
+
+        bt.execute(BoxTrip.Command.START_LATER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals("", getBoxTripSymbols(2));
+        assertEquals("", getBoxTripSymbols(3));
+        assertEquals(" S", getBoxTripSymbols(4));
+
+        // Can't go beyond upcoming jam.
+        bt.execute(BoxTrip.Command.START_LATER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals("", getBoxTripSymbols(2));
+        assertEquals("", getBoxTripSymbols(3));
+        assertEquals(" S", getBoxTripSymbols(4));
+
+        bt.execute(BoxTrip.Command.START_EARLIER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals("", getBoxTripSymbols(2));
+        assertEquals(" -", getBoxTripSymbols(3));
+        assertEquals(" S", getBoxTripSymbols(4));
+
+        bt.execute(BoxTrip.Command.START_EARLIER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals("", getBoxTripSymbols(2));
+        assertEquals(" S", getBoxTripSymbols(3));
+        assertEquals(" S", getBoxTripSymbols(4));
+
+        bt.execute(BoxTrip.Command.START_EARLIER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals(" -", getBoxTripSymbols(2));
+        assertEquals(" S", getBoxTripSymbols(3));
+        assertEquals(" S", getBoxTripSymbols(4));
+
+        bt.execute(BoxTrip.Command.START_EARLIER);
+        assertEquals(null, getBoxTripSymbols(1));
+        assertEquals(" S", getBoxTripSymbols(2));
+        assertEquals(" S", getBoxTripSymbols(3));
+        assertEquals(" S", getBoxTripSymbols(4));
+    }
+
+}

--- a/tests/com/carolinarollergirls/scoreboard/core/impl/FieldingImplTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/core/impl/FieldingImplTests.java
@@ -130,7 +130,7 @@ public class FieldingImplTests {
        assertEquals(1, f1.getAll(Fielding.Child.BOX_TRIP).size());
        assertEquals(1, f2.getAll(Fielding.Child.BOX_TRIP).size());
 
-        // And remed again.
+        // And removed again.
        s.setPenaltyBox(false);
        assertEquals(1, f1.getAll(Fielding.Child.BOX_TRIP).size());
        assertEquals(0, f2.getAll(Fielding.Child.BOX_TRIP).size());


### PR DESCRIPTION
Also:

- color the (P)LT box field, when a Skater has an unserved penalty
- make the buttons etc. in the popups in the P/LT and SK screens submit immediately
- fix handling of adding past box trips and moving their start/end around (closes #269)
- add possibility to unend box trips