### PR TITLE
feat(views/roster): :sparkles: display roles on roster view

### DIFF
--- a/html/components/roster-tab.css
+++ b/html/components/roster-tab.css
@@ -26,6 +26,7 @@
 #Teams table.Skaters th.Title { font-size: 150%; } 
 #Teams table.Skaters th#skaterCount { font-size: 100%; font-weight: normal; } 
 
+#Teams table.Skaters tr[flag='ALT'] { display:none; }
 #Teams table.Skaters tr[role='Pivot'] { background-color: #00ee00 !important; } 
 #Teams table.Skaters tr[role='Pivot']>td { background: #00ee00 !important; }
 #Teams table.Skaters tr[role='Jammer'] { background-color: #00cc00 !important; } 

--- a/html/components/roster-tab.css
+++ b/html/components/roster-tab.css
@@ -25,3 +25,10 @@
 
 #Teams table.Skaters th.Title { font-size: 150%; } 
 #Teams table.Skaters th#skaterCount { font-size: 100%; font-weight: normal; } 
+
+#Teams table.Skaters tr[role='Pivot'] { background-color: #00ee00 !important; } 
+#Teams table.Skaters tr[role='Pivot']>td { background: #00ee00 !important; }
+#Teams table.Skaters tr[role='Jammer'] { background-color: #00cc00 !important; } 
+#Teams table.Skaters tr[role='Jammer']>td { background: #00cc00 !important; }
+#Teams table.Skaters tr[role='Blocker'] { background-color: #70ff70 !important; } 
+#Teams table.Skaters tr[role='Blocker']>td { background: #70ff70 !important; } 

