### PR TITLE
Fix rounding of countdown clocks on scoreboard view and overlay

### DIFF
--- a/html/views/common.js
+++ b/html/views/common.js
@@ -140,6 +140,7 @@ function toClockInitialNumber(k, v) {
 }
 
 function toTime(k, v) {
+	k = WS._enrichProp(k);
 	var isCountDown = isTrue(WS.state['ScoreBoard.Clock(' + k.Clock + ').Direction']);
 	return _timeConversions.msToMinSecNoZero(v, isCountDown);
 }


### PR DESCRIPTION
This change should probably be done somewhere in WS.js, but I couldn't figure out where and wanted to fix the issue at hand.

closes #444 