### PR TITLE
improve PBT UI & handling for lineup changes

### DIFF
--- a/html/components/penalty-list/index.html
+++ b/html/components/penalty-list/index.html
@@ -15,12 +15,15 @@
       <span class="sbVeryVeryImportant" sbDisplay="Clock.Time: sbToSeconds"></span>
       <span class="sbImportant">
         <span class="sbShowOnBoxView"><span sbDisplay="PenaltyCodes"></span> | </span>
-        <span>Total: <span sbDisplay="TotalPenalties"></span></span>
+        <span sbClass="sbHide: CurrentSkater: sbIsEmpty">Total: <span sbDisplay="TotalPenalties"></span></span>
       </span>
     </div>
     <div class="sbShowOnPbt Edit">
       <span>
-        <button sbClass="sbClickMe: CurrentSkater, TotalPenalties: penFoOrExp" sbCall="penSubstitute">Substitute</button>
+        <button sbClass="sbClickMe: CurrentSkater, TotalPenalties: penFoOrExp" sbCall="penSubstitute">
+          <span sbClass="sbHide: CurrentSkater: sbIsEmpty">Substitute</span>
+          <span sbClass="sbHide: CurrentSkater: sbIsNotEmpty">Select Skater</span>
+        </button>
         <button sbCall="penReassign">Change</button>
       </span>
       <span>
@@ -33,7 +36,7 @@
       </span>
       <span>
         <span sbDisplay="PenaltyDetails: penDetailButtons: html"></span>
-        <button sbCall="penAdd">Add</button>
+        <button sbClass="sbHide: CurrentSkater: sbIsEmpty" sbCall="penAdd">Add</button>
       </span>
     </div>
   </div>
@@ -59,7 +62,7 @@
   <div id="ReassignmentSelector" class="sbSegment" sbContext="Team(*).BoxTrip(*)">
     <div class="sbGroup sbStack" sbPrefix="b:[*]">
       <span sbContext="^^" sbForeach="Team: 1,2: only">
-        <span sbDisplay="AlternateName(box), UniformColor, Name"></span>
+        <span sbDisplay="AlternateName(box), UniformColor, Name"></span><span>: &nbsp;</span>
         <button
           sbForeach="Position: Jammer, Pivot, Blocker1, Blocker2, Blocker3: only"
           sbClass="sbUnserved: HasUnserved"
@@ -83,6 +86,6 @@
         sbCall="sbCloseDialog"
       ></div>
     </div>
-    <div class="sbGroup"><button sbSet="Remove">Delete</button></div>
+    <div class="sbGroup"><button sbSet="Remove" sbCall="sbCloseDialog">Delete</button></div>
   </div>
 </div>

