### PR TITLE
Auto-mark some more cases

### DIFF
--- a/src/com/carolinarollergirls/scoreboard/core/Jam.java
+++ b/src/com/carolinarollergirls/scoreboard/core/Jam.java
@@ -10,6 +10,8 @@ import com.carolinarollergirls.scoreboard.event.ScoreBoardEventProvider;
 public interface Jam extends NumberedScoreBoardEventProvider<Jam> {
     public void setParent(ScoreBoardEventProvider p);
 
+    public boolean isOvertimeJam();
+    
     public long getDuration();
     public long getPeriodClockElapsedStart();
     public long getPeriodClockElapsedEnd();
@@ -24,6 +26,7 @@ public interface Jam extends NumberedScoreBoardEventProvider<Jam> {
     public enum Value implements PermanentProperty {
         PERIOD_NUMBER(Integer.class, 0),
         STAR_PASS(Boolean.class, false), //true, if either team had an SP
+        OVERTIME(Boolean.class, false),
         DURATION(Long.class, 0L),
         PERIOD_CLOCK_ELAPSED_START(Long.class, 0L),
         PERIOD_CLOCK_ELAPSED_END(Long.class, 0L),

--- a/src/com/carolinarollergirls/scoreboard/core/impl/JamImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/impl/JamImpl.java
@@ -89,6 +89,9 @@ public class JamImpl extends NumberedScoreBoardEventProviderImpl<Jam> implements
             }
         }
     }
+    
+    @Override
+    public boolean isOvertimeJam() { return (Boolean)get(Value.OVERTIME); }
 
     @Override
     public long getDuration() { return (Long)get(Value.DURATION); }

--- a/src/com/carolinarollergirls/scoreboard/core/impl/ScoreBoardImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/impl/ScoreBoardImpl.java
@@ -110,10 +110,17 @@ public class ScoreBoardImpl extends ScoreBoardEventProviderImpl implements Score
 
     @Override
     protected void valueChanged(PermanentProperty prop, Object value, Object last, Flag flag) {
-        if (prop == Value.IN_OVERTIME && !(Boolean)value) {
-            Clock lc = getClock(Clock.ID_LINEUP);
-            if (lc.isCountDirectionDown()) {
-                lc.setMaximumTime(getRulesets().getLong(Rule.LINEUP_DURATION));
+        if (prop == Value.IN_OVERTIME) {
+            if (isInJam()) {
+                getCurrentPeriod().getCurrentJam().set(Jam.Value.OVERTIME, value);
+            } else {
+                getUpcomingJam().set(Jam.Value.OVERTIME, value);
+            }
+            if (!(Boolean)value) {
+                Clock lc = getClock(Clock.ID_LINEUP);
+                if (lc.isCountDirectionDown()) {
+                    lc.setMaximumTime(getRulesets().getLong(Rule.LINEUP_DURATION));
+                }
             }
         } else if (prop == Value.UPCOMING_JAM) {
             removeAll(Period.NChild.JAM);

--- a/src/com/carolinarollergirls/scoreboard/core/impl/SkaterImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/impl/SkaterImpl.java
@@ -115,6 +115,9 @@ public class SkaterImpl extends ScoreBoardEventProviderImpl implements Skater {
     protected void itemAdded(AddRemoveProperty prop, ValueWithId item) {
         if (prop == NChild.PENALTY && FO_EXP_ID.equals(((Penalty)item).getProviderId())) {
             updateEligibility();
+        } else if (prop == NChild.PENALTY && !((Penalty)item).isServed() && getRole() == Role.JAMMER
+                && !getCurrentFielding().getTeamJam().getOtherTeam().isLead()) {
+            getTeam().set(Team.Value.LOST, true);
         } else if (prop == Child.FIELDING && ((Fielding)item).isCurrent()) {
             set(Value.CURRENT_FIELDING, item, Flag.INTERNAL);
         } else if (prop == Child.FIELDING && team.hasFieldingAdvancePending() &&

--- a/src/com/carolinarollergirls/scoreboard/core/impl/TeamImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/impl/TeamImpl.java
@@ -103,6 +103,12 @@ public class TeamImpl extends ScoreBoardEventProviderImpl implements Team {
                 execute(Command.REMOVE_TRIP);
             }
         }
+        if (prop == Value.INJURY && flag != Flag.COPY && (Boolean)value) {
+            set(Value.CALLOFF, false);
+        }
+        if (prop == Value.CALLOFF && flag != Flag.COPY && (Boolean)value) {
+            set(Value.INJURY, false);
+        }
         return value;
     }
     @Override
@@ -137,6 +143,9 @@ public class TeamImpl extends ScoreBoardEventProviderImpl implements Team {
         case ADD_TRIP:
             tripScoreTimerTask.cancel();
             getRunningOrEndedTeamJam().addScoringTrip();
+            if (!isLead() && !getScoreBoard().getTeam(Team.ID_1.equals(getId()) ? Team.ID_2 : Team.ID_1).isLead()) {
+                set(Value.LOST, true);
+            }
             break;
         case REMOVE_TRIP:
             tripScoreTimerTask.cancel();

--- a/src/com/carolinarollergirls/scoreboard/core/impl/TeamJamImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/impl/TeamJamImpl.java
@@ -62,6 +62,9 @@ public class TeamJamImpl extends ParentOrderedScoreBoardEventProviderImpl<TeamJa
             if (getCurrentScoringTrip() == null) { return true; }
             return getCurrentScoringTrip().getNumber() == 1;
         }
+        if (prop ==Value.LOST && getJam().isOvertimeJam()) {
+            return false;
+        }
         if (prop == Value.DISPLAY_LEAD) {
             return isLead() && !isLost();
         }

--- a/tests/com/carolinarollergirls/scoreboard/core/impl/TeamJamImplTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/core/impl/TeamJamImplTests.java
@@ -7,6 +7,8 @@ import java.util.Queue;
 
 import org.junit.Before;
 import org.junit.Test;
+
+import com.carolinarollergirls.scoreboard.core.Jam;
 import com.carolinarollergirls.scoreboard.core.ScoreBoard;
 import com.carolinarollergirls.scoreboard.core.ScoringTrip;
 import com.carolinarollergirls.scoreboard.core.Team;
@@ -65,4 +67,10 @@ public class TeamJamImplTests {
         assertTrue(tj.isStarPass());
     }
 
+    @Test
+    public void testNoLostInOvertime() {
+        tj.getJam().set(Jam.Value.OVERTIME, true);
+        tj.set(TeamJam.Value.LOST, true);
+        assertFalse(tj.isLost());
+    }
 }


### PR DESCRIPTION
Mark Lost
- when a Jammer completes their initial trip and isn't declared lead
despite being eligible.
- when a Penalty is recorded for an eligible or Lead Jammer.

Make Calloff and Injury mutually exclusive when entered through the
operator controls. (In the rare case where both should be marked, this
can be done on the SK sheet.)