### PR TITLE
Allow keys to be assigned to Jammer/Pivot buttons

### DIFF
--- a/html/components/team-time-tab.js
+++ b/html/components/team-time-tab.js
@@ -712,10 +712,6 @@ function createTeamTable() {
 								WS.Set(prefix + '.Position('+pos+').Skater', k.Skater);
 						}).button();
 						_crgKeyControls.setupKeyControl(button, _crgKeyControls.operator);
-						var key = WS.state[button.attr('_crgKeyControls_prop')];
-						button.toggleClass('HasControlKey', (key?true:false))
-							.find('span.Key').text(key?key:'')
-							.attr('data-keycontrol', String(key?key.charCodeAt(0):''));
 					_windowFunctions.appendAlphaSortedByAttr(container, button, 'number', 1);
 				}
 				setValue(WS.state[prefix + '.Position('+pos+').Skater']);

--- a/html/components/team-time-tab.js
+++ b/html/components/team-time-tab.js
@@ -693,7 +693,7 @@ function createTeamTable() {
 		var makeSkaterSelector = function(pos) {
 			var container = $('<span class="skaterSelector">')
 
-			var none = $('<button>').text("?").attr("skater", "").button();
+			var none = $('<button>').text("?").attr("skater", "").attr('id', 'Team'+team+pos+'None').addClass('KeyControl').button();
 			container.append(none).buttonset();
 			none.click(function(){WS.Set(prefix + '.Position('+pos+').Skater', "") });
 
@@ -706,10 +706,16 @@ function createTeamTable() {
 				container.children('[skater="'+k.Skater+'"]').remove();
 				if (v != null && WS.state[prefix + '.Skater('+k.Skater+').Role'] != 'NotInGame') {
 					var number = WS.state[prefix + '.Skater('+k.Skater+').Number'];
-					var button = $('<button>').attr('number', number).attr('skater', k.Skater).text(number)
+					var button = $('<button>').attr('number', number).attr('skater', k.Skater)
+							.attr('id', 'Team'+team+pos+k.Skater).addClass('KeyControl').text(number)
 							.click(function() {
-						WS.Set(prefix + '.Position('+pos+').Skater', k.Skater);
-					}).button();
+								WS.Set(prefix + '.Position('+pos+').Skater', k.Skater);
+						}).button();
+						_crgKeyControls.setupKeyControl(button, _crgKeyControls.operator);
+						var key = WS.state[button.attr('_crgKeyControls_prop')];
+						button.toggleClass('HasControlKey', (key?true:false))
+							.find('span.Key').text(key?key:'')
+							.attr('data-keycontrol', String(key?key.charCodeAt(0):''));
 					_windowFunctions.appendAlphaSortedByAttr(container, button, 'number', 1);
 				}
 				setValue(WS.state[prefix + '.Position('+pos+').Skater']);

--- a/html/javascript/keycontrols.js
+++ b/html/javascript/keycontrols.js
@@ -57,10 +57,10 @@ _crgKeyControls = {
 			.end()
 			.each(function() {
 				var button = $(this);
-				var prop = "ScoreBoard.Settings.Setting(ScoreBoard.Operator__" + operator + ".KeyControl." + button.attr("id") + ")";
+				var prop = 'ScoreBoard.Settings.Setting(ScoreBoard.Operator__' + operator + '.KeyControl.' + button.attr('id') + ')';
 				var key = WS.state[prop];
-				button.find("span.Key").text(key);
-				button.attr("_crgKeyControls_prop", prop)
+				button.attr('_crgKeyControls_prop', prop).toggleClass("HasControlKey", (key?true:false));
+				button.find('span.Key').attr('data-keycontrol', String(key?key.charCodeAt(0):'')).text(key);
 			});
 		return button;
 	},


### PR DESCRIPTION
Key assignments are tied to SkaterId and Team 1 or 2 and will persist if the team is
reassigned to the same side or if the Skater is temporarily removed
from the roster.