### PR TITLE
Only highlight penalty columns on 5/6/7 penalties

### DIFF
--- a/html/components/plt-input.css
+++ b/html/components/plt-input.css
@@ -60,7 +60,7 @@ body:not(.AllowSelect) .PLT {
 .PLT.Team tr[role='Pivot'] .OnTrack:not(.Advance) { background-color: #00ee00; }
 .PLT.Team tr[role='Jammer'] .OnTrack:not(.Advance) { background-color: #00cc00; }
 .PLT.Team .inBox { background-color: #ff4040; }
-.PLT.Team .Advance { }
+.PLT.Team .Advance { background-color: #FFF; }
 .PLT.Team .Advance.Active { border: none; background-color: #ff9010;  vertical-align: bottom; }
 .PLT.Team tr:nth-child(6n+1) .Advance.Active::after { content: "Go To"; }
 .PLT.Team tr:nth-child(6n+3) .Advance.Active::after { content: "Next Jam"; }


### PR DESCRIPTION
It did bleed over into the annotation column in the light rows