--- a/html/components/penalty-list/index.js
+++ b/html/components/penalty-list/index.js
@@ -12,7 +12,7 @@ WS.Register([
 function penFoOrExp(k, v) {
   const limit = WS.state[k.upTo('Game') + '.Rule(Penalties.NumberToFoulout)'];
   const skaterPrefix = k.upTo('Team') + '.Skater(' + v + ')';
-  return WS.state[skaterPrefix + '.Penalty(0).Code'] || WS.state[skaterPrefix + '.PenaltyCount'] >= limit;
+  return !v || !!WS.state[skaterPrefix + '.Penalty(0).Code'] || WS.state[skaterPrefix + '.PenaltyCount'] >= limit;
 }
 
 function penToInstruction(k, v) {

--- a/html/nso/pbt/index.css
+++ b/html/nso/pbt/index.css
@@ -1,4 +1,4 @@
-body { display: flex; flex-direction: column; height: 100dvh; }
+body { display: flex; flex-direction: column; height: calc(100dvh - 16px); }
 #List { flex: 1; }
 
 #Unassigned { 
@@ -27,5 +27,6 @@ body { display: flex; flex-direction: column; height: 100dvh; }
 #Buttons>div { height: 100%; }
 #Buttons>div>button {  flex: 1; height: 100%; font-size: 5dvh; padding: 1rem; }
 
-#LineupEditor>.sbGroup { display: block; }
+#PositionDetails .edit>.onNoEdit, #PositionDetails .forceEdit>.onNoEdit, #PositionDetails :not(.edit):not(.forceEdit)>.onEdit { display: none; }
+
 button.StartButton { width: 95%; height: 25dvh; font-size: 5dvh; }

--- a/html/nso/pbt/index.html
+++ b/html/nso/pbt/index.html
@@ -34,6 +34,7 @@
           <button
             sbForeach="Position: Jammer, Pivot, Blocker1, Blocker2, Blocker3: only"
             sbClass="sbUnserved: HasUnserved | sbInBox: PenaltyBox"
+            sbAttr="disabled: PenaltyBox"
             sbDisplay="RosterNumber: questionMarkIfEmpty"
             sbSet="b.CurrentFielding: getFielding"
           ></button>
@@ -49,20 +50,22 @@
 
     <div class="sbTemplates">
       <div id="PositionDetails" class="sbSegment" sbContext="Team(*).Position(*)">
-        <div class="sbGroup">
-          <span>Skater: </span>
-          <span sbButtonGroup sbPrefix="p:[*]">
-            <button sbClass="sbActive: p.Skater: sbIsEmpty" sbSet="p.Skater: ''" sbCall="sbCloseDialog">?</button>
+        <div class="sbGroup" sbClass="edit: Skater: sbIsEmpty">
+          <span class="onNoEdit"><button sbCall="elem.closest('div').addClass('forceEdit')">Edit Lineup</button></span>
+          <span class="onEdit">Skater: </span>
+          <span class="onEdit" sbButtonGroup sbPrefix="p:[*]">
+            <button sbClass="sbActive: p.Skater: sbIsEmpty" sbSet="p.Skater: ''">?</button>
             <button
               sbForeach="^Skater:: rosterNumber: resort=RosterNumber"
               sbAttr="rosterNumber: RosterNumber"
               sbDisplay="RosterNumber"
               sbClass="sbActive: p.Skater: === elem.attr('Skater') | sbHide: Role: === 'NotInGame'"
               sbSet="p.Skater: elem.attr('Skater')"
+              sbCall="closeDialogIfInBox"
             ></button>
           </span>
         </div>
-        <div class="sbGroup">
+        <div class="sbGroup" sbClass="sbHide: Skater: sbIsEmpty">
           <span>Penalties:</span>
           <span sbDisplay="PenaltyDetails: penDetailButtons: html"></span>
           <span><button sbCall="addPenalty">Add</button></span>
@@ -75,8 +78,12 @@
           >
         </div>
         <div class="sbGroup">
-          <button class="StartButton" sbClass="sbHide: PenaltyBox" sbSet="StartBoxClock" sbCall="sbCloseDialog">Skater Sat Down</button>
-          <button sbClass="sbHide: PenaltyBox: !" sbSet="PenaltyBox: false" sbCall="sbCloseDialog">Has Left</button>
+          <button class="StartButton" sbClass="sbHide: PenaltyBox" sbSet="StartBoxClock" sbCall="closeDialogIfSkater">
+            Skater Sat Down
+          </button>
+          <button sbClass="sbHide: PenaltyBox: ! | sbClickMe: PenaltyTime: <=0" sbSet="PenaltyBox: false" sbCall="sbCloseDialog">
+            Has Left
+          </button>
         </div>
       </div>
 

--- a/html/nso/pbt/index.js
+++ b/html/nso/pbt/index.js
@@ -36,7 +36,7 @@ function positionDetails(k, v, elem) {
     title: teamName + ' ' + k.Position,
     width: 700,
     buttons: {
-      Cancel: function () {
+      Close: function () {
         $(this).dialog('close');
       },
     },
@@ -59,4 +59,16 @@ function addPenalty(k) {
 function removePenalty(k) {
   const skaterPrefix = k.upTo('Team') + '.Skater(' + WS.state[k + '.Skater'] + ')';
   WS.Set(skaterPrefix + '.Penalty(' + WS.state[skaterPrefix + '.PenaltyCount'] + ').Remove', true);
+}
+
+function closeDialogIfSkater(k, v, elem) {
+  if (!!WS.state[k + '.Skater']) {
+    sbCloseDialog(k, v, elem);
+  }
+}
+
+function closeDialogIfInBox(k, v, elem) {
+  if (isTrue(WS.state[WS._getContext(elem.parent())[0] + '.PenaltyBox'])) {
+    sbCloseDialog(k, v, elem);
+  }
 }

--- a/src/com/carolinarollergirls/scoreboard/core/game/BoxTripImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/game/BoxTripImpl.java
@@ -344,18 +344,6 @@ public class BoxTripImpl extends ScoreBoardEventProviderImpl<BoxTrip> implements
                 // moved end past the present point in the game -> make ongoing
                 unend();
             }
-        } else if (prop == REMOVE_PENALTY) {
-            List<Penalty> penalties = new ArrayList<>(getAll(PENALTY));
-            if (!penalties.isEmpty()) {
-                Collections.sort(penalties, Collections.reverseOrder());
-                for (Penalty p : penalties) {
-                    if ("?".equals(p.getCode())) {
-                        remove(PENALTY, p);
-                        return;
-                    }
-                }
-                remove(PENALTY, penalties.get(0));
-            }
         }
     }
 

--- a/src/com/carolinarollergirls/scoreboard/core/game/FieldingImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/game/FieldingImpl.java
@@ -99,7 +99,13 @@ public class FieldingImpl extends ParentOrderedScoreBoardEventProviderImpl<Field
             teamJam.setNoPivot((Boolean) value);
         }
         if (prop == SKATER && value != null && isInBox() && !source.isFile()) {
-            for (Penalty p : ((Skater) value).getUnservedPenalties()) { getCurrentBoxTrip().add(BoxTrip.PENALTY, p); }
+            Skater s = (Skater) value;
+            if (getCurrentBoxTrip().getClock() != null && last == null &&
+                getCurrentBoxTrip().numberOf(BoxTrip.PENALTY) == 0 && s.getUnservedPenalties().isEmpty()) {
+                s.add(Skater.PENALTY,
+                      new PenaltyImpl(s, s.numberOf(Skater.PENALTY) == 0 ? 1 : s.getMaxNumber(Skater.PENALTY) + 1));
+            }
+            for (Penalty p : s.getUnservedPenalties()) { getCurrentBoxTrip().add(BoxTrip.PENALTY, p); }
         }
     }
 

--- a/src/com/carolinarollergirls/scoreboard/core/interfaces/BoxTrip.java
+++ b/src/com/carolinarollergirls/scoreboard/core/interfaces/BoxTrip.java
@@ -69,5 +69,4 @@ public interface BoxTrip extends ScoreBoardEventProvider {
     public static final Command END_EARLIER = new Command("EndEarlier", props);
     public static final Command END_LATER = new Command("EndLater", props);
     public static final Command DELETE = new Command("Delete", props);
-    public static final Command REMOVE_PENALTY = new Command("RemovePenalty", props);
 }


### PR DESCRIPTION
- Unless no skater is selected yet, the row of buttons is hidden behind an "Edit Lineup" button.
- In addition the dialog doesn't close on clock start when no skater is selected because most likely the operator will want to select the skater at this point.
- All penalty code/count display and add buttons are hidden when no skater is selected as they won't work anyway.
- The "Substitute" button now reads "Select Skater" and is orange when no skater is selected for the position.
- It's no longer possible to assign multiple clocks to the same position in parallel
- Assigning an initial penalty now also works when the skater is selected after the clock is assigned to a position.

closes #733 