### PR TITLE
Keep jam clock indicator until Jam is stopped

### DIFF
--- a/html/components/team-time-tab.js
+++ b/html/components/team-time-tab.js
@@ -771,9 +771,15 @@ function createTimeTable() {
 				it.toggleClass("CountUp", !isTrue(v));
 			});
 		}
-		WS.Register(prefix + ".Running", function(k, v) {
-			nameTd.toggleClass("Running", isTrue(v));
-		});
+		if (clock === 'Jam') {
+			WS.Register('ScoreBoard.InJam', function(k, v) {
+				nameTd.toggleClass("Running", isTrue(v));
+			});
+		} else {
+			WS.Register(prefix + ".Running", function(k, v) {
+				nameTd.toggleClass("Running", isTrue(v));
+			});
+		}
 		WS.Register("ScoreBoard.NoMoreJam", function(k, v) {
 			nameTd.toggleClass("NoMoreJam", isTrue(v));
 		});


### PR DESCRIPTION
When Auto-End jam is deactivated and the clock has run down, there was no
obvious indication that the scoreboard has not ended the jam. This
change keeps the clock header highlighted until "Stop Jam" is pressed (or Auto-End stops it).