### PR TITLE
Don't show jammers when clocks aren't running.

### DIFF
--- a/html/views/common.js
+++ b/html/views/common.js
@@ -11,14 +11,17 @@ function jammer(k, v) {
 	var inJam = isTrue(WS.state["ScoreBoard.InJam"]);
 
 	if (jammerName == null || jammerName == "") {
-		jammerName = (leadJammer && inJam) ? "Lead" : "";
+		jammerName = leadJammer ? "Lead" : "";
 	if (pivotName == null)
 		pivotName = "";
 	}
 
 	var jn = !starPass ? jammerName : pivotName;
+	if (!inJam) {
+		jn = "";  // When no clocks are running, do not show jammer names.
+	};
 	$(".Team" + id + " .Lead").toggleClass("HasLead", (leadJammer && !starPass));
-	$(".Team" + id).toggleClass("HasJammerName", (jn != "" && jn != null));
+	$(".Team" + id).toggleClass("HasJammerName", (jn != ""));
 	return jn
 }
 


### PR DESCRIPTION
This was causing jammers to appear when no clocks
were running, e.g. just before a period start when
the intermission clock wasn't running.

That isn't a problem in itself, however if you were coming
into P2 and had lead in the last jam of P1, then lead
would be incorrectly indicated before the jam start.

So go with consistency when we're in lineup,
and don't show the jammer name.


We could also go with altering the ShowIn logic, but that seems risky giving the release coming up as it touches everything related to clocks.