### PR TITLE
Fix overlay points-per-jam header and roster logo size

### DIFF
--- a/html/views/overlay/index.css
+++ b/html/views/overlay/index.css
@@ -309,7 +309,7 @@ div.PanelWrapperTop    .AnimatedPanel.PanelHideTop.show	{ -webkit-transform: tra
 .AnimatedPanel.Show img  { height: 200px; }
 
 .PenaltyTeam.AnimatedPanel.Show img.TeamLogo  { height: 140px; }
-.RosterTeam.AnimatedPanel.Show  img.TeamLogo  { height: 180px; }
+.RosterTeam.AnimatedPanel.Show  img.TeamLogo  { height: 164px; }
 
 .PanelWrapperCenter .AnimatedPanel.LowerPart { margin-top: 10em; }
 .PanelWrapperCenter .RosterTeam.AnimatedPanel.LowerPart { margin-top: 10.5em; }

--- a/html/views/overlay/index.html
+++ b/html/views/overlay/index.html
@@ -82,8 +82,8 @@
 						</div>
 				</div>
 
-				<div class="PPJBox Wrapper PanelHideLeft OverlayPanel LargePanel AnimatedPanel">
-					<h1 class="NoLogo">Points Per Jam</h1>
+				<div class="PPJBox Wrapper PanelHideLeft OverlayPanel LargePanel AnimatedPanel NoLogo">
+					<h1>Points Per Jam</h1>
 					<h4 class="htop ColourTeam1" sbDisplay="AlternateName(overlay),Name" sbContext="Team(1)"></h4>	
 					<div class="PPJContainer Wrapper">
 						<div class="Wrapper Team Team1">


### PR DESCRIPTION
This commit addresses two issues:

1. The header on the points-per-jam panel of the broadcast overlay is misaligned

This is because the `NoLogo` class was assigned to an h1 element, instead of the div that contains an h1 element. The `NoLogo` class is assigned 4 other times throughout the overlay, and always to a div element that contains an h1.

![ppj0](https://user-images.githubusercontent.com/24471463/73586367-f408fb80-4460-11ea-9a53-99155c7c554c.png)

![ppj1](https://user-images.githubusercontent.com/24471463/73586369-f8cdaf80-4460-11ea-8394-e0739246c57d.png)

2. The team logos on the roster panels of the broadcast overlay are too large

The height of logos on the roster and penalties panels are controlled through separate CSS styles. I adjusted the size of the roster logo to match the gap on the penalties page.

![tr0](https://user-images.githubusercontent.com/24471463/73586371-fe2afa00-4460-11ea-997d-970d441de073.png)

![tr1](https://user-images.githubusercontent.com/24471463/73586373-008d5400-4461-11ea-9ffb-936965498497.png)


