### PR TITLE
Fix rounding of clocks

### DIFF
--- a/html/javascript/timeconversions.js
+++ b/html/javascript/timeconversions.js
@@ -10,22 +10,13 @@
 
 
 _timeConversions = {
-	/* Policy: default round ms up or down
-	 * If true, ms values will be rounded up, i.e. 1001-2000 ms converts to 2 sec.
-	 * If false, ms values will be rounded down, i.e. 1000-1999 ms converts to 1 sec.
-	 *
-	 * This is only used for non-$sb(Clock.Time) conversions;
-	 * for $sb(Clock.Time) conversions, the rounding will be opposite the Clock.Direction.
-	 */
-	defaultRoundUp: true,
-
 	/*
 	 * These are conversion functions for external use
 	 */
 
 	/* Convert ms to seconds */
-	msToSeconds: function(ms) {
-		if (_timeConversions._roundClockUp.call(this))
+	msToSeconds: function(ms, roundUp) {
+		if (roundUp)
 			return String(Math.ceil(ms / 1000));
 		else
 			return String(Math.floor(ms / 1000));
@@ -33,69 +24,57 @@ _timeConversions = {
 	/* Convert seconds to milliseconds */
 	secondsToMs: function(sec) { return String(sec * 1000); },
 	/* Convert milliseconds to min:sec */
-	msToMinSec: function(ms) {
-		return _timeConversions._msOnlyMin.call(this, ms)+":"+_timeConversions._msOnlySec.call(this, ms);
+	msToMinSec: function(ms, roundUp) {
+		return _timeConversions._msOnlyMin(ms, roundUp)+':'+_timeConversions._msOnlySec(ms, roundUp);
 	},
 	/* Convert min:sec to milliseconds */
 	minSecToMs: function(time) {
-		var min = Number(_timeConversions._timeOnlyMin.call(this, time) || 0);
-		var sec = Number(_timeConversions._timeOnlySec.call(this, time) || 0);
-		return _timeConversions.secondsToMs.call(this, (min * 60) + sec);
+		var min = Number(_timeConversions._timeOnlyMin(time) || 0);
+		var sec = Number(_timeConversions._timeOnlySec(time) || 0);
+		return _timeConversions.secondsToMs((min * 60) + sec);
 	},
 	/* Convert milliseconds to min:sec, if min is 0 return only seconds portion */
-	msToMinSecNoZero: function(ms) {
-		var limit = (_timeConversions._roundClockUp.call(this) ? 59001 : 60000);
+	msToMinSecNoZero: function(ms, roundUp) {
+		var limit = (roundUp ? 59001 : 60000);
 		if (ms >= limit)
-			return _timeConversions.msToMinSec.call(this, ms);
+			return _timeConversions.msToMinSec(ms, roundUp);
 		else
-			return _timeConversions.msToSeconds.call(this, ms);
+			return _timeConversions.msToSeconds(ms, roundUp);
 	},
 	/* Same as minSecToMs() */
-	minSecNoZeroToMs: function(time) { return _timeConversions.minSecToMs.call(this, time); },
+	minSecNoZeroToMs: function(time) { return _timeConversions.minSecToMs(time); },
 
 	/*
 	 * These are utility functions that can be used externally
 	 */
 
 	/* Format number into minimum 2 digits, prepending 0 if needed */
-	twoDigit: function(n) { return (10 > n ? "0" : "")+n; },
+	twoDigit: function(n) { return (10 > n ? '0' : '')+n; },
 
 	/*
 	 * These are generally internal functions that should not be used externally
 	 */
 
 	/* If needed, this preprends ":" */
-	_formatMinSec: function(time) { return ((String(time).indexOf(":") > -1) ? time : ":"+time); },
+	_formatMinSec: function(time) { return ((String(time).indexOf(':') > -1) ? time : ':'+time); },
 	/* Convert ms to seconds portion of min:sec */
-	_msOnlySec: function(ms) {
-		return _timeConversions.twoDigit.call(this, _timeConversions.msToSeconds.call(this, ms) % 60);
+	_msOnlySec: function(ms, roundUp) {
+		return _timeConversions.twoDigit(_timeConversions.msToSeconds(ms, roundUp) % 60);
 	},
 	/* Convert ms to minutes portion of min:sec */
-	_msOnlyMin: function(ms) {
+	_msOnlyMin: function(ms, roundUp) {
 		var min = Math.floor(ms / 60000);
 		// if rounding up and seconds are 59001-59999, we need to add a minute
-		min = min + Number(_timeConversions.msToSeconds.call(this, Math.max(0, (ms % 60000) - 59000)));
+		min = min + Number(_timeConversions.msToSeconds(Math.max(0, (ms % 60000) - 59000), roundUp));
 		return String(min);
 	},
 	/* Accepts min:sec time, returns only seconds portion */
 	_timeOnlySec: function(time) {
-		return _timeConversions._formatMinSec.call(this, time).split(":")[1];
+		return _timeConversions._formatMinSec(time).split(':')[1];
 	},
 	/* Accepts min:sec time, returns only minutes portion */
 	_timeOnlyMin: function(time) {
-		return _timeConversions._formatMinSec.call(this, time).split(":")[0];
-	},
-	/* If converting the time from a $sb Clock, determine the rounding direction */
-	_roundClockUp: function() {
-		if (typeof $sb == "undefined")
-			return _timeConversions.defaultRoundUp;
-		if (!is$sb(this) || !(this.$sbName == "Time"))
-			return _timeConversions.defaultRoundUp; // Not a Clock.Time, use default
-		var countDir = this.parent().children("Direction");
-		if (!countDir.length)
-			return _timeConversions.defaultRoundUp; // Can't find Clock.Direction, use default
-		// Round direction should be opposite count direction, e.g. count down == round up
-		return $sb(countDir).$sbIsTrue();
+		return _timeConversions._formatMinSec(time).split(':')[0];
 	}
 };
 //# sourceURL=timeconversions.js

--- a/html/views/common.js
+++ b/html/views/common.js
@@ -140,7 +140,8 @@ function toClockInitialNumber(k, v) {
 }
 
 function toTime(k, v) {
-	return _timeConversions.msToMinSecNoZero(v);
+	var isCountDown = isTrue(WS.state['ScoreBoard.Clock(' + k.Clock + ').Direction']);
+	return _timeConversions.msToMinSecNoZero(v, isCountDown);
 }
 
 function toJamScore(k, v) {
@@ -173,12 +174,8 @@ function clockRunner(k,v) {
 
 
 // Show Clocks
-WS.Register( [
-	"ScoreBoard.Clock(Period).Running",
-	"ScoreBoard.Clock(Jam).Running",
-	"ScoreBoard.Clock(Lineup).Running",
-	"ScoreBoard.Clock(Timeout).Running",
-	"ScoreBoard.Clock(Intermission).Running" ], function(k, v) { clockRunner(k,v); } );
+WS.Register( 'ScoreBoard.Clock(*).Running', function(k, v) { clockRunner(k,v); } );
+WS.Register( 'ScoreBoard.Clock(*).Direction');
 
 WS.Register( 'ScoreBoard.Rulesets.CurrentRule(Period.Number)' );
 WS.Register( 'ScoreBoard.InJam' );


### PR DESCRIPTION
The WS display would use the same rounding function as the XML display
but without the $sb objects, causing it to always round up instead of
opposite to the clock direction. Change it to use the established
behaviour.

This fixees the bug of lineup and period occasionally adding to 31 with a red lineup clock.