### PR TITLE
Hide non-in-game skaters on the overlay penalties panel

### DIFF
--- a/html/views/overlay/index.css
+++ b/html/views/overlay/index.css
@@ -239,6 +239,9 @@ html > body div.Wrapper .FloatRight 	{ float: right !important; right: 0; }
 .RosterTeam .Team .Skater:nth-last-child(1) .Number, .RosterTeam .Team .Skater:nth-last-child(2) .Number,
 .RosterTeam .Team .Skater:nth-last-child(1), .RosterTeam .Team .Skater:nth-last-child(2) { border-radius: 0 0 10px 10px; }
 
+.PenaltyTeam .SortBox { border-radius: 10px; }
+.PenaltyTeam .NoShow { display: none; }
+
 .PenaltyTeam .Team .Skater { width: 100%; font-size: 1.2em; line-height: 1.4em; height: 1.4em; }
 .PenaltyTeam .Team .Skater:nth-child(odd)  {  background: #ccc; }
 .PenaltyTeam .Team .Skater:nth-child(even) {  background: #ddd; }
@@ -247,8 +250,6 @@ html > body div.Wrapper .FloatRight 	{ float: right !important; right: 0; }
 .PenaltyTeam .Team .Name { float: left; width: 24%; color: #333; }
 .PenaltyTeam .Team .Penalty { float: left; width: 8%; }
 
-.PenaltyTeam .Skater:nth-child(1) { border-radius: 10px 10px 0 0; }
-.PenaltyTeam .Skater:nth-last-child(1) { border-radius: 0 0 10px 10px; }
 .PenaltyTeam .Skater { clear: both; }
 .PenaltyTeam .Skater .Penalty { display: block; padding: 0px 2px; background: #333; color: white; width: 2em; border-radius: 8px; text-align: center; margin-right: 10px;}
 

--- a/html/views/overlay/index.js
+++ b/html/views/overlay/index.js
@@ -190,9 +190,22 @@ function ensureSkaterExists(skaterId, team) {
 
 function updateSort(sel) {
 	var skaterRow = $(sel);
+	var sortValue;
+	// First, sort invisible rows to the end, so they don't interfere with alternating row color
+	if (skaterRow.hasClass('NoShow')) {
+		sortValue = '1';
+	} else {
+		sortValue = '0';
+	}
+
+	// Second, sort by number with missing numbers at the end
 	var n = $('.Number', sel).text();
-	var sortValue = (skaterRow.hasClass('NoShow') ? '1' : '0')
-			+ (n == '' || n == '-' || n == null ? 'ZZZZZZ' : n);
+	if (n == '' || n == '-' || n == null) {
+		sortValue += 'ZZZZZZ';
+	} else {
+		sortValue += n;
+	}
+
 	skaterRow.attr('data-sort', sortValue);
 	skaterRow.parent().sortDivs();
 }


### PR DESCRIPTION
Skaters who are not-in-game are not removed from the broadcast overlay's penalties panel. This limits the usefulness of role assignment since, unlike the roster panel, the penalties panel does not handle more than ~17 skaters. Skaters who are not-in-game also cannot receive penalties, so there is no need to display them.

This PR makes a few changes to accommodate this:

1. When a skater's role is updated, the skater's row (in the penalties panel only) will be hidden (or revealed, if they have been added back into the game).
2. Rows which are not visible are sorted to the end, so as not to interfere with the alternating row color.
3. The border-radius is applied to the container rather than the first and last skater rows, so the corner appearance does not change with row order/visibility.

![roster](https://user-images.githubusercontent.com/24471463/73598620-7213e380-44ef-11ea-9365-199b0ab00bbf.png)

![penalties](https://user-images.githubusercontent.com/24471463/73598622-750ed400-44ef-11ea-892c-7648657070a8.png)
