### PR TITLE
Disallow deleting jams with points or SP

### DIFF
--- a/html/components/team-time-tab.css
+++ b/html/components/team-time-tab.css
@@ -98,6 +98,7 @@ table.TimeDialog button.Set>span { padding: 0.1em 1em; }
 /* Period/Jam/Timeout Dialog */
 div.NumberDialog .Hide { display: none; } 
 div.NumberDialog button.Active { background: #3F3; color: black; } 
+div.NumberDialog button:disabled { background: #eee; color: #bbb; } 
 /* End Period/Jam/Timeout Dialog */
 
 

--- a/html/components/team-time-tab.js
+++ b/html/components/team-time-tab.js
@@ -1315,6 +1315,7 @@ function createJamDialog(gameId) {
     [
       'ScoreBoard.Game(' + gameId + ').Period(*).Jam(*).Duration',
       'ScoreBoard.Game(' + gameId + ').Period(*).Jam(*).Number',
+      'ScoreBoard.Game(' + gameId + ').Period(*).Jam(*).StarPass',
       'ScoreBoard.Game(' + gameId + ').Period(*).Jam(*).PeriodClockDisplayEnd',
       'ScoreBoard.Game(' + gameId + ').Period(*).Jam(*).TeamJam(*).JamScore',
     ],
@@ -1353,6 +1354,7 @@ function createJamDialog(gameId) {
             $('<td>').append(
               $('<button>')
                 .text('Delete')
+                .addClass('delete')
                 .button()
                 .on('click', function () {
                   //TODO: confirmation popup
@@ -1389,6 +1391,18 @@ function createJamDialog(gameId) {
       if (v != null) {
         if (key === 'JamScore') {
           row.find('td.Points .' + k.TeamJam).text(v);
+        }
+        if (key === 'StarPass' || key === 'JamScore') {
+          row
+            .find('button.delete')
+            .prop(
+              'disabled',
+              isTrue(
+                WS.state[prefix + '.StarPass'] ||
+                  WS.state[prefix + '.TeamJam(1).JamScore'] > 0 ||
+                  WS.state[prefix + '.TeamJam(2).JamScore'] > 0
+              )
+            );
         }
         if (key === 'Duration') {
           if (WS.state[prefix + '.WalltimeEnd'] === 0 && WS.state[prefix + '.WalltimeStart'] > 0) {

--- a/src/com/carolinarollergirls/scoreboard/core/game/JamImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/game/JamImpl.java
@@ -14,6 +14,7 @@ import com.carolinarollergirls.scoreboard.event.NumberedScoreBoardEventProviderI
 import com.carolinarollergirls.scoreboard.event.ScoreBoardEventProvider;
 import com.carolinarollergirls.scoreboard.event.ScoreBoardListener;
 import com.carolinarollergirls.scoreboard.event.Value;
+import com.carolinarollergirls.scoreboard.utils.Logger;
 import com.carolinarollergirls.scoreboard.utils.ScoreBoardClock;
 
 public class JamImpl extends NumberedScoreBoardEventProviderImpl<Jam> implements Jam {
@@ -71,8 +72,18 @@ public class JamImpl extends NumberedScoreBoardEventProviderImpl<Jam> implements
             if (prop == DELETE) {
                 if (game.isInJam() && (parent == game.getCurrentPeriod()) &&
                     (this == ((Period) parent).getCurrentJam())) {
+                    Logger.printMessage("Refusing to delete current Jam.");
                     return;
                 }
+                if (getTeamJam(Team.ID_1).getJamScore() > 0 || getTeamJam(Team.ID_2).getJamScore() > 0) {
+                    Logger.printMessage("Refusing to delete Jam with points. Remove points first.");
+                    return;
+                }
+                if (get(STAR_PASS)) {
+                    Logger.printMessage("Refusing to delete Jam with Star Pass. Remove SP first.");
+                    return;
+                }
+
                 delete(source);
                 game.updateTeamJams();
             } else if (prop == INSERT_BEFORE) {


### PR DESCRIPTION
It'S buggy and almost certainly result of a misclick.
If anybody ever needs to actually do this, they can delete points and/or SP first and delete the Jam afterwards.

Closes #558 