### PR TITLE
Fix a variety of issues, including groundhog jam

### DIFF
--- a/html/components/penalty-list/index.html
+++ b/html/components/penalty-list/index.html
@@ -13,14 +13,15 @@
       </span>
       <span class="sbVeryImportant Instruction" sbDisplay="Clock.Time, EndFielding: penToInstruction"></span>
       <span class="sbVeryVeryImportant" sbDisplay="Clock.Time: sbToSeconds"></span>
-      <span class="sbImportant">
-        <span sbDisplay="PenaltyCodes"></span> | <span>Total: <span sbDisplay="TotalPenalties"></span></span>
+      <span>
+        <span sbDisplay="PenaltyDetails: penDetailButtons: html"></span>
+        <button sbCall="penAdd">Add</button>
       </span>
     </div>
     <div class="sbShowOnPbt Edit">
       <span>
         <button sbClass="sbClickMe: CurrentSkater, TotalPenalties: penFoOrExp" sbCall="penSubstitute">Substitute</button>
-        <button sbCall="penReassign">Reassign</button>
+        <button sbCall="penReassign">Change</button>
       </span>
       <span>
         <button sbClass="sbClickMe: EndFielding: sbIsNotEmpty | sbHide: Clock.Time: > 0" sbSet="IsCurrent: false">Has Left</button>
@@ -30,9 +31,8 @@
         <button sbToggle="TimingStopped"><span class="ui-icon ui-icon-pause"></span></button>
         <button sbSet="Clock.Time:+1000:change">+1</button>
       </span>
-      <span>
-        <button sbCall="penAdd">Add</button>
-        <button sbSet="RemovePenalty">Remove</button>
+      <span class="sbImportant">
+        <span>Total: <span sbDisplay="TotalPenalties"></span></span>
       </span>
     </div>
   </div>
@@ -82,5 +82,6 @@
         sbCall="sbCloseDialog"
       ></div>
     </div>
+    <div class="sbGroup"><button sbSet="Remove">Delete</button></div>
   </div>
 </div>

--- a/html/components/penalty-list/index.js
+++ b/html/components/penalty-list/index.js
@@ -19,6 +19,25 @@ function penToInstruction(k, v) {
   return WS.state[k.upTo('BoxTrip') + '.EndFielding'] ? 'Done' : v > 10000 ? 'Sit' : 'Stand';
 }
 
