### PR TITLE
Preserve aspect ratio in full-screen scoreboard displays

### DIFF
--- a/html/components/settings-tab.js
+++ b/html/components/settings-tab.js
@@ -256,16 +256,38 @@ function createScoreBoardViewPreviewRows(table, type) {
   var imageViewSelect = $('<label>Image View: </label>')
     .add(mediaSelect('ScoreBoard.Settings.Setting(ScoreBoard.' + type + '_Image)', 'images', 'fullscreen', 'Image'))
     .attr('ApplyPreview', 'Image');
+
+  var imageScaleSelect = $('<label>Image Scaling: </label>').add(
+      WSControl(
+        'ScoreBoard.Settings.Setting(ScoreBoard.' + type + '_ImageScaling)',
+        $('<select>')
+          .attr('ApplyPreview', 'ImageScaling')
+          .append('<option value="contain">Scale to fit</option>')
+          .append('<option value="cover">Scale to fill</option>')
+          .append('<option value="fill">Stretch</option>')));
+
   var videoViewSelect = $('<label>Video View: </label>')
     .add(mediaSelect('ScoreBoard.Settings.Setting(ScoreBoard.' + type + '_Video)', 'videos', 'fullscreen', 'Video'))
     .attr('ApplyPreview', 'Video');
+
+  var videoScaleSelect = $('<label>Video Scaling: </label>').add(
+    WSControl(
+      'ScoreBoard.Settings.Setting(ScoreBoard.' + type + '_VideoScaling)',
+      $('<select>')
+        .attr('ApplyPreview', 'VideoScaling')
+        .append('<option value="contain">Scale to fit</option>')
+        .append('<option value="cover">Scale to fill</option>')
+        .append('<option value="fill">Stretch</option>')));
+
   var customPageViewSelect = $('<label>Custom Page View: </label>')
     .add(mediaSelect('ScoreBoard.Settings.Setting(ScoreBoard.' + type + '_CustomHtml)', 'custom', 'view', 'Page'))
     .attr('ApplyPreview', 'CustomHtml');
 
   var optionsTable = $('<table/>').addClass(type).addClass('RowTable').css('width', '100%');
   $('<tr><td></td></tr>').addClass(type).appendTo(table).find('td').append(optionsTable);
-  $('<tr><td/><td/><td/></tr>')
+
+  let optionsTableRow = '<tr><td/><td/><td/><td/></tr>';
+  $(optionsTableRow)
     .addClass(type)
     .appendTo(optionsTable)
     .addClass('ScoreBoardOptions')
@@ -275,8 +297,10 @@ function createScoreBoardViewPreviewRows(table, type) {
     .next()
     .append(boxStyle)
     .next()
-    .append(imageViewSelect);
-  $('<tr><td/><td/><td/></tr>')
+    .append(imageViewSelect)
+    .next()
+    .append(imageScaleSelect);
+  $(optionsTableRow)
     .addClass(type)
     .appendTo(optionsTable)
     .addClass('ScoreBoardOptions')
@@ -286,8 +310,10 @@ function createScoreBoardViewPreviewRows(table, type) {
     .next()
     .append(sidePadding)
     .next()
-    .append(videoViewSelect);
-  $('<tr><td/><td/><td/></tr>')
+    .append(videoViewSelect)
+    .next()
+    .append(videoScaleSelect);
+  $(optionsTableRow)
     .addClass(type)
     .addClass('ScoreBoardOptions EndSubSection Footer')
     .appendTo(optionsTable)

--- a/html/views/standard/index.css
+++ b/html/views/standard/index.css
@@ -9,7 +9,7 @@ user-select: none;-webkit-user-select: none;-khtml-user-select: none;-moz-user-s
 .DisplayPane {opacity: 0;position: absolute;left: 0; top: 0;width: 100%;height: 100%; } 
 .DisplayPane.Hide {animation: HidePanel 1s;-moz-animation: HidePanel 1s;-webkit-animation: HidePanel 1s; } 
 .DisplayPane.Show {animation: ShowPanel 1s;-moz-animation: ShowPanel 1s;-webkit-animation: ShowPanel 1s;opacity: 1; } 
-.DisplayPane>.object {width: 100%;height: 100%;scrolling: no; frameborder: 0px; border: 0px; } 
+.DisplayPane>.object {width: 100%;height: 100%;scrolling: no; frameborder: 0px; border: 0px; object-fit: contain; } 
 @-moz-keyframes ShowPanel { 
  0% { opacity: 0; } 100% { opacity: 1; } 
  } 

--- a/html/views/standard/index.js
+++ b/html/views/standard/index.js
@@ -41,8 +41,14 @@ function initialize() {
   WS.Register('ScoreBoard.Settings.Setting(ScoreBoard.' + view + '_Image)', function (k, v) {
     $('div#image>img').attr('src', v);
   });
+  WS.Register('ScoreBoard.Settings.Setting(ScoreBoard.' + view + '_ImageScaling)', function (k, v) {
+    $('div#image>img').css('object-fit', v);
+  });
   WS.Register('ScoreBoard.Settings.Setting(ScoreBoard.' + view + '_Video)', function (k, v) {
     $('div#video>video').attr('src', v);
+  });
+  WS.Register('ScoreBoard.Settings.Setting(ScoreBoard.' + view + '_VideoScaling)', function (k, v) {
+    $('div#video>video').css('object-fit', v);
   });
   WS.Register('ScoreBoard.Settings.Setting(ScoreBoard.' + view + '_CustomHtml)', function (k, v) {
     $('div#html>iframe').attr('src', v);

--- a/src/com/carolinarollergirls/scoreboard/core/admin/SettingsImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/admin/SettingsImpl.java
@@ -56,10 +56,12 @@ public class SettingsImpl extends ScoreBoardEventProviderImpl<Settings> implemen
         setBothViews("CurrentView", "scoreboard");
         setBothViews("CustomHtml", "/customhtml/fullscreen/example.html");
         setBothViews("Image", "/images/fullscreen/test-image.png");
+        setBothViews("ImageScaling", "contain");
         setBothViews("HideLogos", "false");
         setBothViews("SidePadding", "");
         setBothViews("SwapTeams", "false");
         setBothViews("Video", "/videos/fullscreen/test-video.webm");
+        setBothViews("VideoScaling", "contain");
     }
 
     @Override

--- a/src/com/carolinarollergirls/scoreboard/core/admin/SettingsImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/admin/SettingsImpl.java
@@ -11,6 +11,9 @@ import com.carolinarollergirls.scoreboard.event.ValueWithId;
 import com.carolinarollergirls.scoreboard.utils.StatsbookExporter;
 import com.carolinarollergirls.scoreboard.utils.ValWithId;
 
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
 public class SettingsImpl extends ScoreBoardEventProviderImpl<Settings> implements Settings {
     public SettingsImpl(ScoreBoard s) {
         super(s, "", ScoreBoard.SETTINGS);
@@ -48,22 +51,15 @@ public class SettingsImpl extends ScoreBoardEventProviderImpl<Settings> implemen
         set("ScoreBoard.Intermission.Intermission", "Intermission");
         set("ScoreBoard.Intermission.Unofficial", "Unofficial Score");
         set("ScoreBoard.Intermission.Official", "Final Score");
-        set("ScoreBoard.Preview_BoxStyle", "box_flat_bright");
-        set("ScoreBoard.Preview_CurrentView", "scoreboard");
-        set("ScoreBoard.Preview_CustomHtml", "/customhtml/fullscreen/example.html");
-        set("ScoreBoard.Preview_Image", "/images/fullscreen/test-image.png");
-        set("ScoreBoard.Preview_HideLogos", "false");
-        set("ScoreBoard.Preview_SidePadding", "");
-        set("ScoreBoard.Preview_SwapTeams", "false");
-        set("ScoreBoard.Preview_Video", "/videos/fullscreen/test-video.webm");
-        set("ScoreBoard.View_BoxStyle", "box_flat_bright");
-        set("ScoreBoard.View_CurrentView", "scoreboard");
-        set("ScoreBoard.View_CustomHtml", "/customhtml/fullscreen/example.html");
-        set("ScoreBoard.View_HideLogos", "false");
-        set("ScoreBoard.View_Image", "/images/fullscreen/test-image.png");
-        set("ScoreBoard.View_SidePadding", "");
-        set("ScoreBoard.View_SwapTeams", "false");
-        set("ScoreBoard.View_Video", "/videos/fullscreen/test-video.webm");
+
+        setBothViews("BoxStyle", "box_flat_bright");
+        setBothViews("CurrentView", "scoreboard");
+        setBothViews("CustomHtml", "/customhtml/fullscreen/example.html");
+        setBothViews("Image", "/images/fullscreen/test-image.png");
+        setBothViews("HideLogos", "false");
+        setBothViews("SidePadding", "");
+        setBothViews("SwapTeams", "false");
+        setBothViews("Video", "/videos/fullscreen/test-video.webm");
     }
 
     @Override
@@ -82,5 +78,10 @@ public class SettingsImpl extends ScoreBoardEventProviderImpl<Settings> implemen
                 add(SETTING, new ValWithId(k, v));
             }
         }
+    }
+
+    private void setBothViews(String key, String value) {
+        set("ScoreBoard.Preview_" + key, value);
+        set("ScoreBoard.View_" + key, value);
     }
 }


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit for details.

Videos already scale correctly without `object-fit` (as `<img>` and `<video>` tags are seemingly handled inconsistently), but specifying it explicitly doesn't hurt.
