### PR TITLE
Set Lead to Lost when Jammer removes the star on their initial pass

### DIFF
--- a/src/com/carolinarollergirls/scoreboard/core/game/TeamImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/game/TeamImpl.java
@@ -290,6 +290,7 @@ public class TeamImpl extends ScoreBoardEventProviderImpl<Team> implements Team 
                     .setRole(FloorPosition.PIVOT.getRole(getRunningOrUpcomingTeamJam()));
             }
             if ((Boolean) value && isLead()) { set(LOST, true); }
+            if ((Boolean) value && !getOtherTeam().isLead() && isOnInitial()) { set(LOST, true); }
         } else if ((prop == CALLOFF || prop == INJURY) && game.isInJam() && (Boolean) value) {
             game.stopJamTO();
         } else if (prop == CAPTAIN && last != null) {
@@ -868,6 +869,11 @@ public class TeamImpl extends ScoreBoardEventProviderImpl<Team> implements Team 
     @Override
     public boolean isLead() {
         return get(LEAD);
+    }
+
+    @Override
+    public boolean isOnInitial() {
+        return get(NO_INITIAL);
     }
 
     @Override

--- a/src/com/carolinarollergirls/scoreboard/core/interfaces/Team.java
+++ b/src/com/carolinarollergirls/scoreboard/core/interfaces/Team.java
@@ -70,6 +70,7 @@ public interface Team extends ScoreBoardEventProvider, TimeoutOwner {
 
     public boolean isLost();
     public boolean isLead();
+    public boolean isOnInitial();
     public boolean isCalloff();
     public boolean isInjury();
     public boolean isDisplayLead();


### PR DESCRIPTION
Fixes #762

Checking 'getOtherTeam().isLead()' is used over checking 'getOtherTeam().isOnInitial()' to prevent an edge case where the opposing jammer exits the pack but is not declared lead, leaving lead open, allowing for it to be lost on a star pass