--- a/html/components/roster-tab.js
+++ b/html/components/roster-tab.js
@@ -36,7 +36,6 @@ function createRosterTable(element, teamPrefix) {
     .appendTo(teamTable.find('tr.Skaters>td'))
     .append('<col class="RosterNumber">')
     .append('<col class="Name">')
-    .append('<col class="Role">')
     .append('<col class="Pronouns">')
     .append('<col class="Flags">')
     .append('<thead/><tbody/>')
@@ -46,7 +45,7 @@ function createRosterTable(element, teamPrefix) {
 
   var updateSkaterCount = function () {
     var count = 0;
-    skatersTable.find('tr.Skater td.Flags span').each(function (_, f) {
+    skatersTable.find('tr.Skater').each(function (_, f) {
       var flag = $(f).attr('flag');
       if (flag === '' || flag === 'C' || flag === 'A') {
         count++;
@@ -73,31 +72,46 @@ function createRosterTable(element, teamPrefix) {
         .attr('skaterid', k.Skater)
         .append('<td class="RosterNumber">')
         .append('<td class="Name">')
-        .append('<td class="Role">')
         .append('<td class="Pronouns">')
         .append('<td class="Flags">');
       $('<span>').appendTo(skaterRow.children('td.RosterNumber'));
       $('<span>').appendTo(skaterRow.children('td.Name'));
-      $('<span>').appendTo(skaterRow.children('td.Role'));
       $('<span>').appendTo(skaterRow.children('td.Pronouns'));
       $('<span>').appendTo(skaterRow.children('td.Flags'));
       _windowFunctions.appendAlphaSortedByAttr(skatersTable.children('tbody'), skaterRow, 'skaternum');
     }
 
-    if (k.field === 'Flags') {
-      var position = v;
-      switch (v) {
+    if (k.field === 'Flags' || k.field === 'Role') {
+      var position = '';
+      var flag = WS.state[teamPrefix + '.Skater(' + k.Skater + ').Flags'];
+      var role = WS.state[teamPrefix + '.Skater(' + k.Skater + ').Role'];
+      switch (flag) {
         case '':
-          position = 'Skater';
+          switch (role) {
+            case 'Jammer': position = 'Jammer'; break;
+            case 'Pivot': position = 'Pivot'; break;
+            case 'Blocker': position = 'Blocker'; break;
+            default: position = 'Skater'; break;
+          }
           break;
         case 'ALT':
           position = 'Not Skating';
           break;
         case 'C':
-          position = 'Captain';
+          switch (role) {
+            case 'Jammer': position = 'Jammer C'; break;
+            case 'Pivot': position = 'Pivot C'; break;
+            case 'Blocker': position = 'Blocker C'; break;
+            default: position = 'Captain'; break;
+          }
           break;
         case 'A':
-          position = 'Alt Captain';
+          switch (role) {
+            case 'Jammer': position = 'Jammer A'; break;
+            case 'Pivot': position = 'Pivot A'; break;
+            case 'Blocker': position = 'Blocker A'; break;
+            default: position = 'Alt Captain'; break;
+          }
           break;
         case 'BA':
           position = 'Bench Alt Captain';
@@ -106,7 +120,7 @@ function createRosterTable(element, teamPrefix) {
           position = 'Bench Staff';
           break;
       }
-      skaterRow.children('td.Flags').children().attr('flag', v).text(position);
+      skaterRow.attr('flag', flag).attr('role', role).children('td.Flags').children().text(position);
       updateSkaterCount();
     } else {
       skaterRow
@@ -116,9 +130,6 @@ function createRosterTable(element, teamPrefix) {
       if (k.field === 'RosterNumber') {
         skaterRow.attr('skaternum', v);
         _windowFunctions.appendAlphaSortedByAttr(skatersTable.children('tbody'), skaterRow, 'skaternum');
-      }
-      if (k.field === 'Role') {
-        skaterRow.attr('role', v);
       }
     }
   };

--- a/html/components/roster-tab.js
+++ b/html/components/roster-tab.js
@@ -36,6 +36,7 @@ function createRosterTable(element, teamPrefix) {
     .appendTo(teamTable.find('tr.Skaters>td'))
     .append('<col class="RosterNumber">')
     .append('<col class="Name">')
+    .append('<col class="Role">')
     .append('<col class="Pronouns">')
     .append('<col class="Flags">')
     .append('<thead/><tbody/>')
@@ -72,10 +73,12 @@ function createRosterTable(element, teamPrefix) {
         .attr('skaterid', k.Skater)
         .append('<td class="RosterNumber">')
         .append('<td class="Name">')
+        .append('<td class="Role">')
         .append('<td class="Pronouns">')
         .append('<td class="Flags">');
       $('<span>').appendTo(skaterRow.children('td.RosterNumber'));
       $('<span>').appendTo(skaterRow.children('td.Name'));
+      $('<span>').appendTo(skaterRow.children('td.Role'));
       $('<span>').appendTo(skaterRow.children('td.Pronouns'));
       $('<span>').appendTo(skaterRow.children('td.Flags'));
       _windowFunctions.appendAlphaSortedByAttr(skatersTable.children('tbody'), skaterRow, 'skaternum');
@@ -114,6 +117,9 @@ function createRosterTable(element, teamPrefix) {
         skaterRow.attr('skaternum', v);
         _windowFunctions.appendAlphaSortedByAttr(skatersTable.children('tbody'), skaterRow, 'skaternum');
       }
+      if (k.field === 'Role') {
+        skaterRow.attr('role', v);
+      }
     }
   };
 
@@ -122,6 +128,7 @@ function createRosterTable(element, teamPrefix) {
       teamPrefix + '.Skater(*).Flags',
       teamPrefix + '.Skater(*).Name',
       teamPrefix + '.Skater(*).RosterNumber',
+      teamPrefix + '.Skater(*).Role',
       teamPrefix + '.Skater(*).Pronouns',
     ],
     handleSkaterUpdate


### PR DESCRIPTION
## Description

Show roles and color code on roster view same as on lineup tracking

## Why

Closes #654 

## Testing

Tested locally in a test game with lineup tracking

![image](https://github.com/rollerderby/scoreboard/assets/3342243/76211aa5-9ac4-43b3-b435-a9c0c390c0d7)

When lineup tracking is disabled, players currently appear in "bench" by default

![image](https://github.com/rollerderby/scoreboard/assets/3342243/e89d7286-66cd-4747-b902-d69f2ccbaa46)

## Notes

* I added the roles column to the roster view because the shades of green used on the lineup tracking are close enough that they could be confused with one another without context. From an accessibility standpoint, we should probably keep the names in addition to colors and maybe also change to more contrasting colors.
* `NotInGame` is just the value of `role` but itself isn't very friendly to read.
* `Bench` when lineup tracking is disabled should probably be replaced with "not tracking" or similar to avoid confusion.
* I haven't gotten penalty box highlighting/displaying on the roster view yet. Ideally I'd like to see an indicator of when a player is in the box and a separate color. The name or code of the penalty being served would be a nice to have. This point may saved for a follow-up issue.