### PR TITLE
Avoid reverse DNS resolution when looking for URLs.

### DIFF
--- a/src/com/carolinarollergirls/scoreboard/jetty/JettyServletScoreBoardController.java
+++ b/src/com/carolinarollergirls/scoreboard/jetty/JettyServletScoreBoardController.java
@@ -15,8 +15,7 @@ import io.prometheus.client.hotspot.DefaultExports;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.SocketException;
-import java.net.URL;
-import java.util.Iterator;
+import java.util.Set;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.ServletException;
 
@@ -50,12 +49,12 @@ public class JettyServletScoreBoardController {
         Logger.printMessage("Open a web browser (either Google Chrome or Mozilla Firefox recommended) to:");
         Logger.printMessage("	http://localhost:"+port);
         try {
-            Iterator<URL> urls = urlsServlet.getUrls().iterator();
-            if (urls.hasNext()) {
+            Set<String> urls = urlsServlet.getUrls();
+            if (!urls.isEmpty()) {
                 Logger.printMessage("or try one of these URLs:");
             }
-            while (urls.hasNext()) {
-                Logger.printMessage("	"+urls.next().toString());
+            for (String u : urls) {
+                Logger.printMessage("	"+u);
             }
         } catch ( MalformedURLException muE ) {
             Logger.printMessage("Internal error: malformed URL from Server Connector: "+muE.getMessage());


### PR DESCRIPTION
At most events the scoreboard will not be connected to the internet,
so users end up having to wait for a DNS timeout before the URLs show
at startup or on the index page.

This loses us hostnames, but it's very unlikely that there was a DNS
setup that would have allowed them to work.

We'll still do forward resolution to bind to if hostname is provided on
the command line, but that's going to be rare and also likey something
present in /etc/hosts so it won't hit the network.

Also cleanup and modernise the code generally, and don't exclude v6
addresses.



Something I noticed over the weekend.