### PR TITLE
Turn "Auto End Jam" off by default

### DIFF
--- a/src/com/carolinarollergirls/scoreboard/core/impl/ScoreBoardImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/impl/ScoreBoardImpl.java
@@ -308,12 +308,11 @@ public class ScoreBoardImpl extends ScoreBoardEventProviderImpl implements Score
     @Override
     public void stopJamTO() {
         synchronized (coreLock) {
-            Clock jc = getClock(Clock.ID_JAM);
             Clock lc = getClock(Clock.ID_LINEUP);
             Clock tc = getClock(Clock.ID_TIMEOUT);
             Clock ic = getClock(Clock.ID_INTERMISSION);
 
-            if (jc.isRunning()) {
+            if (isInJam()) {
                 createSnapshot(ACTION_STOP_JAM);
                 setLabels(ACTION_START_JAM, ACTION_NONE, ACTION_TIMEOUT);
                 _endJam();

--- a/src/com/carolinarollergirls/scoreboard/rules/Rule.java
+++ b/src/com/carolinarollergirls/scoreboard/rules/Rule.java
@@ -29,7 +29,7 @@ public enum Rule {
     AUTO_START(new BooleanRule("Automate.AutoStart", "When the Linup time plus AutoStartBuffer has elapsed start a Jam or Timeout as defined below. Jam/Timeout/Period Clocks will be adjusted by the buffer time. This only works if the lineup clock is counting up.", false, "Enabled", "Disabled")),
     AUTO_START_BUFFER(new TimeRule("Automate.AutoStartType", "How long to wait after end of lineup before auto start is triggered.", "0:02")),
     AUTO_START_JAM(new BooleanRule("Automate.AutoStartBuffer", "What to start after lineup is up", false, "Jam", "Timeout")),
-    AUTO_END_JAM(new BooleanRule("Automate.AutoEndJam", "End a jam, when the jam clock has run down", true, "Enabled", "Disabled")),
+    AUTO_END_JAM(new BooleanRule("Automate.AutoEndJam", "End a jam, when the jam clock has run down", false, "Enabled", "Disabled")),
     AUTO_END_TTO(new BooleanRule("Automate.AutoEndTTO", "End a team timeout, after it's defined duration has elapsed", false, "Enabled", "Disabled")),
 
     NUMBER_TIMEOUTS(new IntegerRule("Team.Timeouts", "How many timeouts each team is granted per game or period", 3)),

--- a/tests/com/carolinarollergirls/scoreboard/core/impl/ScoreboardImplTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/core/impl/ScoreboardImplTests.java
@@ -1184,7 +1184,8 @@ public class ScoreboardImplTests {
     }
 
     @Test
-    public void testJamClockEnd_pcRemaining() {
+    public void testJamClockEnd_autoEndEnabled() {
+        sb.getRulesets().set(Rule.AUTO_END_JAM, "true");
         sb.startJam();
         String prevUndoLabel = Button.UNDO.getLabel();
         assertTrue(pc.isRunning());
@@ -1209,7 +1210,6 @@ public class ScoreboardImplTests {
 
     @Test
     public void testJamClockEnd_autoEndDisabled() {
-        sb.getRulesets().set(Rule.AUTO_END_JAM, "false");
         sb.startJam();
         String prevStartLabel = Button.START.getLabel();
         String prevStopLabel = Button.STOP.getLabel();

--- a/tests/com/carolinarollergirls/scoreboard/core/impl/TeamImplTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/core/impl/TeamImplTests.java
@@ -182,6 +182,7 @@ public class TeamImplTests {
         sb.stopJamTO();
         sb.startJam();
         advance(sb.getRulesets().getLong(Rule.PERIOD_DURATION));
+        sb.stopJamTO();
         advance(15*60*1000);
         sb.startJam();
         team.setRetainedOfficialReview(true);


### PR DESCRIPTION
Rationale:

Auto ending adds additional problems if the JT misses calling of the Jam at 2:00, as the lineup clock will have run up prematurely. It also makes it harder to notice at a glance that the jam clock has run down, as there is a non-zero value displayed in the spot of the jam clock. (With the change, the jam clock will idle at 0 until "Stop Jam" is pressed.)

There is also little advantage to having the automation - it is easier for the SBO to just react to the calloff whistles by reflex than to try to remember to skip that button press on 2 minute jams.