### PR TITLE
Correct page title to Penalty Whiteboard

### DIFF
--- a/html/views/wb/index.html
+++ b/html/views/wb/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
-		<title>Penalty Tracker</title>
+		<title>Penalty Whiteboard</title>
 		<!--
 		 Copyright (C) 2008-2012 Mr Temper <MrTemper@CarolinaRollergirls.com>
 		


### PR DESCRIPTION
the title is displayed in the browser tab. The title Penalty Tracker is misleading here.