### PR TITLE
On dereigstering from JSM, don't process remaining updates.

### DIFF
--- a/src/com/carolinarollergirls/scoreboard/json/JSONStateManager.java
+++ b/src/com/carolinarollergirls/scoreboard/json/JSONStateManager.java
@@ -25,7 +25,7 @@ public class JSONStateManager {
     }
 
     public synchronized void unregister(JSONStateListener source) {
-        sources.get(source).shutdown();
+        sources.get(source).shutdownNow();
         sources.remove(source);
     }
 


### PR DESCRIPTION
The only place we deregister from the JSM is the WS endpoint.
If a WS client has backed up and then we finally timeout disconnect
(e.g. other end stops responding but the TCP connection is still there)
we shouldn't try to send the backlog through as that just spams the logs
with a stack trace per backlogged message.