### PR TITLE
Close trip editor after inserting a trip

### DIFF
--- a/html/components/sk-sheet.js
+++ b/html/components/sk-sheet.js
@@ -314,6 +314,7 @@ function prepareTripEditor() {
 						})))
 						.append($('<td>').append($('<button>').attr('id','insert_before').text('Insert Before').button().click(function() {
 							WS.Set(tripEditor.data('prefix')+'InsertBefore', true);
+							tripEditor.dialog('close');
 						})))));
 	}
 }


### PR DESCRIPTION
This makes the button's behaviour consistent with the other buttons in
the row. It is also the common use case.