+function penDetailButtons(k, v) {
+  var content = '<span>';
+  v.split(',').forEach(function (detailsText) {
+    if (detailsText) {
+      const details = detailsText.split('_');
+      content =
+        content +
+        '<button sbContext="/' +
+        k.upTo('Team') +
+        '.Skater(' +
+        details[0] +
+        ').Penalty(' +
+        details[1] +
+        ')" sbDisplay="Code" sbCall="penSelectCode | sbCloseDialog"></button>';
+    }
+  });
+  return content + '</span>';
+}
+
 function penToPenaltyCodeDisplay(k, v) {
   let output = '<div class="Code">' + k.PenaltyCode + '</div><div class="Description">';
   v.split(',').forEach(function (d) {

--- a/html/components/sbo-input/index.css
+++ b/html/components/sbo-input/index.css
@@ -22,7 +22,7 @@
 #ClockDialog .Label { font-style: normal; }
 #ClockDialog .TimeControls { display: grid; grid: auto auto / 1fr 1fr 1fr; gap: var(--element-gap); }
 
-#JamDialog tr.isRunning .ifNotRunning { display: none; }
-#JamDialog tr:not(.isRunning) .ifRunning { display: none; }
-#JamDialog td.hasPoints .ifNoPoints { display: none; }
-#JamDialog td:not(.hasPoints) .ifPoints { display: none; }
+tr.isRunning .ifNotRunning { display: none; }
+tr:not(.isRunning) .ifRunning { display: none; }
+td.hasPoints .ifNoPoints { display: none; }
+td:not(.hasPoints) .ifPoints { display: none; }

--- a/html/components/sbo-input/index.html
+++ b/html/components/sbo-input/index.html
@@ -302,13 +302,15 @@
         </tr>
       </thead>
       <tbody>
-        <tr sbForeach="Period: -0">
+        <tr sbForeach="Period: -0" sbClass="isRunning: Running">
           <td sbDisplay="Number"></td>
           <td sbDisplay="CurrentJamNumber"></td>
-          <td>
-            <span sbClass="sbHide: Running: !">running</span><span sbClass="sbHide: Running" sbDisplay="Duration: sbToLongTime"></span>
+          <td><span class="ifRunning">running</span><span class="ifNotRunning" sbDisplay="Duration: sbToLongTime"></span></td>
+          <td sbClass="hasPoints: Team1Points,Team2Points: opPerHasPoints">
+            <span class="ifRunning">running</span>
+            <span class="ifNotRunning ifPoints">has points</span>
+            <button class="ifNotRunning ifNoPoints" sbSet="Delete">Delete</button>
           </td>
-          <td><button sbSet="Delete">Delete</button></td>
           <td><button sbSet="InsertBefore">Insert Before</button></td>
         </tr>
       </tbody>

--- a/html/components/sbo-input/index.js
+++ b/html/components/sbo-input/index.js
@@ -278,6 +278,10 @@ function opHasPoints(k) {
   );
 }
 
+function opPerHasPoints(k) {
+  return WS.state[k.upTo('Period') + '.Team1Points'] != 0 || WS.state[k.upTo('Period') + '.Team2Points'] != 0;
+}
+
 function opInsertBeforeUpcoming(k) {
   WS.Set(k.upTo('Game') + '.Jam)' + WS.state[k.upTo('Game') + '.UpcomingJamNumber'] + ').InsertBefore', true);
 }

--- a/html/components/settings-tab/index.html
+++ b/html/components/settings-tab/index.html
@@ -11,6 +11,7 @@
         </select>
       </span>
       <button sbToggle="$.Penalties.UseLT">CRG Tracks Lineups</button>
+      <button sbToggle="$.Penalties.UsePBT">CRG Times Penalties</button>
     </div>
     <div class="sbGroup ScoreBoardOptions">
       <button class="ui-button-small" sbCall="stgOpenIntermissionDialog">Intermission Labels</button>

--- a/html/components/sk-input/index.html
+++ b/html/components/sk-input/index.html
@@ -82,7 +82,9 @@
     <button class="sbKeyControl" sbAttr="id:-:'Team[Team]RetainedOfficialReview'" sbToggle="RetainedOfficialReview">Retained</button>
     <div class="OfficialTimeout">
       <div>
-        <button id="OfficialTimeout" sbClass="sbActive: ^TimeoutOwner: ==='O'" sbSet="^OfficialTimeout">Official Timeout</button>
+        <button class="sbKeyControl" id="OfficialTimeout" sbClass="sbActive: ^TimeoutOwner: ==='O'" sbSet="^OfficialTimeout">
+          Official Timeout
+        </button>
       </div>
     </div>
   </div>

--- a/html/components/sk-sheet/index.css
+++ b/html/components/sk-sheet/index.css
@@ -38,6 +38,7 @@
 .SkSheet>.Period tr:not(.HasSP) .InitialSP { display: none; }
 
 /* Misc */
+.SkSheet>.Period tbody.emptyOnly:not(:only-of-type) { display: none; }
 .SkSheet>.Period .Overtime .JamNumber::after { font-size: 50%; content: "OT"; vertical-align: top; padding-left: 1px; } 
 .SkSheet>.Period tr:not(.IsOR) .OROnly { display:none; }
 

--- a/html/components/sk-sheet/index.html
+++ b/html/components/sk-sheet/index.html
@@ -35,6 +35,13 @@
           <th class="AutoFit Gametotal">TOTAL</th>
         </tr>
       </thead>
+      <tbody class="emptyOnly">
+        <tr class="Darker">
+          <td colspan="19" class="Buttons Darker">
+            <button sbSet="AddInitialJam" sbDisplay="Number: 'Add Jam to Period ' + v;"></button>
+          </td>
+        </tr>
+      </tbody>
       <tbody sbForeach="Jam:: sbCompareJam: onInsert=sbReverseOnNonSheet" sbContext=":TeamJam([Team])" class="Jam">
         <tr class="Edits" sbContext="^">
           <td class="EditButton Darker"></td>

--- a/html/json/WS.js
+++ b/html/json/WS.js
@@ -309,6 +309,10 @@ let WS = {
         } else if (options.html) {
           callback = function (k, v) {
             elem.html(v);
+            elem.find('button').button();
+            elem.children().each(function () {
+              WS.AutoRegister($(this));
+            });
           };
         } else {
           if (elem.hasClass('AutoFit')) {

--- a/html/nso/pbt/index.html
+++ b/html/nso/pbt/index.html
@@ -64,7 +64,7 @@
         </div>
         <div class="sbGroup">
           <span>Penalties:</span>
-          <span sbDisplay="CurrentPenalties"></span>
+          <span sbDisplay="PenaltyDetails: penDetailButtons: html"></span>
           <span><button sbCall="addPenalty">Add</button></span>
           |
           <span>Total: <span sbDisplay="PenaltyCount"></span></span>
@@ -79,8 +79,8 @@
           <button sbClass="sbHide: PenaltyBox: !" sbSet="PenaltyBox: false" sbCall="sbCloseDialog">Has Left</button>
         </div>
       </div>
-    </div>
 
-    <div id="UsePBTDialog">Use of Penalty Box Timing is disabled.</div>
+      <div id="UsePBTDialog">Use of Penalty Box Timing is disabled.</div>
+    </div>
   </body>
 </html>

--- a/html/nso/pbt/index.html
+++ b/html/nso/pbt/index.html
@@ -80,5 +80,7 @@
         </div>
       </div>
     </div>
+
+    <div id="UsePBTDialog">Use of Penalty Box Timing is disabled.</div>
   </body>
 </html>

--- a/html/nso/pbt/index.js
+++ b/html/nso/pbt/index.js
@@ -1,5 +1,24 @@
 'use strict';
 
+WS.AfterLoad(function () {
+  'use strict';
+  $('#UsePBTDialog').dialog({
+    modal: true,
+    closeOnEscape: false,
+    title: 'Use Penalty Box Timing',
+    buttons: {
+      Enable: function () {
+        WS.Set('ScoreBoard.Settings.Setting(ScoreBoard.Penalties.UsePBT)', true);
+      },
+    },
+    width: '300px',
+    autoOpen: false,
+  });
+  WS.Register(['ScoreBoard.Settings.Setting(ScoreBoard.Penalties.UsePBT)'], function (k, v) {
+    $('#UsePBTDialog').dialog(isTrue(v) ? 'close' : 'open');
+  });
+});
+
 WS.Register('ScoreBoard.CurrentGame.Team(*).Position(*).CurrentFielding');
 
 function toggleSwap() {

--- a/html/nso/plt/index.html
+++ b/html/nso/plt/index.html
@@ -38,6 +38,9 @@
       <div class="sbSegment">
         <div class="sbGroup sbHeader">Options</div>
         <div class="sbGroup"><button sbToggle="$">Enable Lineup Tracking</button></div>
+        <div class="sbGroup">
+          <button sbToggle="/ScoreBoard.Settings.Setting(ScoreBoard.Penalties.UsePBT)">Enable Penalty Box Timing</button>
+        </div>
         <div class="sbGroup"><button sbCall="setZoom">Allow Pinch Zoom</button></div>
       </div>
     </div>

--- a/html/nso/plt/index.js
+++ b/html/nso/plt/index.js
@@ -45,9 +45,15 @@ function toTitle() {
   return (
     pos +
     ' ' +
-    (team === 'both' ? 'both' : WS.state[prefix + 'AlternateName(plt)'] || WS.state[prefix + 'UniformColor'] || WS.state[prefix + 'Name']) +
-    ' CRG ScoreBoard'
+    (team === 'both'
+      ? 'both'
+      : WS.state[prefix + 'AlternateName(plt)'] || WS.state[prefix + 'UniformColor'] || WS.state[prefix + 'Name'] || '') +
+    ' | CRG ScoreBoard'
   );
+}
+
+function updateTitle() {
+  $('title').text(toTitle());
 }
 
 function openOptionsDialog() {
@@ -60,6 +66,7 @@ function setTeam(k, v, elem) {
   elem.addClass('sbActive');
   $('body').attr('showTeam', elem.attr('team'));
   _sbUpdateUrl('team', elem.attr('team'));
+  updateTitle();
 }
 
 function setPos(k, v, elem) {
@@ -68,6 +75,7 @@ function setPos(k, v, elem) {
   elem.addClass('sbActive');
   $('body').attr('sbSheetStyle', elem.attr('pos'));
   _sbUpdateUrl('pos', elem.attr('pos'));
+  updateTitle();
 }
 
 function setZoom(k, v, elem) {

--- a/html/nso/sk/index.js
+++ b/html/nso/sk/index.js
@@ -27,9 +27,13 @@ function toTitle() {
     'SK ' +
     (team === 'both'
       ? 'both'
-      : WS.state[prefix + 'AlternateName(operator)'] || WS.state[prefix + 'UniformColor'] || WS.state[prefix + 'Name']) +
-    ' CRG ScoreBoard'
+      : WS.state[prefix + 'AlternateName(operator)'] || WS.state[prefix + 'UniformColor'] || WS.state[prefix + 'Name'] || '') +
+    ' | CRG ScoreBoard'
   );
+}
+
+function updateTitle() {
+  $('title').text(toTitle());
 }
 
 function openOptionsDialog() {
@@ -41,6 +45,7 @@ function setTeam(k, v, elem) {
   elem.addClass('sbActive');
   $('body').attr('showTeam', elem.attr('team'));
   _sbUpdateUrl('team', elem.attr('team'));
+  updateTitle();
 }
 
 function setZoom(k, v, elem) {

--- a/html/styles/common.css
+++ b/html/styles/common.css
@@ -137,8 +137,8 @@ div.sbSheets { height: calc(100% - 10px); align-items: flex-start; flex-wrap: wr
 
 .sbKeyControl span.Indicator { font-size: 0.75em; } 
 .sbKeyControl:not(.HasControlKey) span.Indicator { display: none; } 
-.sbKeyControl.Editing { border: 1px solid #f00; } 
-.sbKeyControl.Editing:hover { background: #faa; } 
+.sbKeyControl.sbKeyControl.Editing { border: 1px solid #f00; pointer-events: auto; } 
+.sbKeyControl.sbKeyControl.Editing.hover { background: #faa; } 
 
 #sbIndexLink { float: right; border: none; }
 

--- a/html/views/standard/index.html
+++ b/html/views/standard/index.html
@@ -116,7 +116,7 @@
       <div class="ShowInLineup Clock Description Small Box AutoFit">Lineup</div>
       <div
         class="ShowInTimeout Clock Description Small Box AutoFit"
-        sbDisplay="TimeoutOwner, OfficialReview: sbToTimeoutType"
+        sbDisplay="TimeoutOwner, OfficialReview, Clock(Lineup).Running: sbToTimeoutType"
         sbClass="Red: Clock(Lineup).Running: !"
       ></div>
       <div

--- a/src/com/carolinarollergirls/scoreboard/core/admin/SettingsImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/admin/SettingsImpl.java
@@ -44,6 +44,7 @@ public class SettingsImpl extends ScoreBoardEventProviderImpl<Settings> implemen
         set("ScoreBoard.Operator_Default.ReplaceButton", "false");
         set("ScoreBoard.Operator_Default.ScoreAdjustments", "false");
         set(ScoreBoard.SETTING_USE_LT, "false");
+        set(ScoreBoard.SETTING_USE_PBT, "false");
         set(ScoreBoard.SETTING_STATSBOOK_INPUT, "");
         set(ScoreBoard.SETTING_AUTO_START, "");
         set(ScoreBoard.SETTING_AUTO_START_BUFFER, "0:02");

--- a/src/com/carolinarollergirls/scoreboard/core/current/CurrentGameImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/current/CurrentGameImpl.java
@@ -136,21 +136,21 @@ public class CurrentGameImpl extends MirrorScoreBoardEventProviderImpl<Game, Cur
 
     @Override
     protected void fillMaps() {
-        classMap.put(Game.class, CurrentGame.class);
-        classMap.put(Clock.class, CurrentClock.class);
-        classMap.put(Team.class, CurrentTeam.class);
-        classMap.put(Skater.class, CurrentSkater.class);
-        classMap.put(Penalty.class, CurrentPenalty.class);
-        classMap.put(Position.class, CurrentPosition.class);
-        classMap.put(BoxTrip.class, CurrentBoxTrip.class);
-        classMap.put(Period.class, CurrentPeriod.class);
-        classMap.put(Jam.class, CurrentJam.class);
-        classMap.put(TeamJam.class, CurrentTeamJam.class);
-        classMap.put(Fielding.class, CurrentFielding.class);
-        classMap.put(ScoringTrip.class, CurrentScoringTrip.class);
-        classMap.put(Timeout.class, CurrentTimeout.class);
-        classMap.put(Official.class, CurrentOfficial.class);
-        classMap.put(Expulsion.class, CurrentExpulsion.class);
+        addClassMapping(Game.class, CurrentGame.class);
+        addClassMapping(Clock.class, CurrentClock.class);
+        addClassMapping(Team.class, CurrentTeam.class);
+        addClassMapping(Skater.class, CurrentSkater.class);
+        addClassMapping(Penalty.class, CurrentPenalty.class);
+        addClassMapping(Position.class, CurrentPosition.class);
+        addClassMapping(BoxTrip.class, CurrentBoxTrip.class);
+        addClassMapping(Period.class, CurrentPeriod.class);
+        addClassMapping(Jam.class, CurrentJam.class);
+        addClassMapping(TeamJam.class, CurrentTeamJam.class);
+        addClassMapping(Fielding.class, CurrentFielding.class);
+        addClassMapping(ScoringTrip.class, CurrentScoringTrip.class);
+        addClassMapping(Timeout.class, CurrentTimeout.class);
+        addClassMapping(Official.class, CurrentOfficial.class);
+        addClassMapping(Expulsion.class, CurrentExpulsion.class);
 
         addPropertyMapping(Game.CLOCK, Game.TEAM, Game.PERIOD, Period.JAM, Team.BOX_TRIP, Game.REF, Game.NSO,
                            Game.EXPULSION);

--- a/src/com/carolinarollergirls/scoreboard/core/game/BoxTripImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/game/BoxTripImpl.java
@@ -70,6 +70,7 @@ public class BoxTripImpl extends ScoreBoardEventProviderImpl<BoxTrip> implements
         setInverseReference(PENALTY, Penalty.BOX_TRIP);
         setRecalculated(DURATION).addSource(this, JAM_CLOCK_START).addSource(this, JAM_CLOCK_END);
         setRecalculated(PENALTY_CODES).addSource(this, PENALTY);
+        setRecalculated(PENALTY_DETAILS).addSource(this, PENALTY_CODES);
         setCopy(START_JAM_NUMBER, this, START_FIELDING, Fielding.NUMBER, true);
         setCopy(END_JAM_NUMBER, this, END_FIELDING, Fielding.NUMBER, true);
         setCopy(ROSTER_NUMBER, this, CURRENT_FIELDING, Fielding.SKATER_NUMBER, true);
@@ -130,6 +131,14 @@ public class BoxTripImpl extends ScoreBoardEventProviderImpl<BoxTrip> implements
                         .filter(p -> !p.getProviderId().equals(Skater.FO_EXP_ID))
                         .map(Penalty::getCode)
                         .collect(Collectors.joining(" "));
+        }
+        if (prop == PENALTY_DETAILS) {
+            List<Penalty> penalties = new ArrayList<>(getAll(PENALTY));
+            Collections.sort(penalties);
+            value = penalties.stream()
+                        .filter(p -> !p.getProviderId().equals(Skater.FO_EXP_ID))
+                        .map(Penalty::getDetails)
+                        .collect(Collectors.joining(","));
         }
         return value;
     }
@@ -206,7 +215,7 @@ public class BoxTripImpl extends ScoreBoardEventProviderImpl<BoxTrip> implements
         if (prop == PENALTY) {
             Clock clock = getClock();
             if (clock != null && ((Penalty) item).getProviderId() != Skater.FO_EXP_ID) {
-                if (initialTimeAdjusted) {
+                if (initialTimeAdjusted && !source.isFile()) {
                     clock.changeMaximumTime(game.getLong(Rule.PENALTY_DURATION));
                 } else {
                     initialTimeAdjusted = true;

--- a/src/com/carolinarollergirls/scoreboard/core/game/BoxTripImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/game/BoxTripImpl.java
@@ -194,6 +194,11 @@ public class BoxTripImpl extends ScoreBoardEventProviderImpl<BoxTrip> implements
                 f.updateBoxTripSymbols();
                 Skater s = f.getSkater();
                 if (s != null) {
+                    if (getClock() != null && s.getUnservedPenalties().isEmpty()) {
+                        s.add(Skater.PENALTY,
+                              new PenaltyImpl(s, s.numberOf(Skater.PENALTY) == 0 ? 1
+                                                                                 : s.getMaxNumber(Skater.PENALTY) + 1));
+                    }
                     for (Penalty p : s.getUnservedPenalties()) { add(PENALTY, p); }
                 }
             }
@@ -206,7 +211,8 @@ public class BoxTripImpl extends ScoreBoardEventProviderImpl<BoxTrip> implements
                 } else {
                     initialTimeAdjusted = true;
                 }
-                if (getCurrentFielding().getCurrentRole() == Role.JAMMER && numberOf(PENALTY) > get(SHORTENED)) {
+                if (!source.isFile() && getCurrentFielding().getCurrentRole() == Role.JAMMER &&
+                    numberOf(PENALTY) > get(SHORTENED)) {
                     Position otherPos = getTeam().getOtherTeam().getPosition(
                         getTeam().getOtherTeam().isStarPass() ? FloorPosition.PIVOT : FloorPosition.JAMMER);
                     if (otherPos.isPenaltyBox()) {

--- a/src/com/carolinarollergirls/scoreboard/core/game/GameImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/game/GameImpl.java
@@ -402,7 +402,7 @@ public class GameImpl extends ScoreBoardEventProviderImpl<Game> implements Game 
             getRuleset().add(Ruleset.RULE, (ValWithId) item);
             return false;
         }
-        if (prop == Period.JAM && item != getUpcomingJam()) { return false; }
+        if (prop == Period.JAM && item != getUpcomingJam() && !source.isFile()) { return false; }
         return true;
     }
 

--- a/src/com/carolinarollergirls/scoreboard/core/game/JamImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/game/JamImpl.java
@@ -55,7 +55,7 @@ public class JamImpl extends NumberedScoreBoardEventProviderImpl<Jam> implements
             if (parent instanceof Period && this == ((Period) parent).getCurrentJam()) {
                 parent.set(Period.CURRENT_JAM, getPrevious());
             }
-            for (Penalty p : getAll(PENALTY)) { p.set(Penalty.JAM, getNext()); }
+            for (Penalty p : getAll(PENALTY)) { p.set(Penalty.JAM, hasNext() ? getNext() : getPrevious()); }
             for (Timeout t : getAll(TIMEOUTS_AFTER)) { t.set(Timeout.PRECEDING_JAM, getPrevious()); }
         }
         super.delete(source);

--- a/src/com/carolinarollergirls/scoreboard/core/game/PenaltyImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/game/PenaltyImpl.java
@@ -120,6 +120,11 @@ public class PenaltyImpl extends NumberedScoreBoardEventProviderImpl<Penalty> im
         return get(SERVED);
     }
 
+    @Override
+    public String getDetails() {
+        return skater.getId() + "_" + getProviderId();
+    }
+
     private Game game;
     private Skater skater;
 }

--- a/src/com/carolinarollergirls/scoreboard/core/game/PeriodImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/game/PeriodImpl.java
@@ -23,16 +23,15 @@ public class PeriodImpl extends NumberedScoreBoardEventProviderImpl<Period> impl
         super(g, p, Game.PERIOD);
         game = g;
         addProperties(props);
-        setCopy(CURRENT_JAM_NUMBER, this, CURRENT_JAM, Jam.NUMBER, true);
-        setRecalculated(FIRST_JAM).addSource(this, JAM);
-        setCopy(FIRST_JAM_NUMBER, this, FIRST_JAM, Jam.NUMBER, true);
         penaltyListener = setRecalculated(TEAM_1_PENALTY_COUNT).addSource(this, JAM);
         if (hasPrevious()) {
-            set(CURRENT_JAM, getPrevious().get(CURRENT_JAM));
+            set(CURRENT_JAM, getPrevious().get(CURRENT_JAM), Flag.SPECIAL_CASE);
             set(SUDDEN_SCORING, getPrevious().isSuddenScoring());
         } else {
-            set(CURRENT_JAM, getOrCreate(JAM, "0"));
+            set(CURRENT_JAM, getOrCreate(JAM, "0"), Flag.SPECIAL_CASE);
         }
+        setRecalculated(CURRENT_JAM).addIndirectSource(this, PREVIOUS, CURRENT_JAM);
+        setRecalculated(CURRENT_JAM_NUMBER).addIndirectSource(this, CURRENT_JAM, NUMBER);
         setRecalculated(DURATION).addSource(this, WALLTIME_END).addSource(this, WALLTIME_START);
         addWriteProtectionOverride(RUNNING, Source.NON_WS);
         addWriteProtectionOverride(JAM, Source.NON_WS);
@@ -47,7 +46,21 @@ public class PeriodImpl extends NumberedScoreBoardEventProviderImpl<Period> impl
 
     @Override
     protected Object computeValue(Value<?> prop, Object value, Object last, Source source, Flag flag) {
-        if (prop == FIRST_JAM) { return getFirst(JAM); }
+        if (prop == CURRENT_JAM && source == Source.RECALCULATE) {
+            if (numberOf(JAM) > 0) {
+                return getLast(JAM);
+            } else if (hasPrevious()) {
+                return getPrevious().getCurrentJam();
+            }
+        }
+        if (prop == CURRENT_JAM_NUMBER) {
+            if (getCurrentJam() != null && getCurrentJam().getParent() == this ||
+                !game.getBoolean(Rule.JAM_NUMBER_PER_PERIOD)) {
+                return getCurrentJam().getNumber();
+            } else {
+                return 0;
+            }
+        }
         if (prop == DURATION) {
             if (getWalltimeEnd() == 0L) {
                 return 0L;
@@ -73,14 +86,14 @@ public class PeriodImpl extends NumberedScoreBoardEventProviderImpl<Period> impl
             return t1Count;
         }
         if (prop == TEAM_1_POINTS) {
-            return getAll(JAM).size() > 0 ? getCurrentJam().getTeamJam(Team.ID_1).get(TeamJam.TOTAL_SCORE) -
-                                                getFirst(JAM).getTeamJam(Team.ID_1).get(TeamJam.LAST_SCORE)
-                                          : 0;
+            return getAll(JAM).isEmpty() ? 0
+                                         : getCurrentJam().getTeamJam(Team.ID_1).get(TeamJam.TOTAL_SCORE) -
+                                               getFirst(JAM).getTeamJam(Team.ID_1).get(TeamJam.LAST_SCORE);
         }
         if (prop == TEAM_2_POINTS) {
-            return getAll(JAM).size() > 0 ? getCurrentJam().getTeamJam(Team.ID_2).get(TeamJam.TOTAL_SCORE) -
-                                                getFirst(JAM).getTeamJam(Team.ID_2).get(TeamJam.LAST_SCORE)
-                                          : 0;
+            return getAll(JAM).isEmpty() ? 0
+                                         : getCurrentJam().getTeamJam(Team.ID_2).get(TeamJam.TOTAL_SCORE) -
+                                               getFirst(JAM).getTeamJam(Team.ID_2).get(TeamJam.LAST_SCORE);
         }
         return value;
     }
@@ -96,23 +109,32 @@ public class PeriodImpl extends NumberedScoreBoardEventProviderImpl<Period> impl
                     set(WALLTIME_START, ScoreBoardClock.getInstance().getCurrentWalltime());
                 }
             }
-        } else if (prop == CURRENT_JAM && value != null) {
-            Jam j = (Jam) value;
-            if (hasNext() && getNext().get(CURRENT_JAM) == last) { getNext().set(CURRENT_JAM, j); }
-            if (j.getParent() != this && (!hasPrevious() || getPrevious().getCurrentJam() != j)) {
-                j.getParent().remove(JAM, j);
-                j.setParent(this);
-                add(JAM, j);
-            }
-            if (this == game.getCurrentPeriod()) { game.set(Game.UPCOMING_JAM, j.getNext()); }
-        } else if (prop == PREVIOUS && value != null && numberOf(JAM) > 0) {
-            getFirst(JAM).setPrevious(getPrevious().getCurrentJam());
+        } else if (prop == CURRENT_JAM && this == game.getCurrentPeriod()) {
+            game.updateTeamJams();
         }
     }
 
     @Override
     protected void itemAdded(Child<?> prop, ValueWithId item, Source source) {
-        if (prop == JAM) { penaltyListener.addSource((ScoreBoardEventProvider) item, Jam.PENALTY); }
+        if (prop == JAM && source != Source.RENUMBER) {
+            Jam j = (Jam) item;
+            penaltyListener.addSource(j, Jam.PENALTY);
+            if (j == getFirst(JAM)) { j.setPrevious(hasPrevious() ? getPrevious().getCurrentJam() : null); }
+            if (j == getLast(JAM)) {
+                Jam next = hasNext() ? getNext().getInitialJam() : game.getUpcomingJam();
+                if (next == null || next == j) { next = new JamImpl(game, j); }
+                j.setNext(next);
+                set(CURRENT_JAM, j);
+            }
+        }
+    }
+
+    @Override
+    protected void itemRemoved(Child<?> prop, ValueWithId item, Source source) {
+        if (prop == JAM && source != Source.RENUMBER) {
+            Jam j = (Jam) item;
+            if (j == getLast(JAM)) { set(CURRENT_JAM, j.getPrevious()); }
+        }
     }
 
     @Override
@@ -131,7 +153,7 @@ public class PeriodImpl extends NumberedScoreBoardEventProviderImpl<Period> impl
     public void execute(Command prop, Source source) {
         synchronized (coreLock) {
             if (prop == DELETE) {
-                if (!isRunning()) { delete(source); }
+                if (!isRunning() && get(TEAM_1_POINTS) == 0 && get(TEAM_2_POINTS) == 0) { delete(source); }
             } else if (prop == INSERT_BEFORE) {
                 if (game.getCurrentPeriodNumber() < game.getInt(Rule.NUMBER_PERIODS))
                     game.add(ownType, new PeriodImpl(game, getNumber()));
@@ -140,6 +162,14 @@ public class PeriodImpl extends NumberedScoreBoardEventProviderImpl<Period> impl
                 t.stop();
                 t.getParent().add(TIMEOUT, t); // if this period hasn't started, the timeout is added to the
                                                // previous period
+            } else if (prop == ADD_INITIAL_JAM) {
+                if (!getAll(JAM).isEmpty()) { return; }
+                Jam j = new JamImpl(
+                    this, game.getBoolean(Rule.JAM_NUMBER_PER_PERIOD) ? 1 : (getCurrentJam().getNumber() + 1));
+                if (!game.getBoolean(Rule.JAM_NUMBER_PER_PERIOD) && j.hasNext()) {
+                    j.getNext().set(NUMBER, 1, Source.RENUMBER, Flag.CHANGE);
+                }
+                add(JAM, j);
             }
         }
     }
@@ -151,20 +181,18 @@ public class PeriodImpl extends NumberedScoreBoardEventProviderImpl<Period> impl
             if (numberOf(JAM) > 0) {
                 Jam prevJam = getFirst(JAM).getPrevious();
                 Jam nextJam = getLast(JAM).getNext();
-                if (prevJam != null) {
-                    prevJam.setNext(nextJam);
-                } else if (nextJam != null) {
-                    nextJam.setPrevious(null);
-                }
+                nextJam.setPrevious(prevJam);
+                nextJam.set(NUMBER, game.getBoolean(Rule.JAM_NUMBER_PER_PERIOD) ? 1 : prevJam.getNumber() + 1,
+                            Source.RENUMBER);
                 for (Jam j : getAll(JAM)) {
-                    for (Penalty p : j.getAll(Jam.PENALTY)) { p.set(Penalty.JAM, nextJam != null ? nextJam : prevJam); }
+                    for (Penalty p : j.getAll(Jam.PENALTY)) { p.set(Penalty.JAM, nextJam); }
                 }
             }
-            if (this == game.getCurrentPeriod()) {
-                Period prev = getPrevious();
-                prev.setNext(getNext());
-                game.set(Game.CURRENT_PERIOD, prev);
-            }
+            Period prev = getPrevious();
+            Period next = getNext();
+            prev.setNext(next);
+            game.remove(Game.PERIOD, this);
+            if (next != null) { next.set(NUMBER, -1, Source.RENUMBER, Flag.CHANGE); }
         }
         super.delete(source);
     }
@@ -201,6 +229,16 @@ public class PeriodImpl extends NumberedScoreBoardEventProviderImpl<Period> impl
         return get(JAM, j);
     }
     @Override
+    public Jam getInitialJam() {
+        if (numberOf(JAM) > 0) {
+            return getFirst(JAM);
+        } else if (hasNext()) {
+            return getNext().getInitialJam();
+        } else {
+            return ((Game) parent).getUpcomingJam();
+        }
+    }
+    @Override
     public Jam getCurrentJam() {
         return get(CURRENT_JAM);
     }
@@ -213,7 +251,7 @@ public class PeriodImpl extends NumberedScoreBoardEventProviderImpl<Period> impl
     public void startJam() {
         synchronized (coreLock) {
             set(RUNNING, true);
-            set(CURRENT_JAM, game.getUpcomingJam());
+            game.getUpcomingJam().setParent(this);
             getCurrentJam().start();
         }
     }

--- a/src/com/carolinarollergirls/scoreboard/core/game/PositionImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/game/PositionImpl.java
@@ -26,6 +26,7 @@ public class PositionImpl extends ScoreBoardEventProviderImpl<Position> implemen
         setCopy(HAS_UNSERVED, this, SKATER, Skater.HAS_UNSERVED, true);
         setCopy(PENALTY_COUNT, this, SKATER, Skater.PENALTY_COUNT, true);
         setCopy(ANNOTATION, this, CURRENT_FIELDING, Fielding.ANNOTATION, false);
+        setCopy(PENALTY_DETAILS, this, SKATER, Skater.PENALTY_DETAILS, true);
         addWriteProtectionOverride(CURRENT_FIELDING, Source.NON_WS);
     }
 

--- a/src/com/carolinarollergirls/scoreboard/core/game/SkaterImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/game/SkaterImpl.java
@@ -16,6 +16,7 @@ import com.carolinarollergirls.scoreboard.core.interfaces.Penalty;
 import com.carolinarollergirls.scoreboard.core.interfaces.Position;
 import com.carolinarollergirls.scoreboard.core.interfaces.PreparedTeam.PreparedSkater;
 import com.carolinarollergirls.scoreboard.core.interfaces.Role;
+import com.carolinarollergirls.scoreboard.core.interfaces.ScoreBoard;
 import com.carolinarollergirls.scoreboard.core.interfaces.Skater;
 import com.carolinarollergirls.scoreboard.core.interfaces.Team;
 import com.carolinarollergirls.scoreboard.core.interfaces.TeamJam;
@@ -93,6 +94,10 @@ public class SkaterImpl extends ScoreBoardEventProviderImpl<Skater> implements S
                 if (!FO_EXP_ID.equals(p.getProviderId()) && !p.get(Penalty.SERVED)) { return true; }
             }
             return false;
+        }
+        if (prop == PENALTY_BOX && source == Source.WS &&
+            Boolean.parseBoolean(scoreBoard.getSettings().get(ScoreBoard.SETTING_USE_PBT))) {
+            return last;
         }
         return value;
     }

--- a/src/com/carolinarollergirls/scoreboard/core/game/SkaterImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/game/SkaterImpl.java
@@ -98,7 +98,7 @@ public class SkaterImpl extends ScoreBoardEventProviderImpl<Skater> implements S
     }
     @Override
     protected void valueChanged(Value<?> prop, Object value, Object last, Source source, Flag flag) {
-        if (prop == CURRENT_FIELDING) {
+        if (prop == CURRENT_FIELDING && !source.isFile()) {
             Fielding f = (Fielding) value;
             Fielding lf = (Fielding) last;
             setRole(value == null ? getBaseRole() : f.getCurrentRole());

--- a/src/com/carolinarollergirls/scoreboard/core/game/SkaterImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/game/SkaterImpl.java
@@ -59,6 +59,7 @@ public class SkaterImpl extends ScoreBoardEventProviderImpl<Skater> implements S
         setRecalculated(CURRENT_PENALTIES).addSource(this, PENALTY).addSource(this, PENALTY_BOX);
         setRecalculated(PENALTY_COUNT).addSource(this, PENALTY);
         setRecalculated(HAS_UNSERVED).addSource(this, PENALTY);
+        setRecalculated(PENALTY_DETAILS).addSource(this, CURRENT_PENALTIES);
     }
 
     @Override
@@ -81,6 +82,12 @@ public class SkaterImpl extends ScoreBoardEventProviderImpl<Skater> implements S
             List<Penalty> penalties = getUnservedPenalties();
             Collections.sort(penalties);
             value = penalties.stream().map(Penalty::getCode).collect(Collectors.joining(" "));
+        }
+        if (prop == PENALTY_DETAILS) {
+            if (isPenaltyBox()) { return getCurrentFielding().getCurrentBoxTrip().get(BoxTrip.PENALTY_DETAILS); }
+            List<Penalty> penalties = getUnservedPenalties();
+            Collections.sort(penalties);
+            value = penalties.stream().map(Penalty::getDetails).collect(Collectors.joining(","));
         }
         if (prop == PENALTY_COUNT) {
             int count = 0;

--- a/src/com/carolinarollergirls/scoreboard/core/game/TeamJamImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/game/TeamJamImpl.java
@@ -23,7 +23,7 @@ public class TeamJamImpl extends ParentOrderedScoreBoardEventProviderImpl<TeamJa
     public TeamJamImpl(Jam j, String teamId) {
         super(j, teamId, Jam.TEAM_JAM);
         addProperties(props);
-        game = j.getPeriod().getGame();
+        game = j.getGame();
         team = game.getTeam(teamId);
         setRecalculated(CURRENT_TRIP).addSource(this, SCORING_TRIP);
         setCopy(CURRENT_TRIP_NUMBER, this, CURRENT_TRIP, ScoringTrip.NUMBER, true);
@@ -97,7 +97,7 @@ public class TeamJamImpl extends ParentOrderedScoreBoardEventProviderImpl<TeamJa
 
     @Override
     protected void itemAdded(Child<?> prop, ValueWithId item, Source source) {
-        if (prop == SCORING_TRIP) {
+        if (prop == SCORING_TRIP && source != Source.RENUMBER) {
             jamScoreListener.addSource((ScoreBoardEventProvider) item, ScoringTrip.SCORE);
             afterSPScoreListener.addSource((ScoreBoardEventProvider) item, ScoringTrip.SCORE);
             afterSPScoreListener.addSource((ScoreBoardEventProvider) item, ScoringTrip.AFTER_S_P);

--- a/src/com/carolinarollergirls/scoreboard/core/interfaces/BoxTrip.java
+++ b/src/com/carolinarollergirls/scoreboard/core/interfaces/BoxTrip.java
@@ -58,6 +58,7 @@ public interface BoxTrip extends ScoreBoardEventProvider {
     public static final Value<Boolean> TIMING_STOPPED = new Value<>(Boolean.class, "TimingStopped", false, props);
     public static final Value<Long> TIME = new Value<>(Long.class, "Time", null, props);
     public static final Value<Integer> SHORTENED = new Value<>(Integer.class, "Shortened", 0, props);
+    public static final Value<String> PENALTY_DETAILS = new Value<>(String.class, "PenaltyDetails", "", props);
 
     public static final Child<Fielding> FIELDING = new Child<>(Fielding.class, "Fielding", props);
     public static final Child<Penalty> PENALTY = new Child<>(Penalty.class, "Penalty", props);

--- a/src/com/carolinarollergirls/scoreboard/core/interfaces/Jam.java
+++ b/src/com/carolinarollergirls/scoreboard/core/interfaces/Jam.java
@@ -12,6 +12,7 @@ import com.carolinarollergirls.scoreboard.event.Value;
 
 public interface Jam extends NumberedScoreBoardEventProvider<Jam> {
     public Period getPeriod();
+    public Game getGame();
 
     public void setParent(ScoreBoardEventProvider p);
 

--- a/src/com/carolinarollergirls/scoreboard/core/interfaces/Penalty.java
+++ b/src/com/carolinarollergirls/scoreboard/core/interfaces/Penalty.java
@@ -18,6 +18,8 @@ public interface Penalty extends NumberedScoreBoardEventProvider<Penalty> {
 
     public boolean isServed();
 
+    public String getDetails();
+
     public static Collection<Property<?>> props = new ArrayList<>();
 
     public static final Value<Long> TIME = new Value<>(Long.class, "Time", 0L, props);

--- a/src/com/carolinarollergirls/scoreboard/core/interfaces/Period.java
+++ b/src/com/carolinarollergirls/scoreboard/core/interfaces/Period.java
@@ -21,6 +21,7 @@ public interface Period extends NumberedScoreBoardEventProvider<Period> {
     public boolean isRunning();
 
     public Jam getJam(int j);
+    public Jam getInitialJam();
     public Jam getCurrentJam();
     public int getCurrentJamNumber();
 
@@ -35,8 +36,6 @@ public interface Period extends NumberedScoreBoardEventProvider<Period> {
 
     public static final Value<Jam> CURRENT_JAM = new Value<>(Jam.class, "CurrentJam", null, props);
     public static final Value<Integer> CURRENT_JAM_NUMBER = new Value<>(Integer.class, "CurrentJamNumber", 0, props);
-    public static final Value<Jam> FIRST_JAM = new Value<>(Jam.class, "FirstJam", null, props);
-    public static final Value<Integer> FIRST_JAM_NUMBER = new Value<>(Integer.class, "FirstJamNumber", 0, props);
     public static final Value<Boolean> SUDDEN_SCORING = new Value<>(Boolean.class, "SuddenScoring", false, props);
     public static final Value<Boolean> RUNNING = new Value<>(Boolean.class, "Running", false, props);
     public static final Value<Long> DURATION = new Value<>(Long.class, "Duration", 0L, props);
@@ -55,6 +54,7 @@ public interface Period extends NumberedScoreBoardEventProvider<Period> {
     public static final Command DELETE = new Command("Delete", props);
     public static final Command INSERT_BEFORE = new Command("InsertBefore", props);
     public static final Command INSERT_TIMEOUT = new Command("InsertTimeout", props);
+    public static final Command ADD_INITIAL_JAM = new Command("AddInitialJam", props);
 
     public static interface PeriodSnapshot {
         public String getId();

--- a/src/com/carolinarollergirls/scoreboard/core/interfaces/Position.java
+++ b/src/com/carolinarollergirls/scoreboard/core/interfaces/Position.java
@@ -34,6 +34,7 @@ public interface Position extends ScoreBoardEventProvider {
     public static final Value<Boolean> HAS_UNSERVED = new Value<>(Boolean.class, "HasUnserved", false, props);
     public static final Value<Long> PENALTY_TIME = new Value<>(Long.class, "PenaltyTime", null, props);
     public static final Value<Integer> PENALTY_COUNT = new Value<>(Integer.class, "PenaltyCount", 0, props);
+    public static final Value<String> PENALTY_DETAILS = new Value<>(String.class, "PenaltyDetails", "", props);
 
     public static final Command CLEAR = new Command("Clear", props);
     public static final Command UNEND_BOX_TRIP = new Command("UnendBoxTrip", props);

--- a/src/com/carolinarollergirls/scoreboard/core/interfaces/ScoreBoard.java
+++ b/src/com/carolinarollergirls/scoreboard/core/interfaces/ScoreBoard.java
@@ -56,5 +56,6 @@ public interface ScoreBoard extends ScoreBoardEventProvider {
     public static final String SETTING_AUTO_END_JAM = "ScoreBoard.AutoEndJam";
     public static final String SETTING_AUTO_END_TTO = "ScoreBoard.AutoEndTTO";
     public static final String SETTING_USE_LT = "ScoreBoard.Penalties.UseLT";
+    public static final String SETTING_USE_PBT = "ScoreBoard.Penalties.UsePBT";
     public static final String SETTING_STATSBOOK_INPUT = "ScoreBoard.Stats.InputFile";
 }

--- a/src/com/carolinarollergirls/scoreboard/core/interfaces/Skater.java
+++ b/src/com/carolinarollergirls/scoreboard/core/interfaces/Skater.java
@@ -60,6 +60,7 @@ public interface Skater extends ScoreBoardEventProvider {
     public static final Value<String> FLAGS = new Value<>(String.class, "Flags", "", preparedProps);
     public static final Value<String> PRONOUNS = new Value<>(String.class, "Pronouns", "", preparedProps);
     public static final Value<String> COLOR = new Value<>(String.class, "Color", "", props);
+    public static final Value<String> PENALTY_DETAILS = new Value<>(String.class, "PenaltyDetails", "", props);
 
     public static final Child<Fielding> FIELDING = new Child<>(Fielding.class, "Fielding", props);
 

--- a/src/com/carolinarollergirls/scoreboard/event/MirrorScoreBoardEventProviderImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/event/MirrorScoreBoardEventProviderImpl.java
@@ -189,9 +189,10 @@ public class MirrorScoreBoardEventProviderImpl<M extends ScoreBoardEventProvider
     public static void addClassMapping(Class<? extends ScoreBoardEventProvider> source,
                                        Class<? extends MirrorScoreBoardEventProvider<?>> mirror) {
         classMap.put(source, mirror);
+        if (elements.get(mirror) == null) { elements.put(mirror, new HashMap<>()); }
     }
 
-    protected static Map<Class<? extends ScoreBoardEventProvider>, Class<? extends MirrorScoreBoardEventProvider<?>>>
+    private static Map<Class<? extends ScoreBoardEventProvider>, Class<? extends MirrorScoreBoardEventProvider<?>>>
         classMap = new HashMap<>();
     protected static MirrorFactory mirrorFactory;
 }

--- a/src/com/carolinarollergirls/scoreboard/event/ScoreBoardEventProviderImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/event/ScoreBoardEventProviderImpl.java
@@ -724,7 +724,9 @@ public abstract class ScoreBoardEventProviderImpl<C extends ScoreBoardEventProvi
     public void cleanupAliases() {
         synchronized (coreLock) {
             for (Map<String, ScoreBoardEventProvider> list : elements.values()) {
-                list.entrySet().removeIf(o -> (o.getValue() == null || !o.getKey().equals(o.getValue().getId())));
+                list.entrySet().removeIf(o
+                                         -> (o.getValue() == null || (!o.getKey().equals(o.getValue().getId()) &&
+                                                                      !"".equals(o.getValue().getId()))));
             }
         }
     }

--- a/src/com/carolinarollergirls/scoreboard/json/ScoreBoardJSONSetter.java
+++ b/src/com/carolinarollergirls/scoreboard/json/ScoreBoardJSONSetter.java
@@ -150,6 +150,7 @@ public class ScoreBoardJSONSetter {
             key.equals("ScoreBoard.Settings.Setting(Overlay.Interactive.ShowPenaltyClocks)") ||
             key.equals("ScoreBoard.Settings.Setting(ScoreBoard.Preview_HidePenaltyClocks)") ||
             key.equals("ScoreBoard.Settings.Setting(ScoreBoard.View_HidePenaltyClocks)") ||
+            key.equals("ScoreBoard.Settings.Setting(ScoreBoard.UsePBT)") ||
             key.contains("Jam.SuddenScoringMaxTrailingPoints") ||
             (key.contains("BoxTrip(") && key.endsWith("CurrentSkater")) ||
             (key.contains("BoxTrip(") && key.endsWith("RosterNumber")) ||

--- a/src/com/carolinarollergirls/scoreboard/json/ScoreBoardJSONSetter.java
+++ b/src/com/carolinarollergirls/scoreboard/json/ScoreBoardJSONSetter.java
@@ -105,7 +105,8 @@ public class ScoreBoardJSONSetter {
 
                 if (newKey.startsWith("ScoreBoard.Clients.Client") ||
                     (newKey.startsWith("ScoreBoard.Settings.Setting(ScoreBoard.Operator") &&
-                     newKey.endsWith("StartStopButtons)"))) {
+                     newKey.endsWith("StartStopButtons)")) ||
+                    newKey.endsWith("FirstJam") || newKey.endsWith("FirstJamNumber")) {
                     newKey = "";
                 }
                 if (newKey.contains("Jam.SuddenScoringMaxTrainingPoints")) {
@@ -211,7 +212,8 @@ public class ScoreBoardJSONSetter {
         if (priorLimit.equals("v5") || key.startsWith("ScoreBoard.Twitter")) { return "v5"; }
         if (priorLimit.equals("v2023") || key.equals("ScoreBoard.Settings.Setting(Overlay.Interactive.ShowAllNames)") ||
             (key.startsWith("ScoreBoard.Settings.Setting(ScoreBoard.Operator") && key.endsWith("StartStopButtons")) ||
-            key.contains("Jam.SuddenScoringMaxTrainingPoints") || key.startsWith("ScoreBoard.Clients.Client(")) {
+            key.contains("Jam.SuddenScoringMaxTrainingPoints") || key.startsWith("ScoreBoard.Clients.Client(") ||
+            key.endsWith("FirstJam") || key.endsWith("FirstJamNumber")) {
             return "v2023";
         }
 

--- a/src/com/carolinarollergirls/scoreboard/json/ScoreBoardJSONSetter.java
+++ b/src/com/carolinarollergirls/scoreboard/json/ScoreBoardJSONSetter.java
@@ -151,7 +151,7 @@ public class ScoreBoardJSONSetter {
             key.equals("ScoreBoard.Settings.Setting(ScoreBoard.Preview_HidePenaltyClocks)") ||
             key.equals("ScoreBoard.Settings.Setting(ScoreBoard.View_HidePenaltyClocks)") ||
             key.equals("ScoreBoard.Settings.Setting(ScoreBoard.UsePBT)") ||
-            key.contains("Jam.SuddenScoringMaxTrailingPoints") ||
+            key.contains("Jam.SuddenScoringMaxTrailingPoints") || key.endsWith("PenaltyDetails") ||
             (key.contains("BoxTrip(") && key.endsWith("CurrentSkater")) ||
             (key.contains("BoxTrip(") && key.endsWith("RosterNumber")) ||
             (key.contains("BoxTrip(") && key.endsWith("PenaltyCodes")) ||

--- a/tests/com/carolinarollergirls/scoreboard/core/game/BoxTripImplTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/core/game/BoxTripImplTests.java
@@ -346,12 +346,12 @@ public class BoxTripImplTests {
         newBt.set(BoxTrip.CURRENT_FIELDING, s.getCurrentFielding(), Source.WS);
         assertNotNull(newBt.getCurrentFielding());
         assertEquals(s.getCurrentFielding(), newBt.getCurrentFielding());
-        assertEquals(0, s.numberOf(Skater.PENALTY));
+        assertEquals(1, s.numberOf(Skater.PENALTY));
         assertEquals(0, g.numberOf(Team.BOX_TRIP));
         assertEquals(30000L, newBt.getClock().getMaximumTime());
         assertEquals(30000L, newBt.getClock().getTimeRemaining());
 
-        s.add(Skater.PENALTY, new PenaltyImpl(s, 1));
+        s.getOrCreate(Skater.PENALTY, 1);
         assertEquals(1, s.numberOf(Skater.PENALTY));
         assertEquals(30000L, newBt.getClock().getMaximumTime());
         assertEquals(30000L, newBt.getClock().getTimeRemaining());

--- a/tests/com/carolinarollergirls/scoreboard/core/game/GameImplTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/core/game/GameImplTests.java
@@ -3,6 +3,7 @@ package com.carolinarollergirls.scoreboard.core.game;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -103,6 +104,16 @@ public class GameImplTests {
 
     @After
     public void tearDown() throws Exception {
+        // check invariants around current period and upcoming jam
+        assertNotNull(g.getCurrentPeriod());
+        assertNull(g.getCurrentPeriod().getNext());
+        assertNotNull(g.getUpcomingJam());
+        assertNull(g.getUpcomingJam().getNext());
+        assertEquals(g.getUpcomingJam(), g.getCurrentPeriod().getCurrentJam().getNext());
+        assertEquals(g, g.getUpcomingJam().getParent());
+        assertEquals(1, g.numberOf(Period.JAM));
+        assertEquals(g.getUpcomingJam(), g.getFirst(Period.JAM));
+
         ScoreBoardClock.getInstance().start(false);
         GameImpl.setQuickClockThreshold(1000L);
         // Check all started batches were ended.


### PR DESCRIPTION
- Don't break CurrentGame on JSON upload (fixes a crash observed at Europe Regionals)
- Allow setting key controls on currently disabled buttons
- fix label on main display for fresh timeout
- Allow setting a hotkey on  OTO button
- Better enforce invariants around periods & jams (closes #704, closes #705, closes #709)
- Add penalty when box clock is assigned to skater without one (closes #712)
- Properly update titles on SK and P/LT screens (closes #711)
- Inhibit LT box buttons when PBT is used
- Improve penalty editing on PBT screen
- Allow adding jams to empty period
- Inhibit deleting period with points