### PR TITLE
Show all skater numbers for jammer/pivot selection.

### DIFF
--- a/html/components/team-time-tab.css
+++ b/html/components/team-time-tab.css
@@ -47,6 +47,12 @@
 #TeamTime table.Team tr.Jammer td.ui-buttonset label.Lead.ui-state-active { background: #3f3; }
 #TeamTime table.Team tr.Jammer td.ui-buttonset label.StarPass.ui-state-active { background: #3f3; }
 
+#TeamTime .skaterSelector>button { border-radius: 0; }
+#TeamTime .skaterSelector>button:first-of-type { border-radius: 12px 0px 0px 12px; border-top: none; }
+#TeamTime .skaterSelector>button:last-of-type { border-radius: 0px 12px 12px 0px; }
+#TeamTime .skaterSelector>button:only-of-type { border-radius: 12px; }
+#TeamTime .skaterSelector>button>span { padding-top: 0.3em; padding-bottom: 0.3em; }
+
 #TeamTime table.Team button.Box.Active { color: #000; background: #F33; }
 #TeamTime table.Team button.Active:not(.Box) { color: #000; background: #3F3; }
 


### PR DESCRIPTION
No more dropdowns to get in the way of keyboard shortcuts,
plus it should be faster to use.

I think this works nicely, though this bit of the screen might need a small reorg now. These don't support key controls.

![Screenshot_2019-10-23_18-57-46](https://user-images.githubusercontent.com/7115638/67420981-80d12d00-f5c7-11e9-8b0b-19d33b70526d.png)
