### PR TITLE
When points are added, advance to the first scoring trip.

### DIFF
--- a/html/components/sk-sheet.css
+++ b/html/components/sk-sheet.css
@@ -42,9 +42,8 @@ body:not(.AllowSelect) .SK {
 #TripEditor input[type="number"] { width: 50px; }
 #TripEditor table { width: 100%; }
 #TripEditor td { padding: 0.25em; text-align: center; width: 33%; }
+#TripEditor td.close { text-align: right; }
 #TripEditor .header { font-weight: bold; }
-#TripEditor .Annotation.read>td { text-align: left; }
-#TripEditor .close>td { text-align: right; }
 #TripEditor .ui-button { font-size: 75%; }
 #TripEditor .ui-button.checked { background: #3f3; }
 #TripEditor .Hide { display: none; }

--- a/html/components/sk-sheet.css
+++ b/html/components/sk-sheet.css
@@ -44,3 +44,6 @@ body:not(.AllowSelect) .SK {
 #TripEditor .ui-button.checked { background: #3f3; }
 
 #skaterSelector .Hide { display: none; }
+
+.SK.Period .noTripAlert { position: relative; }
+.SK.Period .noTripAlert::after { position: absolute; right: 2px; top: 2px; height: 5px; width: 5px; background-color: red; content: ""; }

--- a/html/components/sk-sheet.css
+++ b/html/components/sk-sheet.css
@@ -41,16 +41,10 @@ body:not(.AllowSelect) .SK {
 
 #TripEditor input[type="number"] { width: 50px; }
 #TripEditor table { width: 100%; }
-#TripEditor td { padding: 0.25em; text-align: center; width: 33%; background: #ccc; }
+#TripEditor td { padding: 0.25em; text-align: center; width: 33%; }
 #TripEditor .header { font-weight: bold; }
-#TripEditor .Annotation.read>td { text-align: left; padding: 0.5em; }
-#TripEditor .Annotation.head>td { border-top: 2px solid white; }
-#TripEditor .Annotation.head>td:first-of-type { border-radius: 12px 0px 0px 0px; }
-#TripEditor .Annotation.head>td:last-of-type { border-radius: 0px 12px 0px 0px; }
-#TripEditor .Annotation.edit>td { border-radius: 0px 0px 12px 12px; border-bottom: 2px solid white; }
-#TripEditor .Annotation.read>td { border-radius: 0px 0px 12px 12px; border-bottom: 2px solid white; }
-#TripEditor tr:not(.Annotation)>td:first-of-type { border-radius: 12px 0px 0px 12px; }
-#TripEditor tr:not(.Annotation)>td:last-of-type { border-radius: 0px 12px 12px 0px; }
+#TripEditor .Annotation.read>td { text-align: left; }
+#TripEditor .close>td { text-align: right; }
 #TripEditor .ui-button { font-size: 75%; }
 #TripEditor .ui-button.checked { background: #3f3; }
 #TripEditor .Hide { display: none; }

--- a/html/components/sk-sheet.css
+++ b/html/components/sk-sheet.css
@@ -36,11 +36,23 @@ body:not(.AllowSelect) .SK {
 .SK.Period .Trip, .Period .JamTotal, .Period .GameTotal { width: 9%; }
 .SK.Period .GameTotal, .SK.Period .JamTotal,.SK.Period .Lost, .SK.Period .Trip2 { border-left-width: 2px; }
 .SK.Period .GameTotal { background-color: #d3ecb6; }
+.SK.Period .hasAnnotation { position: relative; }
+.SK.Period .hasAnnotation::after { position: absolute; right: 2px; top: 2px; height: 5px; width: 5px; background-color: red; content: ""; }
 
 #TripEditor input[type="number"] { width: 50px; }
-#TripEditor td { padding-bottom: 0.5em; }
-#TripEditor .buttons td { text-align: center; }
+#TripEditor table { width: 100%; }
+#TripEditor td { padding: 0.25em; text-align: center; width: 33%; background: #ccc; }
+#TripEditor .header { font-weight: bold; }
+#TripEditor .Annotation.read>td { text-align: left; padding: 0.5em; }
+#TripEditor .Annotation.head>td { border-top: 2px solid white; }
+#TripEditor .Annotation.head>td:first-of-type { border-radius: 12px 0px 0px 0px; }
+#TripEditor .Annotation.head>td:last-of-type { border-radius: 0px 12px 0px 0px; }
+#TripEditor .Annotation.edit>td { border-radius: 0px 0px 12px 12px; border-bottom: 2px solid white; }
+#TripEditor .Annotation.read>td { border-radius: 0px 0px 12px 12px; border-bottom: 2px solid white; }
+#TripEditor tr:not(.Annotation)>td:first-of-type { border-radius: 12px 0px 0px 12px; }
+#TripEditor tr:not(.Annotation)>td:last-of-type { border-radius: 0px 12px 12px 0px; }
 #TripEditor .ui-button { font-size: 75%; }
 #TripEditor .ui-button.checked { background: #3f3; }
+#TripEditor .Hide { display: none; }
 
 #skaterSelector .Hide { display: none; }

--- a/html/components/sk-sheet.css
+++ b/html/components/sk-sheet.css
@@ -47,5 +47,6 @@ body:not(.AllowSelect) .SK {
 #TripEditor .ui-button { font-size: 75%; }
 #TripEditor .ui-button.checked { background: #3f3; }
 #TripEditor .Hide { display: none; }
+#TripEditor .Invisible { visibility: hidden; }
 
 #skaterSelector .Hide { display: none; }

--- a/html/components/sk-sheet.js
+++ b/html/components/sk-sheet.js
@@ -23,6 +23,7 @@ function prepareSkSheetTable(element, teamId, mode) {
 		WS.Register(['ScoreBoard.Period(*).Number',
 				'ScoreBoard.Period(*).Jam(*).Number',
 				'ScoreBoard.Period(*).Jam(*).StarPass',
+				'ScoreBoard.Period(*).Jam(*).Overtime',
 				'ScoreBoard.Period(*).Jam(*).TeamJam(' + teamId + ').AfterSPScore',
 				'ScoreBoard.Period(*).Jam(*).TeamJam(' + teamId + ').Calloff',
 				'ScoreBoard.Period(*).Jam(*).TeamJam(' + teamId + ').JamScore',
@@ -36,7 +37,8 @@ function prepareSkSheetTable(element, teamId, mode) {
 				'ScoreBoard.Period(*).Jam(*).TeamJam(' + teamId + ').Fielding(Pivot).SkaterNumber',
 				'ScoreBoard.Period(*).Jam(*).TeamJam(' + teamId + ').ScoringTrip(*).AfterSP',
 				'ScoreBoard.Period(*).Jam(*).TeamJam(' + teamId + ').ScoringTrip(*).Current',
-				'ScoreBoard.Period(*).Jam(*).TeamJam(' + teamId + ').ScoringTrip(*).Score'
+				'ScoreBoard.Period(*).Jam(*).TeamJam(' + teamId + ').ScoringTrip(*).Score',
+				'ScoreBoard.Period(*).Jam(*).TeamJam(' + teamId + ').ScoringTrip(*).PointsWithoutTrip'
 		], handleUpdate);
 	}
 
@@ -147,7 +149,7 @@ function prepareSkSheetTable(element, teamId, mode) {
 						otherScoreText = trip1Score + ' + SP';
 					}
 				} else if (trip2Score != null) {
-					scoreText = trip2Score; 
+					scoreText = trip2Score; 					
 				}
 				var row = jamRow;
 				var otherRow = spRow;
@@ -166,7 +168,7 @@ function prepareSkSheetTable(element, teamId, mode) {
 					row.find('.Trip2').removeClass('noTripAlert');
 				}
 				break;
-
+				
 			 default:
 				if (k.parts[4] == 'ScoringTrip' && k.ScoringTrip >= 3 && k.ScoringTrip < 10) {
 					var t = k.ScoringTrip;

--- a/html/components/sk-sheet.js
+++ b/html/components/sk-sheet.js
@@ -192,10 +192,10 @@ function prepareSkSheetTable(element, teamId, mode) {
 						var tripScore = WS.state[prefix+'ScoringTrip('+t+').Score'];
 						if (tripScore == null) break;
 						if (isTrue(WS.state[prefix+'ScoringTrip('+t+').AfterSP'])) {
-							scoreAfterSP = scoreAfterSP=='' ? tripScore : scoreAfterSP + " + " + tripScore;
+							scoreAfterSP = scoreAfterSP==='' ? tripScore : scoreAfterSP + " + " + tripScore;
 							annotationAfterSP = annotationAfterSP || WS.state[prefix+'ScoringTrip('+t+').Annotation'] != '';
 						} else {
-							scoreBeforeSP = scoreBeforeSP=='' ? tripScore : scoreBeforeSP + " + " + tripScore;
+							scoreBeforeSP = scoreBeforeSP==='' ? tripScore : scoreBeforeSP + " + " + tripScore;
 							annotationBeforeSP = annotationBeforeSP || WS.state[prefix+'ScoringTrip('+t+').Annotation'] != '';
 						}
 						t++;
@@ -292,8 +292,8 @@ function setupTripEditor(p, j, teamId, t) {
 	tripEditor.find('#afterSP').toggleClass('checked', isTrue(WS.state[prefix+'AfterSP']));
 	var annotation = WS.state[prefix+'Annotation'] || '';
 	tripEditor.find('#annotation').val(annotation);
-	tripEditor.find('#prev').toggleClass('Hide', t === 1);
-	tripEditor.find('#next').toggleClass('Hide', WS.state[prefix+'Score'] === undefined);
+	tripEditor.find('#prev').toggleClass('Invisible', t === 1);
+	tripEditor.find('#next').toggleClass('Invisible', WS.state[prefix+'Score'] === undefined);
 	tripEditor.data('prefix', prefix);
 	tripEditor.data('team', teamId);
 	tripEditor.data('period', p);

--- a/html/components/sk-sheet.js
+++ b/html/components/sk-sheet.js
@@ -288,10 +288,10 @@ function setupTripEditor(p, j, teamId, t) {
 	tripEditor.find('#score').val(WS.state[prefix+'Score']);
 	tripEditor.find('#afterSP').toggleClass('checked', isTrue(WS.state[prefix+'AfterSP']));
 	var annotation = WS.state[prefix+'Annotation'] || '';
-	tripEditor.find('input#annotation').val(annotation);
+	tripEditor.find('textarea#annotation').val(annotation);
 	tripEditor.find('span#annotation').text(annotation);
-	tripEditor.find('.edit.Annotation').toggleClass('Hide', annotation !== '');
-	tripEditor.find('.read.Annotation').toggleClass('Hide', annotation === '');
+	tripEditor.find('.edit.Annotation').addClass('Hide');
+	tripEditor.find('.read.Annotation').removeClass('Hide');
 	tripEditor.data('prefix', prefix);
 	tripEditor.dialog('open');
 }
@@ -308,7 +308,7 @@ function prepareTripEditor() {
 			closeOnEscape: false,
 			title: 'Trip Editor',
 			autoOpen: false,
-			width: '450px',
+			width: '300px',
 		});
 
 		tripEditor.append($('<table>')
@@ -322,48 +322,43 @@ function prepareTripEditor() {
 									}).change(function() {
 										WS.Set(tripEditor.data('prefix')+'Score', $(this).val());
 									})))
-						.append($('<td colspan="2">')
+						.append($('<td>')
 								.append($('<button>').attr('id', 'afterSP').text('After SP').button().click(function() {
 									var check = !$(this).hasClass('checked');
 									$(this).toggleClass('checked', check);
 									WS.Set(tripEditor.data('prefix')+'AfterSP', check);
 								}))))
-				.append($('<tr>').addClass('head Annotation')
-						.append($('<td>').addClass('header').text('Notes: '))
-						.append($('<td>')
-								.append($('<button>').addClass('read Annotation').text('Edit').button().click(function() {
-									tripEditor.find('.edit.Annotation').removeClass('Hide');
-									tripEditor.find('.read.Annotation').addClass('Hide');
-								}))
-								.append($('<button>').addClass('edit Annotation').text('Lock').button().click(function() {
-									tripEditor.find('.edit.Annotation').addClass('Hide');
-									tripEditor.find('.read.Annotation').removeClass('Hide');
-								}))
-						)
-						.append($('<td>').append($('<button>').text('Clear').button().click(function() {
-								WS.Set(tripEditor.data('prefix')+'Annotation', '');
-								tripEditor.find('input#annotation').val('');
-								tripEditor.find('.edit.Annotation').removeClass('Hide');
-								tripEditor.find('.read.Annotation').addClass('Hide');
-							}))))
-				.append($('<tr>').addClass('read Annotation')
-						.append($('<td>').attr('colspan', '3').append($('<span>').attr('id', 'annotation'))))
-				.append($('<tr>').addClass('edit Annotation')
-						.append($('<td>').attr('colspan', '3')
-								.append($('<input type="text">').attr('size', '40').attr('id', 'annotation').change(function() {
-									WS.Set(tripEditor.data('prefix')+'Annotation', $(this).val());
-									tripEditor.find('span#annotation').text($(this).val())
-								}))))
 				.append($('<tr class="buttons">')
-						.append($('<td>').append($('<button>').attr('id','submit').text('Close').button().click(function() {
-							tripEditor.dialog('close');
-						})))
 						.append($('<td>').append($('<button>').attr('id','remove').text('Remove').button().click(function() {
 							WS.Set(tripEditor.data('prefix')+'Remove', true);
 							tripEditor.dialog('close');
 						})))
 						.append($('<td>').append($('<button>').attr('id','insert_before').text('Insert Before').button().click(function() {
 							WS.Set(tripEditor.data('prefix')+'InsertBefore', true);
+							tripEditor.dialog('close');
+						}))))
+				.append($('<tr>').append($('<td>').attr('colspan', '3').append($('<hr>'))))
+				.append($('<tr>').addClass('head Annotation')
+						.append($('<td>').addClass('header').text('Notes: '))
+						.append($('<td>').append($('<button>').addClass('read Annotation').text('Edit').button().click(function() {
+									tripEditor.find('.edit.Annotation').removeClass('Hide');
+									tripEditor.find('.read.Annotation').addClass('Hide');
+									tripEditor.find('textarea#annotation').focus();
+								}))))
+				.append($('<tr>').addClass('read Annotation')
+						.append($('<td>').attr('colspan', '3').append($('<span>').attr('id', 'annotation'))))
+				.append($('<tr>').addClass('edit Annotation')
+						.append($('<td>').attr('colspan', '3')
+								.append($('<textarea>').attr('cols', '25').attr('rows', '4').attr('id', 'annotation').change(function() {
+									WS.Set(tripEditor.data('prefix')+'Annotation', $(this).val());
+									tripEditor.find('span#annotation').text($(this).val());
+									tripEditor.find('#clearAnn').toggleClass('Hide', $(this).val() === '');
+								}).focusout(function(){
+									tripEditor.find('.edit.Annotation').addClass('Hide');
+									tripEditor.find('.read.Annotation').removeClass('Hide');
+								}))))
+				.append($('<tr class="buttons close">')
+						.append($('<td colspan="2">').append($('<hr>')).append($('<button>').attr('id','submit').text('Close').button().click(function() {
 							tripEditor.dialog('close');
 						}))))
 		);

--- a/html/components/sk-sheet.js
+++ b/html/components/sk-sheet.js
@@ -23,7 +23,6 @@ function prepareSkSheetTable(element, teamId, mode) {
 		WS.Register(['ScoreBoard.Period(*).Number',
 				'ScoreBoard.Period(*).Jam(*).Number',
 				'ScoreBoard.Period(*).Jam(*).StarPass',
-				'ScoreBoard.Period(*).Jam(*).Overtime',
 				'ScoreBoard.Period(*).Jam(*).TeamJam(' + teamId + ').AfterSPScore',
 				'ScoreBoard.Period(*).Jam(*).TeamJam(' + teamId + ').Calloff',
 				'ScoreBoard.Period(*).Jam(*).TeamJam(' + teamId + ').JamScore',
@@ -38,11 +37,7 @@ function prepareSkSheetTable(element, teamId, mode) {
 				'ScoreBoard.Period(*).Jam(*).TeamJam(' + teamId + ').ScoringTrip(*).AfterSP',
 				'ScoreBoard.Period(*).Jam(*).TeamJam(' + teamId + ').ScoringTrip(*).Current',
 				'ScoreBoard.Period(*).Jam(*).TeamJam(' + teamId + ').ScoringTrip(*).Score',
-<<<<<<< HEAD
-				'ScoreBoard.Period(*).Jam(*).TeamJam(' + teamId + ').ScoringTrip(*).PointsWithoutTrip'
-=======
 				'ScoreBoard.Period(*).Jam(*).TeamJam(' + teamId + ').ScoringTrip(*).Annotation'
->>>>>>> scoring-annotations
 		], handleUpdate);
 	}
 

--- a/html/components/sk-sheet.js
+++ b/html/components/sk-sheet.js
@@ -159,6 +159,12 @@ function prepareSkSheetTable(element, teamId, mode) {
 				otherRow.find('.Trip2').text(otherScoreText);
 				jamRow.find('.NoInitial').text(trip1AfterSP || noInitial?'X':'');
 				spRow.find('.NoInitial').text(trip1AfterSP && noInitial?'X':'');
+				if (isTrue(WS.state[prefix+'ScoringTrip(2).PointsWithoutTrip'])){
+					row.find('.Trip2').addClass('noTripAlert');
+				}
+				if (trip2Score == null) {
+					row.find('.Trip2').removeClass('noTripAlert');
+				}
 				break;
 
 			 default:

--- a/html/components/sk-sheet.js
+++ b/html/components/sk-sheet.js
@@ -126,6 +126,20 @@ function prepareSkSheetTable(element, teamId, mode) {
 				spRow.find('.Jammer').text(isTrue(WS.state[prefix+'StarPass']) ? WS.state[prefix+'Fielding(Pivot).SkaterNumber'] : '');
 				break;
 
+			case 'ScoringTrip(2).PointsWithoutTrip':
+				var row = jamRow;
+				var otherRow = spRow;
+				if (trip2AfterSP || (trip2Score == null && trip1AfterSP)) {
+					row = spRow;
+					otherRow = jamRow;
+				}
+				if (isTrue(WS.state[prefix+'ScoringTrip(2).PointsWithoutTrip'])){
+					row.find('.Trip2').addClass('noTripAlert');
+				} else {
+					row.find('.Trip2').removeClass('noTripAlert');
+				}
+				break;
+				
 			case 'ScoringTrip(1).AfterSP': case 'ScoringTrip(1).Score': case 'ScoringTrip(2).Score':
 			case 'ScoringTrip(2).AfterSP': case 'ScoringTrip(2).Current': case 'NoInitial':
 				var trip1Score = WS.state[prefix+'ScoringTrip(1).Score'];
@@ -161,12 +175,6 @@ function prepareSkSheetTable(element, teamId, mode) {
 				otherRow.find('.Trip2').text(otherScoreText);
 				jamRow.find('.NoInitial').text(trip1AfterSP || noInitial?'X':'');
 				spRow.find('.NoInitial').text(trip1AfterSP && noInitial?'X':'');
-				if (isTrue(WS.state[prefix+'ScoringTrip(2).PointsWithoutTrip'])){
-					row.find('.Trip2').addClass('noTripAlert');
-				}
-				if (trip2Score == null) {
-					row.find('.Trip2').removeClass('noTripAlert');
-				}
 				break;
 				
 			 default:

--- a/src/com/carolinarollergirls/scoreboard/core/ScoringTrip.java
+++ b/src/com/carolinarollergirls/scoreboard/core/ScoringTrip.java
@@ -11,6 +11,7 @@ public interface ScoringTrip extends NumberedScoreBoardEventProvider<ScoringTrip
         SCORE(Integer.class, 0),
         AFTER_S_P(Boolean.class, false),
         CURRENT(Boolean.class, false),
+        POINTS_WITHOUT_TRIP(Boolean.class, false),
         DURATION(Long.class, 0L),
         JAM_CLOCK_START(Long.class, 0L),
         JAM_CLOCK_END(Long.class, 0L);

--- a/src/com/carolinarollergirls/scoreboard/core/ScoringTrip.java
+++ b/src/com/carolinarollergirls/scoreboard/core/ScoringTrip.java
@@ -11,7 +11,6 @@ public interface ScoringTrip extends NumberedScoreBoardEventProvider<ScoringTrip
         SCORE(Integer.class, 0),
         AFTER_S_P(Boolean.class, false),
         CURRENT(Boolean.class, false),
-        POINTS_WITHOUT_TRIP(Boolean.class, false),
         DURATION(Long.class, 0L),
         JAM_CLOCK_START(Long.class, 0L),
         JAM_CLOCK_END(Long.class, 0L),

--- a/src/com/carolinarollergirls/scoreboard/core/ScoringTrip.java
+++ b/src/com/carolinarollergirls/scoreboard/core/ScoringTrip.java
@@ -13,7 +13,8 @@ public interface ScoringTrip extends NumberedScoreBoardEventProvider<ScoringTrip
         CURRENT(Boolean.class, false),
         DURATION(Long.class, 0L),
         JAM_CLOCK_START(Long.class, 0L),
-        JAM_CLOCK_END(Long.class, 0L);
+        JAM_CLOCK_END(Long.class, 0L),
+        ANNOTATION(String.class, "");
 
         private Value(Class<?> t, Object dv) { type = t; defaultValue = dv; }
         private final Class<?> type;

--- a/src/com/carolinarollergirls/scoreboard/core/impl/TeamImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/impl/TeamImpl.java
@@ -87,8 +87,8 @@ public class TeamImpl extends ScoreBoardEventProviderImpl implements Team {
         if (prop == Value.TRIP_SCORE && flag != Flag.COPY && (Integer)value > 0) {
             // If points arrive during an initial trip and we are not in overtime, assign the points to the first scoring trip instead.
             if (getCurrentTrip().getNumber() == 1 && !getScoreBoard().isInOvertime()) {
-                execute(Command.ADD_TRIP);
                 getCurrentTrip().set(ScoringTrip.Value.ANNOTATION,"Points were added without Trip +1\n" + get(ScoringTrip.Value.ANNOTATION));
+                execute(Command.ADD_TRIP);
             }
             
             if (scoreBoard.isInJam()) {

--- a/src/com/carolinarollergirls/scoreboard/core/impl/TeamImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/impl/TeamImpl.java
@@ -71,7 +71,6 @@ public class TeamImpl extends ScoreBoardEventProviderImpl implements Team {
         addWriteProtectionOverride(Value.OFFICIAL_REVIEWS, Flag.INTERNAL);
         addWriteProtectionOverride(Value.LAST_REVIEW, Flag.INTERNAL);
         setCopy(Value.RETAINED_OFFICIAL_REVIEW, this, Value.LAST_REVIEW, Timeout.Value.RETAINED_REVIEW, false);
-
         sb.addScoreBoardListener(new ConditionalScoreBoardListener(Rulesets.class, Rulesets.Value.CURRENT_RULESET, rulesetChangeListener));
     }
 

--- a/src/com/carolinarollergirls/scoreboard/core/impl/TeamImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/impl/TeamImpl.java
@@ -17,6 +17,7 @@ import com.carolinarollergirls.scoreboard.core.BoxTrip;
 import com.carolinarollergirls.scoreboard.core.Clock;
 import com.carolinarollergirls.scoreboard.core.Fielding;
 import com.carolinarollergirls.scoreboard.core.FloorPosition;
+import com.carolinarollergirls.scoreboard.core.Jam;
 import com.carolinarollergirls.scoreboard.core.Position;
 import com.carolinarollergirls.scoreboard.core.PreparedTeam;
 import com.carolinarollergirls.scoreboard.core.PreparedTeam.PreparedTeamSkater;
@@ -84,16 +85,24 @@ public class TeamImpl extends ScoreBoardEventProviderImpl implements Team {
             Timeout t = scoreBoard.getCurrentTimeout(); 
             return t.isRunning() && this == t.getOwner() && t.isReview();
         }
-        if (prop == Value.TRIP_SCORE && flag != Flag.COPY && scoreBoard.isInJam() && (Integer)value > 0) {
-            tripScoreTimerTask.cancel();
-            tripScoreTimer.purge();
-            tripScoreTimerTask = new TimerTask() {
-                @Override
-                public void run() {
-                    execute(Command.ADD_TRIP);
-                }
-            };
-            tripScoreTimer.schedule(tripScoreTimerTask, 4000);
+        if (prop == Value.TRIP_SCORE && flag != Flag.COPY && (Integer)value > 0) {
+            // If points arrive during an initial trip and we are not in overtime, assign the points to the first scoring trip instead.
+            if (getCurrentTrip().getNumber() == 1 && !getScoreBoard().isInOvertime()) {
+                execute(Command.ADD_TRIP);
+                getCurrentTrip().set(ScoringTrip.Value.POINTS_WITHOUT_TRIP,true);
+            }
+            
+            if (scoreBoard.isInJam()) {
+                tripScoreTimerTask.cancel();
+                tripScoreTimer.purge();
+                tripScoreTimerTask = new TimerTask() {
+                    @Override
+                    public void run() {
+                        execute(Command.ADD_TRIP);
+                    }
+                };
+                tripScoreTimer.schedule(tripScoreTimerTask, 4000);
+            }
         }
         if (prop == Value.NO_INITIAL && flag != Flag.COPY) {
             if (!(Boolean)value && (Boolean)last) {
@@ -572,13 +581,13 @@ public class TeamImpl extends ScoreBoardEventProviderImpl implements Team {
 
     @Override
     public boolean hasNoPivot() { return (Boolean)get(Value.NO_PIVOT); }
-
+    
     @Override
     public Team getOtherTeam() {
         String otherId = getId().equals(Team.ID_1) ? Team.ID_2 : Team.ID_1;
         return getScoreBoard().getTeam(otherId);
     }
-    
+            
     FloorPosition nextReplacedBlocker = FloorPosition.PIVOT;
     
     private Timer tripScoreTimer = new Timer();

--- a/src/com/carolinarollergirls/scoreboard/core/impl/TeamImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/impl/TeamImpl.java
@@ -88,7 +88,7 @@ public class TeamImpl extends ScoreBoardEventProviderImpl implements Team {
             // If points arrive during an initial trip and we are not in overtime, assign the points to the first scoring trip instead.
             if (getCurrentTrip().getNumber() == 1 && !getScoreBoard().isInOvertime()) {
                 execute(Command.ADD_TRIP);
-                getCurrentTrip().set(ScoringTrip.Value.POINTS_WITHOUT_TRIP,true);
+                getCurrentTrip().set(ScoringTrip.Value.ANNOTATION,"Points were added without Trip +1\n" + get(ScoringTrip.Value.ANNOTATION));
             }
             
             if (scoreBoard.isInJam()) {

--- a/tests/com/carolinarollergirls/scoreboard/core/impl/StatsImplTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/core/impl/StatsImplTests.java
@@ -278,7 +278,6 @@ public class StatsImplTests {
         // Add some points without adding a trip or lead.
         team1.set(Value.TRIP_SCORE, 4, Flag.CHANGE);
         assertEquals(2, tj.getCurrentScoringTrip().getNumber());
-        assertEquals(true, tj.getCurrentScoringTrip().get(ScoringTrip.Value.POINTS_WITHOUT_TRIP));
         
         sb.stopJamTO();
         advance(1000);
@@ -292,7 +291,6 @@ public class StatsImplTests {
         // Add some points between jams without adding a trip or lead.
         team1.set(Value.TRIP_SCORE, 4, Flag.CHANGE);
         assertEquals(2, tj.getCurrentScoringTrip().getNumber());
-        assertEquals(true, tj.getCurrentScoringTrip().get(ScoringTrip.Value.POINTS_WITHOUT_TRIP));
         
         sb.startJam();
         sb.setInOvertime(true);

--- a/tests/com/carolinarollergirls/scoreboard/core/impl/StatsImplTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/core/impl/StatsImplTests.java
@@ -14,6 +14,7 @@ import com.carolinarollergirls.scoreboard.core.Jam;
 import com.carolinarollergirls.scoreboard.core.Period;
 import com.carolinarollergirls.scoreboard.core.Role;
 import com.carolinarollergirls.scoreboard.core.ScoreBoard;
+import com.carolinarollergirls.scoreboard.core.ScoringTrip;
 import com.carolinarollergirls.scoreboard.core.Skater;
 import com.carolinarollergirls.scoreboard.core.Team;
 import com.carolinarollergirls.scoreboard.core.Team.Value;
@@ -173,6 +174,10 @@ public class StatsImplTests {
         Period p = sb.getOrCreatePeriod(1);
         Jam j = p.getJam(1);
         TeamJam tj = j.getTeamJam(Team.ID_1);
+        
+        // Lead during the jam.
+        team1.set(Value.LEAD, true);
+        assertTrue(tj.isDisplayLead());
 
         // Change the score during the jam.
         team1.set(Value.TRIP_SCORE, 5, Flag.CHANGE);
@@ -183,15 +188,11 @@ public class StatsImplTests {
         team1.set(Value.STAR_PASS_TRIP, team1.get(Value.CURRENT_TRIP));
         assertEquals(true, tj.isStarPass());
 
-        // Lead during the jam.
-        team1.set(Value.LEAD, true);
-        assertTrue(tj.isDisplayLead());
-
         sb.stopJamTO();
         advance(1000);
         // Star pass and lead still correct after jam end.
         assertEquals(true, tj.isStarPass());
-        assertTrue(tj.isDisplayLead());
+        assertEquals(false, tj.isDisplayLead());
 
         // Some points arrive after end of jam.
         team1.set(Value.TRIP_SCORE, 4, Flag.CHANGE);
@@ -264,6 +265,45 @@ public class StatsImplTests {
         // New jammer does not replace jammer from previous jam.
         team1.field(skater4, Role.JAMMER);
         assertEquals(skater1, tj.getFielding(FloorPosition.JAMMER).getSkater());
+    }
+    @Test
+    public void testTripAutoAdvance() {
+        sb.startJam();
+        advance(1000);
+        
+        Period p = sb.getOrCreatePeriod(1);
+        Jam j = p.getJam(1);
+        TeamJam tj = j.getTeamJam(Team.ID_1);
+        
+        // Add some points without adding a trip or lead.
+        team1.set(Value.TRIP_SCORE, 4, Flag.CHANGE);
+        assertEquals(2, tj.getCurrentScoringTrip().getNumber());
+        assertEquals(true, tj.getCurrentScoringTrip().get(ScoringTrip.Value.POINTS_WITHOUT_TRIP));
+        
+        sb.stopJamTO();
+        advance(1000);
+        sb.startJam();
+        advance(1000);
+        j = p.getJam(2);
+        tj = j.getTeamJam(Team.ID_1);
+        sb.stopJamTO();
+        advance(1000);
+        
+        // Add some points between jams without adding a trip or lead.
+        team1.set(Value.TRIP_SCORE, 4, Flag.CHANGE);
+        assertEquals(2, tj.getCurrentScoringTrip().getNumber());
+        assertEquals(true, tj.getCurrentScoringTrip().get(ScoringTrip.Value.POINTS_WITHOUT_TRIP));
+        
+        sb.startJam();
+        sb.setInOvertime(true);
+        advance(1000);
+        j = p.getJam(3);
+        tj = j.getTeamJam(Team.ID_1);
+        
+        // Add some points without adding a trip or lead during an overtime jam
+        assertEquals(1, tj.getCurrentScoringTrip().getNumber());
+        team1.set(Value.TRIP_SCORE, 1);
+        assertEquals(1, tj.getCurrentScoringTrip().getNumber());
     }
 
 }


### PR DESCRIPTION
Submitted based on the overwhelming support for this modification on the user group. (I count several dozen responses in favor, and only three including Bhrian and Speedy opposed) When points are entered for a skater on an initial trip, a scoring trip is added and the points are transferred to that scoring trip.

Does not break manual entry of initial trip points if desired, and does not apply during overtime.

Resolves issue #428.