### PR TITLE
re-add compatibility for iOS 9.3

### DIFF
--- a/html/components/game-advance/index.js
+++ b/html/components/game-advance/index.js
@@ -1,7 +1,5 @@
-'use strict';
-
 function advanceGame() {
-  let url = new URL(window.location);
+  var url = new URL(window.location);
   url.searchParams.set('game', WS.state['ScoreBoard.CurrentGame.Game']);
   window.location.replace(url);
 }

--- a/html/components/igrf-tab/index.js
+++ b/html/components/igrf-tab/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 $('table.Officials')
   .clone(true)
   .attr('officialType', 'Ref')
@@ -50,7 +48,7 @@ function igrfToAbortTime(k) {
   const curPeriod = WS.state[prefix + '.CurrentPeriodNumber'];
   const lastPeriod = WS.state[prefix + '.Rule(Period.Number)'];
   const pc = WS.state[prefix + '.Clock(Period).Time'];
-  let text = 'Game ended ';
+  var text = 'Game ended ';
 
   if (pc > 0) {
     text = text + 'with ' + _timeConversions.msToMinSec(pc) + ' left in period ' + curPeriod;
@@ -114,7 +112,7 @@ function igrfPasteOfficials(k, v, elem, event) {
   }
 
   // Treat as a tab-seperated roster.
-  let knownNames = {};
+  var knownNames = {};
   elem
     .closest('table')
     .find('.Official')
@@ -123,7 +121,7 @@ function igrfPasteOfficials(k, v, elem, event) {
       knownNames[n.attr('role') + '_' + n.attr('name')] = n.attr('Nso') || n.attr('Ref');
     });
 
-  for (let i = 0; i < lines.length; i++) {
+  for (var i = 0; i < lines.length; i++) {
     const cols = lines[i].split('\t');
     if (cols.length < 2) {
       continue;
@@ -133,11 +131,11 @@ function igrfPasteOfficials(k, v, elem, event) {
     if (name === '') {
       continue;
     }
-    let league = '';
+    var league = '';
     if (cols.length > 2) {
       league = cols[2].trim();
     }
-    let cert = '';
+    var cert = '';
     if (cols.length > 3) {
       cert = cols[3].trim().charAt(0);
     }

--- a/html/components/lt-sheet/index.js
+++ b/html/components/lt-sheet/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 WS.Register('ScoreBoard.Game(' + _windowFunctions.getParam('game') + ').Period(*).Jam(*).StarPass', {
   triggerBatchFunc: function () {
     const selector = 'tr.Jam, tr.SP:not(.sbHide)';

--- a/html/components/or-sheet/index.js
+++ b/html/components/or-sheet/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 WS.Register(
   [
     'ScoreBoard.Game(' + _windowFunctions.getParam('game') + ').Period(*).Timeout(*).Review',
@@ -9,7 +7,7 @@ WS.Register(
     triggerBatchFunc: function () {
       $('.OrSheet>[Period]').each(function () {
         const elem = $(this);
-        let sum = 0;
+        var sum = 0;
         elem.find('tbody:not(.sbHide) td[Duration]').each(function () {
           sum += Number($(this).attr('Duration'));
         });

--- a/html/components/penalty-list/index.js
+++ b/html/components/penalty-list/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 WS.Register([
   'ScoreBoard.CurrentGame.Rule(Penalties.NumberToFoulout)',
   'ScoreBoard.CurrentGame.CurrentPeriodNumber',
@@ -50,7 +48,7 @@ function penDetailButtons(k, v) {
 }
 
 function penToPenaltyCodeDisplay(k, v) {
-  let output = '<div class="Code">' + k.PenaltyCode + '</div><div class="Description">';
+  var output = '<div class="Code">' + k.PenaltyCode + '</div><div class="Description">';
   v.split(',').forEach(function (d) {
     output = output + '<div>' + d + '</div>';
   });

--- a/html/components/plt-input/index.js
+++ b/html/components/plt-input/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 (function () {
   const gameId = _windowFunctions.getParam('game');
   const prefix = gameId ? 'ScoreBoard.Game(' + gameId + ').' : 'ScoreBoard.CurrentGame.';
@@ -114,7 +112,7 @@ function _pltOpenPenaltyEditor(g, t, s, p) {
   if (!g) {
     return; // Whiteboard
   }
-  let prefix = 'ScoreBoard.Game(' + g + ').Team(' + t + ')';
+  var prefix = 'ScoreBoard.Game(' + g + ').Team(' + t + ')';
   const teamName = WS.state[prefix + '.AlternateName(plt)'] || WS.state[prefix + '.UniformColor'] || WS.state[prefix + '.Name'];
   prefix = 'ScoreBoard.Game(' + g + ').Team(' + t + ').Skater(' + s + ')';
   const skaterName = WS.state[prefix + '.Name'];
@@ -164,7 +162,7 @@ function pltUpdateJam(k, v) {
 
 function pltToPenaltyCodeDisplay(k, v, elem, suffix) {
   suffix = suffix || '';
-  let output = '<div class="Code">' + k.PenaltyCode + suffix + '</div><div class="Description">';
+  var output = '<div class="Code">' + k.PenaltyCode + suffix + '</div><div class="Description">';
   v.split(',').forEach(function (d) {
     output = output + '<div>' + d + '</div>';
   });
@@ -183,9 +181,9 @@ function pltToExpCodeDisplay(k, v, elem) {
 //###################################################################
 
 function _pltOpenAnnotationEditor(gameId, teamId, skaterId) {
-  let position = WS.state['ScoreBoard.Game(' + gameId + ').Team(' + teamId + ').Skater(' + skaterId + ').Position'];
+  var position = WS.state['ScoreBoard.Game(' + gameId + ').Team(' + teamId + ').Skater(' + skaterId + ').Position'];
   position = position.slice(position.lastIndexOf('_') + 1);
-  let fieldingPrefix = ').TeamJam(' + teamId + ').Fielding(' + position + ')';
+  var fieldingPrefix = ').TeamJam(' + teamId + ').Fielding(' + position + ')';
   if (isTrue(WS.state['ScoreBoard.Game(' + gameId + ').InJam'])) {
     fieldingPrefix =
       'ScoreBoard.Game(' +

--- a/html/components/roster-tab/index.js
+++ b/html/components/roster-tab/index.js
@@ -1,9 +1,7 @@
-'use strict';
-
 function rstUpdateSkaterCount(k, v) {
-  let count = 0;
+  var count = 0;
   $('#RosterTab [Team="' + k.Team + '"] tr.Skater').each(function (_, f) {
-    let flag = $(f).attr('flag');
+    var flag = $(f).attr('flag');
     if ($(f).attr('Skater') === k.Skater) {
       flag = v;
     }
@@ -17,7 +15,7 @@ function rstUpdateSkaterCount(k, v) {
 }
 
 function rstToPositionDisplay(k, v) {
-  let position = '';
+  var position = '';
   const flag = WS.state[k.upTo('Skater') + '.Flags'];
   const role = WS.state[k.upTo('Skater') + '.Role'];
   switch (role) {

--- a/html/components/ruleset-tab/index.js
+++ b/html/components/ruleset-tab/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 WS.Register('ScoreBoard.Rulesets.Ruleset(*).Parent');
 
 function rsCompareChildIndex(a, b) {
@@ -35,7 +33,7 @@ function rsDefinitionOverride(k, v, elem) {
 }
 
 function _rsGetEffectiveValue(rs, rule) {
-  let value = null;
+  var value = null;
   while (value == null && rs != null) {
     value = WS.state['ScoreBoard.Rulesets.Ruleset(' + rs + ').Rule(' + rule + ')'];
     rs = WS.state['ScoreBoard.Rulesets.Ruleset(' + rs + ').Parent'];

--- a/html/components/sbo-input/index.js
+++ b/html/components/sbo-input/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 WS.Register(['ScoreBoard.Game(' + _windowFunctions.getParam('game') + ').CurrentJam', 'ScoreBoard.Rulesets.Ruleset(*).Parent']);
 
 function opToggleKeyEdit(k, v, elem) {
@@ -63,8 +61,8 @@ function opStartMidGame() {
 }
 
 function opStartAdHoc(k, v, elem) {
-  let startTime = $('#newStartTime').val();
-  let intermissionClock = null;
+  var startTime = $('#newStartTime').val();
+  var intermissionClock = null;
   if (startTime !== '') {
     var now = new Date();
     var parts = startTime.split(':');

--- a/html/components/settings-tab/index.js
+++ b/html/components/settings-tab/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 $(function () {
   $('#IntermissionControlDialog')
     .parent()

--- a/html/components/sheets-tab/index.js
+++ b/html/components/sheets-tab/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 function shtSelectSheet(k, v, elem) {
   elem.toggleClass('sbActive');
   $('#SheetsTab')

--- a/html/components/sk-input/index.js
+++ b/html/components/sk-input/index.js
@@ -1,11 +1,8 @@
-'use strict';
-
 WS.AfterLoad(function () {
   $('[Team="1"] .SkInput .OfficialTimeout>div').remove();
 });
 
 function skiToggleEdit(k, v, elem) {
-  console.log('toggle', elem);
   elem.siblings().addBack().toggleClass('sbHide').filter('input:visible, select:visible').trigger('focus');
 }
 

--- a/html/components/sk-sheet/index.js
+++ b/html/components/sk-sheet/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 (function () {
   const prefix = 'ScoreBoard.Game(' + _windowFunctions.getParam('game') + ').Period(*).Jam(*).TeamJam(*).ScoringTrip(*).';
   WS.Register([prefix + 'AfterSP', prefix + 'Score', prefix + 'Current'], function (k) {
@@ -87,8 +85,8 @@ function sksToTripPoints(k) {
     if (isTrue(WS.state[prefix + 'AfterSP']) || WS.state[prefix + 'Score'] == null) {
       return '';
     } else {
-      let trip = 11;
-      let val = WS.state[prefix + 'Score'];
+      var trip = 11;
+      var val = WS.state[prefix + 'Score'];
       const prefixNoNumber = k.upTo('TeamJam') + '.ScoringTrip(';
       while (WS.state[prefixNoNumber + trip + ').Score'] != null && !isTrue(WS.state[prefixNoNumber + trip + ').AfterSP'])) {
         val = val + ' + ' + WS.state[prefixNoNumber + trip + ').Score'];
@@ -128,12 +126,12 @@ function sksToTripSpPoints(k) {
     if (WS.state[prefix + 'Score'] == null) {
       return '';
     } else {
-      let trip = 10;
+      var trip = 10;
       const prefixNoNumber = k.upTo('TeamJam') + '.ScoringTrip(';
       while (WS.state[prefixNoNumber + trip + ').Score'] != null && !isTrue(WS.state[prefixNoNumber + trip + ').AfterSP'])) {
         trip++;
       }
-      let val = WS.state[prefixNoNumber + trip + ').Score'] || '';
+      var val = WS.state[prefixNoNumber + trip + ').Score'] || '';
       trip++;
       while (WS.state[prefixNoNumber + trip + ').Score'] != null) {
         val = val + ' + ' + WS.state[prefixNoNumber + trip + ').Score'];

--- a/html/components/team-editor/index.js
+++ b/html/components/team-editor/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 $('#teamLogoUpload').fileupload({
   url: '/Media/upload',
   formData: [
@@ -7,7 +5,7 @@ $('#teamLogoUpload').fileupload({
     { name: 'type', value: 'teamlogo' },
   ],
   add: function (e, data) {
-    let fd = new FormData();
+    var fd = new FormData();
     fd.append('f', data.files[0], data.files[0].name);
     data.files[0] = fd.get('f');
     data.submit();
@@ -16,7 +14,7 @@ $('#teamLogoUpload').fileupload({
     WS.Set(WS._getContext($('#teamLogoUpload')) + '.Logo', '/images/teamlogo/' + data.files[0].name);
   },
   fail: function (e, data) {
-    console.log('Failed upload', data.errorThrown);
+    console.error('Failed upload', data.errorThrown);
   },
 });
 
@@ -153,7 +151,7 @@ function tmePasteSkaters(k, v, elem, event) {
   }
 
   // Treat as a tab-seperated roster.
-  let knownNumbers = {};
+  var knownNumbers = {};
   elem
     .closest('.Skaters')
     .find('.Skater')
@@ -162,7 +160,7 @@ function tmePasteSkaters(k, v, elem, event) {
       knownNumbers[n.attr('skaternum')] = n.attr('skaterid');
     });
 
-  for (let i = 0; i < lines.length; i++) {
+  for (var i = 0; i < lines.length; i++) {
     const cols = lines[i].split('\t');
     if (cols.length < 2) {
       continue;

--- a/html/javascript/autofit.js
+++ b/html/javascript/autofit.js
@@ -8,7 +8,6 @@ var _autoFit = {
    * The auto-fit function can also be accessed via element.data('AutoFit').
    */
   enableAutoFitText: function (e, options) {
-    'use strict';
     if (!e) {
       return null;
     }
@@ -35,7 +34,6 @@ var _autoFit = {
     return doAutoFit;
   },
   disableAutoFitText: function (e) {
-    'use strict';
     if (!e.data('AutoFit')) {
       return;
     }
@@ -78,7 +76,6 @@ var _autoFit = {
    * This returns an object with the relevant css properties that were updated.
    */
   autoFitText: function (container, options) {
-    'use strict';
     if (!options) {
       options = {};
     }
@@ -159,27 +156,22 @@ var _autoFit = {
     return _autoFit._cssObject(container, options);
   },
   _currentFontSize: function (container) {
-    'use strict';
     return Number(container.css('fontSize').replace(/px$/, ''));
   },
   _updateFontSize: function (container, size) {
-    'use strict';
     var last = _autoFit._currentFontSize(container);
     container.css('fontSize', size + 'px');
     return last !== _autoFit._currentFontSize(container);
   },
   _updateMinMaxFontSizes: function (container, params, newMin, newMax) {
-    'use strict';
     params.minFontSize = Number(newMin);
     params.maxFontSize = Number(newMax);
     return _autoFit._updateFontSize(container, (params.minFontSize + params.maxFontSize) / 2);
   },
   _overSize: function (contents, params) {
-    'use strict';
     return contents.outerWidth(true) > params.maxW || contents.outerHeight(true) > params.targetH;
   },
   _cssObject: function (container, options) {
-    'use strict';
     if (!options.returnCssObject) {
       return;
     }

--- a/html/javascript/boolconversions.js
+++ b/html/javascript/boolconversions.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /*
  * To bool
  */

--- a/html/javascript/conversions.js
+++ b/html/javascript/conversions.js
@@ -1,5 +1,3 @@
-'use strict';
-
 function sbToNullIfEmpty(k, v) {
   return v === '' ? null : v;
 }
@@ -37,7 +35,7 @@ function sbFromTime(k, v) {
   return _timeConversions.minSecToMs(v);
 }
 function sbToClockInitialNumber(k) {
-  let ret = '';
+  var ret = '';
   const name = WS.state[k.upTo('Clock') + '.Name'];
   const number = WS.state[k.upTo('Clock') + '.Number'];
 
@@ -89,7 +87,7 @@ function sbToIntermissionDisplay(k) {
   const max = WS.state[k.upTo('Game') + '.Rule(Period.Number)'];
   const isOfficial = WS.state[k.upTo('Game') + '.OfficialScore'];
   const showDuringOfficial = WS.state[k.upTo('Game') + '.ClockDuringFinalScore'];
-  let ret = '';
+  var ret = '';
 
   if (isOfficial) {
     if (showDuringOfficial) {

--- a/html/javascript/cssfunctions.js
+++ b/html/javascript/cssfunctions.js
@@ -1,5 +1,3 @@
-'use strict';
-
 function sbCssToUrl(k, v) {
   if (v) {
     return 'url("' + v + '")';

--- a/html/javascript/keycontrols.js
+++ b/html/javascript/keycontrols.js
@@ -7,7 +7,6 @@ var _crgKeyControls = {
    * and calls setupKeyControl, using the given controlParent.
    */
   setupKeyControls: function (operator) {
-    'use strict';
     _crgKeyControls.setupKeyControl($(_crgKeyControls.keySelector), operator);
   },
   /* Destroy all key control buttons.
@@ -15,7 +14,6 @@ var _crgKeyControls = {
    * and calls destroyKeyControl.
    */
   destroyKeyControls: function () {
-    'use strict';
     _crgKeyControls.destroyKeyControl($(_crgKeyControls.keySelector));
   },
 
@@ -37,7 +35,6 @@ var _crgKeyControls = {
    * when there is a control key the button has class HasControlKey
    */
   setupKeyControl: function (button, operator) {
-    'use strict';
     _crgKeyControls._start(operator);
     _crgKeyControls
       .destroyKeyControl(button)
@@ -64,7 +61,6 @@ var _crgKeyControls = {
     return button;
   },
   _hoverFunction: function (event) {
-    'use strict';
     $(this).toggleClass('hover', event.type === 'mouseenter');
   },
 
@@ -75,7 +71,6 @@ var _crgKeyControls = {
    * Note this does not remove the sbKeyControl class from the button.
    */
   destroyKeyControl: function (button) {
-    'use strict';
     button.attr('_crgKeyControls_prop', false);
     button.off('mouseenter mouseleave', _crgKeyControls._hoverFunction);
     button.find('span.Indicator').remove();
@@ -96,23 +91,19 @@ var _crgKeyControls = {
    * CSS note: buttons in edit mode have the class 'Editing'.
    */
   editKeys: function (edit) {
-    'use strict';
     $(_crgKeyControls.keySelector).toggleClass('Editing', edit);
   },
 
   addCondition: function (condition) {
-    'use strict';
     _crgKeyControls._conditions.push(condition);
   },
   _conditions: [
     function () {
-      'use strict';
       return !$('div.MultipleKeyAssignDialog').length;
     },
   ],
 
   _start: function (operator) {
-    'use strict';
     _crgKeyControls.operator = operator;
     if (!_crgKeyControls._keyControlStarted) {
       $(document).on('keypress', _crgKeyControls._keyControlPress);
@@ -123,7 +114,6 @@ var _crgKeyControls = {
           return;
         }
         var button = $('#' + k.Setting.split('.')[4]);
-        console.log(button);
         button
           .toggleClass('HasControlKey', v ? true : false)
           .find('span.Key')
@@ -137,7 +127,6 @@ var _crgKeyControls = {
   _operator: '',
 
   _checkConditions: function () {
-    'use strict';
     var ok = true;
     $.each(_crgKeyControls._conditions, function () {
       if (ok && typeof this === 'function' && !this()) {
@@ -147,7 +136,6 @@ var _crgKeyControls = {
     return ok;
   },
   _validKey: function (keycode) {
-    'use strict';
     /* For reference see http://en.wikipedia.org/wiki/List_of_Unicode_characters */
     if (keycode < 0x20) {
       // Low control chars
@@ -162,7 +150,6 @@ var _crgKeyControls = {
   _existingKeyLast: undefined,
   _existingKeyCount: 0,
   _keyControlPress: function (event) {
-    'use strict';
     if (!_crgKeyControls._checkConditions()) {
       return;
     }
@@ -202,7 +189,6 @@ var _crgKeyControls = {
     }
   },
   _keyControlDown: function (event) {
-    'use strict';
     if (!_crgKeyControls._checkConditions()) {
       return;
     }
@@ -218,11 +204,9 @@ var _crgKeyControls = {
     }
   },
   _clearKey: function (targets) {
-    'use strict';
     _crgKeyControls._setKey(targets, '');
   },
   _setKey: function (targets, key) {
-    'use strict';
     targets.each(function () {
       var prop = $(this).attr('_crgKeyControls_prop');
       if (prop) {
@@ -231,7 +215,6 @@ var _crgKeyControls = {
     });
   },
   _showMultipleKeyAssignDialog: function (existing, target, key) {
-    'use strict';
     var div = $('<div>').addClass('MultipleKeyAssignDialog');
     var n = existing.filter(':not(.Hidden)').length;
     var s = n === 1 ? '' : 's';

--- a/html/javascript/sortfunctions.js
+++ b/html/javascript/sortfunctions.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /*
  * Generally the functions in this file are intended to be used with _windowfunctions.appendSorted
  * In this context they will be given two DOM elements a,b as input and should return true,

--- a/html/javascript/timeconversions.js
+++ b/html/javascript/timeconversions.js
@@ -5,7 +5,6 @@ var _timeConversions = {
 
   /* Convert ms to seconds */
   msToSeconds: function (ms, roundUp) {
-    'use strict';
     if (ms < 0) {
       return '0';
     }
@@ -17,12 +16,10 @@ var _timeConversions = {
   },
   /* Convert seconds to milliseconds */
   secondsToMs: function (sec) {
-    'use strict';
     return String(sec * 1000);
   },
   /* Convert milliseconds to min:sec */
   msToMinSec: function (ms, roundUp) {
-    'use strict';
     if (ms < 0) {
       return '0:00';
     }
@@ -30,14 +27,12 @@ var _timeConversions = {
   },
   /* Convert min:sec to milliseconds */
   minSecToMs: function (time) {
-    'use strict';
     var min = Number(_timeConversions._timeOnlyMin(time) || 0);
     var sec = Number(_timeConversions._timeOnlySec(time) || 0);
     return _timeConversions.secondsToMs(min * 60 + sec);
   },
   /* Convert milliseconds to min:sec, if min is 0 return only seconds portion */
   msToMinSecNoZero: function (ms, roundUp) {
-    'use strict';
     if (ms < 0) {
       return '0';
     }
@@ -50,7 +45,6 @@ var _timeConversions = {
   },
   /* Same as minSecToMs() */
   minSecNoZeroToMs: function (time) {
-    'use strict';
     return _timeConversions.minSecToMs(time);
   },
 
@@ -60,7 +54,6 @@ var _timeConversions = {
 
   /* Format number into minimum 2 digits, prepending 0 if needed */
   twoDigit: function (n) {
-    'use strict';
     return (10 > n ? '0' : '') + n;
   },
 
@@ -70,17 +63,14 @@ var _timeConversions = {
 
   /* If needed, this preprends ':' */
   _formatMinSec: function (time) {
-    'use strict';
     return String(time).indexOf(':') > -1 ? time : ':' + time;
   },
   /* Convert ms to seconds portion of min:sec */
   _msOnlySec: function (ms, roundUp) {
-    'use strict';
     return _timeConversions.twoDigit(_timeConversions.msToSeconds(ms, roundUp) % 60);
   },
   /* Convert ms to minutes portion of min:sec */
   _msOnlyMin: function (ms, roundUp) {
-    'use strict';
     var min = Math.floor(ms / 60000);
     // if rounding up and seconds are 59001-59999, we need to add a minute
     min = min + Number(_timeConversions.msToSeconds(Math.max(0, (ms % 60000) - 59000), roundUp));
@@ -88,12 +78,10 @@ var _timeConversions = {
   },
   /* Accepts min:sec time, returns only seconds portion */
   _timeOnlySec: function (time) {
-    'use strict';
     return _timeConversions._formatMinSec(time).split(':')[1];
   },
   /* Accepts min:sec time, returns only minutes portion */
   _timeOnlyMin: function (time) {
-    'use strict';
     return _timeConversions._formatMinSec(time).split(':')[0];
   },
 };

--- a/html/javascript/utils.js
+++ b/html/javascript/utils.js
@@ -1,5 +1,3 @@
-'use strict';
-
 function sbNewUuid() {
   return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
     var r = (Math.random() * 16) | 0,
@@ -63,7 +61,7 @@ function sbReverseOnNonSheet(k, v, elem) {
 }
 
 function _sbUpdateUrl(key, val) {
-  let url = new URL(window.location);
+  var url = new URL(window.location);
   url.searchParams.set(key, val);
   window.history.replaceState(null, '', url);
 }

--- a/html/javascript/windowfunctions.js
+++ b/html/javascript/windowfunctions.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const _windowFunctions = {
   /* Display area dimensions */
   getAspectDimensions: function (aspect, overflow) {
@@ -186,43 +184,5 @@ const _windowFunctions = {
   },
   numCompareByText: function (a, b) {
     return _windowFunctions.numCompare($(a).text(), $(b).text());
-  },
-  fullscreenRequest: function (a) {
-    var isFullscreen = false;
-    if (document.fullscreen) {
-      isFullscreen = true;
-    }
-    if (document.mozFullScreen) {
-      isFullscreen = true;
-    }
-    if (document.webkitIsFullScreen) {
-      isFullscreen = true;
-    }
-    if (document.msFullscreenElement) {
-      isFullscreen = true;
-    }
-
-    var docElem = document.documentElement;
-    if (!isFullscreen && (a === true || a == null)) {
-      if (docElem.requestFullscreen) {
-        docElem.requestFullscreen();
-      } else if (docElem.mozRequestFullScreen) {
-        docElem.mozRequestFullScreen();
-      } else if (docElem.webkitRequestFullScreen) {
-        docElem.webkitRequestFullScreen();
-      } else if (docElem.msRequestFullscreen) {
-        docElem.msRequestFullscreen();
-      }
-    } else if (isFullscreen && (a === false || a == null)) {
-      if (document.exitFullscreen) {
-        document.exitFullscreen();
-      } else if (document.mozCancelFullScreen) {
-        document.mozCancelFullScreen();
-      } else if (document.webkitCancelFullScreen) {
-        document.webkitCancelFullScreen();
-      } else if (document.msExitFullscreen) {
-        document.msExitFullscreen();
-      }
-    }
   },
 };

--- a/html/json/WS.js
+++ b/html/json/WS.js
@@ -1,5 +1,4 @@
-'use strict';
-let WS = {
+var WS = {
   _connectCallback: null,
   _connectTimeout: null,
   _registerOnConnect: [],
@@ -23,11 +22,11 @@ let WS = {
 
   _connect: function () {
     WS._connectTimeout = null;
-    let url = (document.location.protocol === 'http:' ? 'ws' : 'wss') + '://';
+    var url = (document.location.protocol === 'http:' ? 'ws' : 'wss') + '://';
     url += document.location.host + '/WS/';
     // This is not required, but helps figure out which device is which.
     url += '?source=' + encodeURIComponent(document.location.pathname + document.location.search);
-    let platform = '';
+    var platform = '';
     if (navigator.userAgent || false) {
       const match = navigator.userAgent.match(/\((.*)\).*\(.*\)/);
       if (match) {
@@ -59,7 +58,7 @@ let WS = {
         });
         WS.state = {};
         if (WS._preRegisterDone) {
-          let req = {
+          var req = {
             action: 'Register',
             paths: WS._registerOnConnect,
           };
@@ -103,7 +102,7 @@ let WS = {
         clearInterval(WS._heartbeat);
       };
       WS.socket.onerror = function (e) {
-        console.log('WS', 'Websocket: Error', e);
+        console.error('WS', 'Websocket: Error', e);
         WS._connectionStatus.attr('status', 'error').text('Not connected');
         if (WS._connectTimeout == null) {
           WS._connectTimeout = setTimeout(WS._connect, 1000);
@@ -164,12 +163,12 @@ let WS = {
   _processUpdate: function (state) {
     // update all incoming properties before triggers
     // dependency issues causing problems
-    let plainNull = [];
-    let plain = [];
+    var plainNull = [];
+    var plain = [];
     // Batch functions are only called once per update.
     // This is useful to avoid n^2 operations when
     // every callback redraws everything.
-    let batched = new Set();
+    var batched = new Set();
     $.each(state, function (k, v) {
       k = WS._enrichProp(k);
       const callbacks = WS._getMatchesFromTrie(WS._callbackTrie, k, 'partialKey');
@@ -226,17 +225,16 @@ let WS = {
 
   // Parse property name, and make it easily accessible.
   _enrichProp: function (prop) {
-    'use strict';
     if (WS._enrichPropCache[prop] != null) {
       return WS._enrichPropCache[prop];
     }
     prop = new String(prop);
-    let i = prop.length - 1;
-    let parts = [];
+    var i = prop.length - 1;
+    var parts = [];
     while (i >= 0) {
-      let dot;
-      let key;
-      let val = '';
+      var dot;
+      var key;
+      var val = '';
       if (prop[i] === ')') {
         const open = prop.lastIndexOf('(', i);
         dot = prop.lastIndexOf('.', open);
@@ -271,9 +269,9 @@ let WS = {
       options = { triggerFunc: options };
     }
 
-    let callback = null;
-    let batchCallback = null;
-    let elem = null;
+    var callback = null;
+    var batchCallback = null;
+    var elem = null;
     if (options == null) {
       callback = null;
     } else {
@@ -399,7 +397,7 @@ let WS = {
   _stateTrie: {},
   _addToTrie: function (t, key, value) {
     const p = key.split(/(?=[.(])/);
-    for (let i = 0; i < p.length; i++) {
+    for (var i = 0; i < p.length; i++) {
       const c = p[i];
       t[c] = t[c] || {};
       t = t[c];
@@ -429,7 +427,7 @@ let WS = {
     remove(t, key.split(/(?=[.(])/), 0);
   },
   _getMatchesFromTrie: function (trie, key, mode) {
-    let result = [];
+    var result = [];
     function findAllMatches(t) {
       if (t._values) {
         result.push(...t._values);
@@ -447,7 +445,7 @@ let WS = {
       for (; i < p.length; i++) {
         if (t['.*)'] || t['(*)']) {
           // Allow Blah(*) as a wildcard.
-          let j = i;
+          var j = i;
           // id captured by * might contain . and thus be split - find the end
           while (j < p.length && !p[j].endsWith(')')) {
             j++;
@@ -530,11 +528,15 @@ let WS = {
     const val = WS._replacePathComponents(elem, attr, isPreRegister)[0];
     return val
       ? val.split('|').map(function (part) {
-          let list = part.split(':').map((s) => s.trim());
+          var list = part.split(':').map(function (s) {
+            return s.trim();
+          });
           if (pathIndex > -1) {
             const prefixes = WS._getPrefixes(elem, isPreRegister);
             const basePath = WS._getContext(elem, attr === 'sbForeach', isPreRegister);
-            list[pathIndex] = list[pathIndex].split(',').map((item) => WS._combinePaths(basePath, [item.trim(), false], prefixes)[0]);
+            list[pathIndex] = list[pathIndex].split(',').map(function (item) {
+              return WS._combinePaths(basePath, [item.trim(), false], prefixes)[0];
+            });
           }
           if (readFuncIndex > -1 && (isBool || list[readFuncIndex] != null || list[pathIndex].length > 1 || alwaysReadState)) {
             list[readFuncIndex] = WS._getModifyFunc(list[pathIndex], list[readFuncIndex] || '', isBool, alwaysReadState);
@@ -548,7 +550,7 @@ let WS = {
   },
 
   _getAutoFitPaths: function (elem) {
-    let value = WS._getParameters(elem, 'sbAutoFitOn', 0);
+    var value = WS._getParameters(elem, 'sbAutoFitOn', 0);
     return value.length ? value[0][0] : value;
   },
 
@@ -561,7 +563,7 @@ let WS = {
     } else {
       return function (path, v, elem) {
         v = null;
-        for (let i = 0; i < paths.length; i++) {
+        for (var i = 0; i < paths.length; i++) {
           path = paths[i];
           if (WS.state[path] != null) {
             v = WS.state[path];
@@ -653,13 +655,19 @@ let WS = {
       }
       elem.next('[sbForeach]').attr('sbSubId', subId + 1);
       const preForeachItem = subId === 0 ? elem.prev() : elem.prevUntil(':not([sbSubId])').prev();
-      let [paths, fixedKeys, sortFunction, optionsString] = forEachEntries[0];
-      fixedKeys = fixedKeys ? fixedKeys.split(',').map((s) => s.trim()) : [];
-      let blockedKeys = {};
-      let options = {};
+      var [paths, fixedKeys, sortFunction, optionsString] = forEachEntries[0];
+      fixedKeys = fixedKeys
+        ? fixedKeys.split(',').map(function (s) {
+            return s.trim();
+          })
+        : [];
+      var blockedKeys = {};
+      var options = {};
       if (optionsString) {
         optionsString.split(',').map(function (option) {
-          option = option.split('=', 2).map((s) => s.trim());
+          option = option.split('=', 2).map(function (s) {
+            return s.trim();
+          });
           options[option[0]] = option[1] || true;
         });
         if (options.onInsert) {
@@ -669,7 +677,7 @@ let WS = {
           options.onRemove = WS._buildNonBoolFunc(options.onRemove);
         }
       }
-      let context = elem.attr('sbContext');
+      var context = elem.attr('sbContext');
       context = context ? (context + ':').split(':', 2) : ['', ''];
       if (context[0] != '' && !context[0].endsWith('^')) {
         context[0] = context[0] + '.';
@@ -694,7 +702,7 @@ let WS = {
             if (!options.noContext) {
               newElem.attr('sbContext', context[0] + field + '(' + key + '):' + context[1]);
             }
-            let prev = paren.children('[' + field + '="' + key + '"][sbSubId="' + (subId - 1) + '"]');
+            var prev = paren.children('[' + field + '="' + key + '"][sbSubId="' + (subId - 1) + '"]');
             if (!prev.length) {
               prev = preForeachItem.nextUntil(':not(.sbFixed)').addBack().last();
             }
@@ -806,8 +814,8 @@ let WS = {
     } else {
       const autoFitPaths = WS._getAutoFitPaths(elem);
       const context = WS._enrichProp(WS._getContext(elem)[0]);
-      let autoFitNeeded = elem.hasClass('AutoFit');
-      let stopRecursion = false;
+      var autoFitNeeded = elem.hasClass('AutoFit');
+      var stopRecursion = false;
 
       WS._getParameters(elem, 'sbOn', -1, -1, 1).forEach(function ([event, func]) {
         elem.on(event, function (e) {
@@ -895,7 +903,7 @@ let WS = {
   },
 
   _preRegister: function () {
-    let paths = [];
+    var paths = [];
     const preRegisterAttribute = function (attr, pathIndex) {
       $('[' + attr + ']').each(function (idx, elem) {
         WS._getParameters($(elem), attr, pathIndex, -1, -1, false, true).forEach(function (params) {
@@ -906,7 +914,11 @@ let WS = {
 
     $('[sbForeach]').each(function (idx, elem) {
       WS._getParameters($(elem), 'sbForeach', 0, -1, -1, false, true).forEach(function (params) {
-        paths = paths.concat(params[0].map((s) => s + '(*)' + ((params[3] || '').includes('noId') ? '' : '.Id')));
+        paths = paths.concat(
+          params[0].map(function (s) {
+            return s + '(*)' + ((params[3] || '').includes('noId') ? '' : '.Id');
+          })
+        );
       });
     });
 
@@ -922,10 +934,10 @@ let WS = {
 
   _replacePathRe: /\[([^\]]*)\]/g,
   _replacePathComponents: function (elem, attr, isPreRegister, skipCopyContext) {
-    let reevaluate = false;
-    let value = elem.attr(attr);
+    var reevaluate = false;
+    var value = elem.attr(attr);
     if (value) {
-      let changed = false;
+      var changed = false;
       value = value.replaceAll(WS._replacePathRe, function (match, field) {
         changed = true;
         if (field === '*') {
@@ -933,7 +945,7 @@ let WS = {
             // we're called as part of determining the proper replacement - break infinite loop
             return match;
           }
-          let context = WS._getContext(elem, false, isPreRegister, attr === 'sbPrefix');
+          var context = WS._getContext(elem, false, isPreRegister, attr === 'sbPrefix');
           return context[1] ? match : context[0];
         } else {
           const src = elem.closest(match + ', [sbForeach^="' + match + '"]:not([sbForeach*="noContext"])');
@@ -964,14 +976,14 @@ let WS = {
         return match;
       }
     }
-    let path = ['', false];
+    var path = ['', false];
     const parent = elem.parent();
     if (parent.length > 0) {
       path = WS._getContext(parent, false, isPreRegister);
     }
     const prefixes = WS._getPrefixes(elem, isPreRegister, skipCopyContext);
-    let [value, reeval] = WS._replacePathComponents(elem, 'sbContext', isPreRegister);
-    let suffix = [undefined, reeval];
+    var [value, reeval] = WS._replacePathComponents(elem, 'sbContext', isPreRegister);
+    var suffix = [undefined, reeval];
     if (value) {
       const parts = value.split(':', 2);
       path = WS._combinePaths(path, [parts[0], reeval], prefixes);
@@ -1022,14 +1034,16 @@ let WS = {
       return cached.prefixes;
     }
 
-    let prefixes = {};
+    var prefixes = {};
     Object.entries(WS._getPrefixes(elem.parent(), isPreRegister)).forEach(function ([prefix, value]) {
       prefixes[prefix] = { prefix: value.prefix, suffix: value.suffix, reevaluate: value.reevaluate };
     });
     const [value, reevaluate] = WS._replacePathComponents(elem, 'sbPrefix', isPreRegister, skipCopyContext);
     if (value) {
       value.split('|').map(function (entry) {
-        entry = entry.split(':').map((s) => s.trim());
+        entry = entry.split(':').map(function (s) {
+          return s.trim();
+        });
         prefixes[entry[0]] = { prefix: entry[1], suffix: entry[2], reevaluate: reevaluate };
       });
     }

--- a/html/json/core.js
+++ b/html/json/core.js
@@ -1,4 +1,3 @@
-'use strict';
 if (typeof $ === 'undefined') {
   alert('You MUST include jQuery before this file!');
   throw 'You MUST include jQuery before this file!';

--- a/html/json/state.js
+++ b/html/json/state.js
@@ -1,7 +1,6 @@
 WS.Register('ScoreBoard', display);
 
 function display(k, v) {
-  'use strict';
   var row = findRow(k);
   if (v != null) {
     if ($.isPlainObject(v)) {
@@ -15,7 +14,6 @@ function display(k, v) {
 }
 
 function findRow(k) {
-  'use strict';
   var row = $('tr[key="' + k + '"]');
   if (row.length === 0) {
     row = $('<tr>').attr('key', k);

--- a/html/nso/hnso/index.js
+++ b/html/nso/hnso/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 (function () {
   $('#tabsDiv').tabs();
 })();

--- a/html/nso/jt/index.css
+++ b/html/nso/jt/index.css
@@ -1,4 +1,4 @@
-:root { --button-margin: min(2 * var(--segment-corner-radius), 1dvh); }
+:root { --button-margin: 1dvh; --button-margin: min(2 * var(--segment-corner-radius), 1dvh); }
 body { margin: 0; padding: 0; width: 100dvw; height: 100dvh; }
 div { position: absolute; margin: 0; top: 0; left: 0; height: inherit; width: inherit; text-align: center; border-radius: var(--segment-corner-radius); }
 button.AutoFit { position: absolute; margin: var(--button-margin); top: 0; left: 0; height: calc(100% - 2 * var(--button-margin)); width: calc(100% - 2 *  var(--button-margin)); }

--- a/html/nso/jt/index.js
+++ b/html/nso/jt/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 function jtToggleSetting(k, v, elem) {
   elem.toggleClass('sbActive');
 }

--- a/html/nso/pbt/index.js
+++ b/html/nso/pbt/index.js
@@ -1,7 +1,4 @@
-'use strict';
-
 WS.AfterLoad(function () {
-  'use strict';
   $('#UsePBTDialog').dialog({
     modal: true,
     closeOnEscape: false,

--- a/html/nso/plt/index.js
+++ b/html/nso/plt/index.js
@@ -1,5 +1,4 @@
 WS.AfterLoad(function () {
-  'use strict';
   _windowFunctions.configureZoom();
   $('body')
     .attr('showTeam', _windowFunctions.getParam('team'))
@@ -57,7 +56,6 @@ function updateTitle() {
 }
 
 function openOptionsDialog() {
-  'use strict';
   $('#OptionsDialog').dialog('open');
 }
 
@@ -70,7 +68,6 @@ function setTeam(k, v, elem) {
 }
 
 function setPos(k, v, elem) {
-  console.log('called');
   $('#OptionsDialog [pos]').removeClass('sbActive');
   elem.addClass('sbActive');
   $('body').attr('sbSheetStyle', elem.attr('pos'));
@@ -79,14 +76,12 @@ function setPos(k, v, elem) {
 }
 
 function setZoom(k, v, elem) {
-  'use strict';
   elem.toggleClass('sbActive');
   _sbUpdateUrl('zoomable', elem.filter('.sbActive').length);
   _windowFunctions.configureZoom();
 }
 
 function advanceFieldings(k) {
-  'use strict';
   const team = _windowFunctions.getParam('team');
   if (team === 'both') {
     WS.Set(k + '.Team(1).AdvanceFieldings', true);

--- a/html/nso/sbo/index.js
+++ b/html/nso/sbo/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 (function () {
   WS.Register(['ScoreBoard.Settings.Setting(ScoreBoard.Operator.*)', 'ScoreBoard.Settings.Setting(ScoreBoard.Operator_Default.*)']);
 

--- a/html/nso/sk/index.js
+++ b/html/nso/sk/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 (function () {
   _windowFunctions.configureZoom();
   $('body').attr('showTeam', _windowFunctions.getParam('team'));

--- a/html/settings/devices/index.js
+++ b/html/settings/devices/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 WS.Register('WS.Device.Id');
 
 WS.AfterLoad(function () {

--- a/html/settings/file_management/index.js
+++ b/html/settings/file_management/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 WS.AfterLoad(function () {
   $('#tabsDiv').tabs();
 });

--- a/html/settings/rulesets/index.js
+++ b/html/settings/rulesets/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 function toTitle(k, v) {
   if (v == null && $('#sbConnectionStatus').attr('status') === 'ready') {
     window.close();

--- a/html/settings/sb_data/index.js
+++ b/html/settings/sb_data/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 WS.Register('ScoreBoard.Rulesets.Ruleset(*).Parent');
 
 WS.AfterLoad(function () {
@@ -9,7 +7,7 @@ WS.AfterLoad(function () {
 
 function _datUpdateAllUrl() {
   const d = new Date();
-  let name = $.datepicker.formatDate('yy-mm-dd_', d);
+  var name = $.datepicker.formatDate('yy-mm-dd_', d);
   name += _timeConversions.twoDigit(d.getHours());
   name += _timeConversions.twoDigit(d.getMinutes());
   name += _timeConversions.twoDigit(d.getSeconds());
@@ -18,22 +16,30 @@ function _datUpdateAllUrl() {
 
 function _datUpdateSelectedUrl() {
   const paths = $('#games tr.Content.Selected')
-    .map((i, elem) => 'ScoreBoard.Game(' + $(elem).attr('Game') + ')')
+    .map(function (i, elem) {
+      return 'ScoreBoard.Game(' + $(elem).attr('Game') + ')';
+    })
     .get()
     .concat(
       $('#teams tr.Content.Selected')
-        .map((i, elem) => 'ScoreBoard.PreparedTeam(' + $(elem).attr('PreparedTeam') + ')')
+        .map(function (i, elem) {
+          return 'ScoreBoard.PreparedTeam(' + $(elem).attr('PreparedTeam') + ')';
+        })
         .get(),
       $('#rulesets tr.Content.Selected')
-        .map((i, elem) => 'ScoreBoard.Rulesets.Ruleset(' + $(elem).attr('Ruleset') + ')')
+        .map(function (i, elem) {
+          return 'ScoreBoard.Rulesets.Ruleset(' + $(elem).attr('Ruleset') + ')';
+        })
         .get(),
       $('#operators tr.Content.Selected')
-        .map((i, elem) => 'ScoreBoard.Settings.Setting(' + $(elem).attr('Setting').slice(0, -1))
+        .map(function (i, elem) {
+          return 'ScoreBoard.Settings.Setting(' + $(elem).attr('Setting').slice(0, -1);
+        })
         .get()
     )
     .join();
   const d = new Date();
-  let name = $.datepicker.formatDate('yy-mm-dd_', d);
+  var name = $.datepicker.formatDate('yy-mm-dd_', d);
   name += _timeConversions.twoDigit(d.getHours());
   name += _timeConversions.twoDigit(d.getMinutes());
   name += _timeConversions.twoDigit(d.getSeconds());
@@ -64,7 +70,7 @@ function datUpdateUploadButtons(k, v, elem) {
 }
 
 function _datCreateRemoveDialog(type) {
-  let div = $('.sbTemplates .RemoveDataDialog').clone(true);
+  var div = $('.sbTemplates .RemoveDataDialog').clone(true);
   const selector = type === 'selected' ? ' tr.Content.Selected' : type === 'singleElement' ? ' tr.Content.ToDelete' : ' tr.Content.None'; // class None is not used, so this will match nothing
   if (!$(selector).length) {
     return;

--- a/html/settings/teams/index.js
+++ b/html/settings/teams/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 function toTitle(k, v) {
   if (v == null && $('#sbConnectionStatus').attr('status') === 'ready') {
     window.close();

--- a/html/views/overlay/admin/index.js
+++ b/html/views/overlay/admin/index.js
@@ -1,7 +1,5 @@
-'use strict';
-
-let nextPanel = '';
-let currrentPanel = '';
+var nextPanel = '';
+var currrentPanel = '';
 
 (function () {
   $('#PanelSelect').val('');

--- a/html/views/overlay/index.js
+++ b/html/views/overlay/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 WS.Register(
   [
     'ScoreBoard.CurrentGame.Clock(Timeout).Running',
@@ -100,7 +98,7 @@ function ovlIsJamming(k, v, elem) {
 }
 
 function ovlToPpjColumnWidth(k, v, elem) {
-  let ne1 = $('.PPJBox [Team="1"] .GraphBlock').length;
+  var ne1 = $('.PPJBox [Team="1"] .GraphBlock').length;
   const ne2 = $('.PPJBox [Team="2"] .GraphBlock').length;
   if (ne2 > ne1) {
     ne1 = ne2;
@@ -139,7 +137,7 @@ function _ovlToLowerThirdColor(type) {
 }
 
 function ovlToClockType() {
-  let ret;
+  var ret;
   const to = WS.state['ScoreBoard.CurrentGame.TimeoutOwner'];
   const or = WS.state['ScoreBoard.CurrentGame.OfficialReview'];
   const tc = WS.state['ScoreBoard.CurrentGame.Clock(Timeout).Running'];

--- a/html/views/standard/index.js
+++ b/html/views/standard/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 (function () {
   const view = _windowFunctions.checkParam('preview', 'true') ? 'Preview' : 'View';
   $('body').attr('sbPrefix', '&: ScoreBoard.Settings.Setting(ScoreBoard.' + view + ' : )');


### PR DESCRIPTION
closes #731 

Support is not perfect: iOS does not support `display: grid` and some calculations with CSS variables. But as far as I can tell without access to an affected device, the relevant screens (JT, single team PLT and PBT) degrade in a way that keeps them usable.