### PR TITLE
Make points handling on operator screen more intuitive

### DIFF
--- a/html/components/rulesets-tab.js
+++ b/html/components/rulesets-tab.js
@@ -208,7 +208,7 @@ function createRulesetsTab(tab) {
       tab.find('#current_rs').val(v);
       markEffectiveRulesets();
       var definitions = tab.children('.definitions');
-      if (activeRuleset.Effective) {
+      if (activeRuleset != null && activeRuleset.Effective) {
         definitions.find('.Update, .EditNote').show();
         definitions.find('.Delete').hide();
       } else {

--- a/html/components/sk-sheet.js
+++ b/html/components/sk-sheet.js
@@ -87,7 +87,7 @@ function prepareSkSheetTable(element, teamId, mode) {
     }
 
     // Everything after here is team specific.
-    if (k.TeamJam !== teamId) { return; }
+    if (k.TeamJam != teamId) { return; }
     prefix = prefix + 'TeamJam(' + teamId + ').';
     switch (k.substring(prefix.length)) {
       case 'Fielding(Jammer).SkaterNumber':
@@ -417,4 +417,4 @@ function prepareSkaterSelector() {
   WS.Register(['ScoreBoard.Period(*).Jam(*).TeamJam(*).Fielding(*).Skater']);
 }
 
-//# sourceURL=controls\sk\sk-sheet.js
+//# sourceURL=components\sk-sheet.js

--- a/html/components/team-time-tab.css
+++ b/html/components/team-time-tab.css
@@ -38,8 +38,8 @@
 #TeamTime table.Team tr.Name td.Name div a.AlternateName { display: none; }
 #TeamTime table.Team tr.Name td.Logo img { height: 50px; vertical-align: middle; }
 #TeamTime table.Team tr.Score td.Score a { font-size: 300%; }
-#TeamTime table.Team tr.Score td a.TripScore { font-size: 200%; line-height: 175%; }
-#TeamTime table.Team tr.Score td a.JamScore { font-size: 200%; line-height: 175%; }
+#TeamTime table.Team tr.Score td a.TripScore { font-size: 150%; }
+#TeamTime table.Team tr.Score td a.JamScore { font-size: 150%; }
 #TeamTime table.Team tr.Timeout td.Timeouts a { font-size: 200%; }
 #TeamTime table.Team tr.Timeout td.OfficialReviews a { font-size: 200%; }
 #TeamTime table.Team tr.Timeout td.OfficialTimeout { position: relative; }

--- a/src/com/carolinarollergirls/scoreboard/core/impl/ScoringTripImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/impl/ScoringTripImpl.java
@@ -1,11 +1,11 @@
 package com.carolinarollergirls.scoreboard.core.impl;
 
+import com.carolinarollergirls.scoreboard.core.Clock;
 import com.carolinarollergirls.scoreboard.core.ScoringTrip;
 import com.carolinarollergirls.scoreboard.core.TeamJam;
 import com.carolinarollergirls.scoreboard.event.Command;
 import com.carolinarollergirls.scoreboard.event.NumberedScoreBoardEventProviderImpl;
 import com.carolinarollergirls.scoreboard.event.Value;
-import com.carolinarollergirls.scoreboard.utils.ScoreBoardClock;
 
 public class ScoringTripImpl extends NumberedScoreBoardEventProviderImpl<ScoringTrip> implements ScoringTrip {
     ScoringTripImpl(TeamJam parent, int number) {
@@ -32,7 +32,7 @@ public class ScoringTripImpl extends NumberedScoreBoardEventProviderImpl<Scoring
     @Override
     public void valueChanged(Value<?> prop, Object value, Object last, Source source, Flag flag) {
         if ((prop == SCORE || (prop == CURRENT && !(Boolean) value)) && get(JAM_CLOCK_END) == 0L) {
-            set(JAM_CLOCK_END, ScoreBoardClock.getInstance().getCurrentWalltime());
+            set(JAM_CLOCK_END, scoreBoard.getClock(Clock.ID_JAM).getTimeElapsed());
         }
         if (prop == CURRENT && (Boolean) value && get(SCORE) == 0) {
             set(JAM_CLOCK_END, 0L);


### PR DESCRIPTION
- Make trip points always visible.
- Add labels to jam and trip points and rearrange them on top of each
  other in order to not waste a lot of screen space.
- Flash points values of 0 that prevent a "Points -1" input from having
  an effect. (Closes #438)
- Relabel the Points+- and Trip+- buttons to make their function more
  obvious.
- Add button to set current trip score to 0. Pressing it when the trip score is 0 triggers a trip advancement timer like the other trip score buttons do.
- Add explanatory label to trip score buttons

![Screenshot_20200718_215300](https://user-images.githubusercontent.com/34135287/87861076-217c2f80-c943-11ea-845b-79287a1c4b93.png)

Additionally fix a bug that prevented the score sheets from being
populated.
