### PR TITLE
init feature request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[FEATURE REQUEST] One-liner description of feature request"
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: "Feature+Request"
+labels: "Feature Request"
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,8 +1,8 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: "[FEATURE REQUEST] One-liner description of feature request"
-labels: enhancement
+title: ''
+labels: "Feature+Request"
 assignees: ''
 
 ---


### PR DESCRIPTION
Adds an issue template for feature requests. Now that we have a bug report template, the create issue screen looks like this:

![image](https://github.com/rollerderby/scoreboard/assets/3342243/85e12937-f110-430d-ab1b-50197caaf073)

The "open a blank issue" link can be hard to find. Adding a feature request template will make it more obvious how we expect folks to submit feature requests, and also give us the opportunity to request certain bits of info from them.