### PR TITLE
Enhance Officials Handling

### DIFF
--- a/html/components/igrf-tab/index.css
+++ b/html/components/igrf-tab/index.css
@@ -19,7 +19,8 @@
 #Igrf table.Officials col.Name { width: 30%; } 
 #Igrf table.Officials col.League { width: 30%; } 
 #Igrf table.Officials col.Cert { width: 10%; } 
-#Igrf table.Officials col.Button { width: 10%; } 
+#Igrf table.Officials col.Store { width: 5%; } 
+#Igrf table.Officials col.Button { width: 5%; } 
 #Igrf table.Officials tr.AddOfficial>td { border-bottom: 1px dashed #777; }
 #Igrf table.Officials button.Swap { font-size: 80%; padding: 0.4em; } 
 

--- a/html/components/igrf-tab/index.html
+++ b/html/components/igrf-tab/index.html
@@ -137,6 +137,7 @@
     <col class="Name" />
     <col class="League" />
     <col class="Cert" />
+    <col class="Store" />
     <col class="Button" />
     <thead>
       <tr class="sbHeader">
@@ -150,6 +151,7 @@
         </th>
         <th></th>
         <th></th>
+        <th></th>
       </tr>
       <tr class="sbSubHeader">
         <th>Role</th>
@@ -157,9 +159,10 @@
         <th>League</th>
         <th>Cert Level</th>
         <th></th>
+        <th></th>
       </tr>
       <tr class="AddOfficial sbSubHeader">
-        <th>
+        <th rowspan="2">
           <span class="Role">
             <select class="Role" sbCall="igrfToggleInput">
               <option value="">None Selected</option>
@@ -181,18 +184,23 @@
         </th>
         <th><input type="text" size="30" class="Name" sbOn="keyup: igrfUpdateAddButton | paste: igrfPasteOfficials" /></th>
         <th><input type="text" size="30" class="League" sbOn="keyup: igrfUpdateAddButton | paste: igrfPasteOfficials" /></th>
-        <th>
-          <select class="Cert">
-            <option value="">None</option>
-            <option value="R">Recognized</option>
-            <option value="1">Level 1</option>
-            <option value="2">Level 2</option>
-            <option value="3">Level 3</option>
+        <th><input type="text" size="10" class="Cert" sbOn="keyup: igrfUpdateAddButton | paste: igrfPasteOfficials" /></th>
+        <th></th>
+        <th rowspan="2"><button class="AddOfficial" sbCall="igrfAddOfficial">Add</button></th>
+      </tr>
+      <tr class="AddPreparedOfficial sbSubHeader">
+        <th colspan="2">
+          <select class="Prepared">
+            <option value="">Select Stored Official</option>
+            <option
+              sbContext="/ScoreBoard"
+              sbForeach="PreparedOfficial::info"
+              sbAttr="value: Id | info: FullInfo"
+              sbDisplay="FullInfo"
+            ></option>
           </select>
         </th>
-        <th>
-          <button class="AddOfficial" sbCall="igrfAddOfficial">Add</button>
-        </th>
+        <th colspan="3"></th>
       </tr>
     </thead>
     <tbody>
@@ -225,17 +233,14 @@
             <button class="Swap" sbToggle="Swap">Swap</button>
           </span>
         </td>
-        <td class="Name"><input type="text" size="30" sbControl="Name" /></td>
-        <td class="League"><input type="text" size="30" sbControl="League" /></td>
-        <td class="Cert">
-          <select class="Cert" sbControl="Cert">
-            <option value="">None</option>
-            <option value="R">Recognized</option>
-            <option value="1">Level 1</option>
-            <option value="2">Level 2</option>
-            <option value="3">Level 3</option>
-          </select>
+        <td colspan="2" class="Prepared" sbClass="sbHide: PreparedOfficial: sbIsEmpty">
+          <span sbDisplay="Name"></span> (<span sbDisplay="League"></span> - <span sbDisplay="Cert"></span>)
         </td>
+        <td colspan="2" sbClass="sbHide: PreparedOfficial: sbIsEmpty"></td>
+        <td class="Name" sbClass="sbHide: PreparedOfficial: sbIsNotEmpty"><input type="text" size="30" sbControl="Name" /></td>
+        <td class="League" sbClass="sbHide: PreparedOfficial: sbIsNotEmpty"><input type="text" size="30" sbControl="League" /></td>
+        <td class="Cert" sbClass="sbHide: PreparedOfficial: sbIsNotEmpty"><input type="text" size="30" sbControl="Cert" /></td>
+        <td class="Store" sbClass="sbHide: PreparedOfficial: sbIsNotEmpty"><button sbSet="Store">Store</button></td>
         <td class="Remove"><button class="RemoveOfficial" sbCall="igrfOpenRemoveDialog">Remove</button></td>
       </tr>
     </tbody>

--- a/html/components/igrf-tab/index.js
+++ b/html/components/igrf-tab/index.js
@@ -70,15 +70,22 @@ function igrfToggleInput(k, v, elem) {
 }
 
 function igrfAddOfficial(k, v, elem) {
-  const row = elem.closest('tr');
-  _igrfAddOfficial(
-    k,
-    elem.closest('[officialType]').attr('officialType'),
-    row.find('input.Role').val(),
-    row.find('input.Name').val(),
-    row.find('input.League').val(),
-    row.find('select.Cert').val()
-  );
+  const row = elem.closest('thead');
+  const prepared = elem.closest('thead').find('select.Prepared').val();
+  if (prepared) {
+    const prefix = k + '.' + elem.closest('[officialType]').attr('officialType') + '(' + sbNewUuid() + ').';
+    WS.Set(prefix + 'Role', elem.closest('thead').find('input.Role').val());
+    WS.Set(prefix + 'PreparedOfficial', prepared);
+  } else {
+    _igrfAddOfficial(
+      k,
+      elem.closest('[officialType]').attr('officialType'),
+      row.find('input.Role').val(),
+      row.find('input.Name').val(),
+      row.find('input.League').val(),
+      row.find('input.Cert').val()
+    );
+  }
   row.find('select').val('');
   row.find('input').val('');
   elem.prop('disabled', true).toggleClass('ui-button-disabled ui-state-disabled', true);
@@ -88,14 +95,15 @@ function _igrfAddOfficial(prefix, type, role, name, league, cert, id) {
   id = id || sbNewUuid();
   prefix = prefix + '.' + type + '(' + id + ').';
   WS.Set(prefix + 'Role', role);
-  WS.Set(prefix + 'Name', name);
   WS.Set(prefix + 'League', league);
   WS.Set(prefix + 'Cert', cert);
+  // set name last as it triggers lookup for stored officials with extra info
+  WS.Set(prefix + 'Name', name);
 }
 
 function igrfUpdateAddButton(k, v, elem, event) {
-  const button = elem.closest('tr').find('button.AddOfficial');
-  const disable = !elem.closest('tr').find('input.Name').val();
+  const button = elem.closest('thead').find('button.AddOfficial');
+  const disable = !elem.closest('thead').find('input.Name').val() && !elem.closest('thead').find('select.Prepared').val();
   button.prop('disabled', disable).toggleClass('ui-button-disabled ui-state-disabled', disable);
   if (!disable && 13 === event.which) {
     // Enter

--- a/html/settings/sb_data/index.html
+++ b/html/settings/sb_data/index.html
@@ -129,6 +129,32 @@
           </tbody>
         </table>
       </div>
+      <div class="sbSegment">
+        <table class="sbGroup Type" id="Officials">
+          <thead class="sbHeader">
+            <tr>
+              <th>
+                <button class="SelectAll Left" sbCall="datSelectAll">All</button>
+                <span>Officials</span>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr sbForeach="PreparedOfficial:: info" sbAttr="info: FullInfo" class="Content">
+              <td class="Name">
+                <button class="Select Left" sbCall="datSelect">Select</button>
+                <button class="Delete Left" sbCall="datDeleteElem">Delete</button>
+                <a download class="Download Left" sbAttr="href: Name: datOfficialDlLink" sbButton>Download</a>
+                <button sbCall="datEditOfficial">Edit</button>
+                <span class="Name" sbDisplay="FullInfo"></span>
+                <input class="Edit sbHide" type="text" size="30" class="Name" sbControl="Name" />
+                <input class="Edit sbHide" type="text" size="30" class="League" sbControl="League" />
+                <input class="Edit sbHide" type="text" size="10" class="Cert" sbControl="Cert" />
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </div>
 
     <div class="sbTemplates">

--- a/html/settings/sb_data/index.js
+++ b/html/settings/sb_data/index.js
@@ -168,10 +168,21 @@ function datOperatorDlLink(k) {
   );
 }
 
+function datOfficialDlLink(k, v) {
+  return v
+    ? '/SaveJSON/crg-official-' + v.replace(/[\/|\\:*?"<>\ ]/g, '_') + '.json?path=ScoreBoard.PreparedOfficial(' + k.PreparedOfficial + ')'
+    : null;
+}
+
 function datToEditButtonLabel(k, v) {
   return isTrue(v) ? 'View' : 'Edit';
 }
 
 function datToOperatorName(k) {
   return k.Setting.split('.')[2];
+}
+
+function datEditOfficial(k, v, elem) {
+  elem.toggleClass('sbActive');
+  elem.parent().children('span, input').toggleClass('sbHide');
 }

--- a/src/com/carolinarollergirls/scoreboard/core/ScoreBoardImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/ScoreBoardImpl.java
@@ -17,6 +17,7 @@ import com.carolinarollergirls.scoreboard.core.interfaces.ScoreBoard;
 import com.carolinarollergirls.scoreboard.core.interfaces.Settings;
 import com.carolinarollergirls.scoreboard.core.interfaces.Timeout;
 import com.carolinarollergirls.scoreboard.core.interfaces.TimeoutOwner;
+import com.carolinarollergirls.scoreboard.core.prepared.PreparedOfficialImpl;
 import com.carolinarollergirls.scoreboard.core.prepared.PreparedTeamImpl;
 import com.carolinarollergirls.scoreboard.core.prepared.RulesetsImpl;
 import com.carolinarollergirls.scoreboard.event.Child;
@@ -66,6 +67,7 @@ public class ScoreBoardImpl extends ScoreBoardEventProviderImpl<ScoreBoard> impl
     public ScoreBoardEventProvider create(Child<? extends ScoreBoardEventProvider> prop, String id, Source source) {
         synchronized (coreLock) {
             if (prop == PREPARED_TEAM) { return new PreparedTeamImpl(this, id); }
+            if (prop == PREPARED_OFFICIAL) { return new PreparedOfficialImpl(this, id); }
             if (prop == GAME) { return new GameImpl(this, id); }
             return null;
         }

--- a/src/com/carolinarollergirls/scoreboard/core/interfaces/Official.java
+++ b/src/com/carolinarollergirls/scoreboard/core/interfaces/Official.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 import com.carolinarollergirls.scoreboard.event.Child;
+import com.carolinarollergirls.scoreboard.event.Command;
 import com.carolinarollergirls.scoreboard.event.Property;
 import com.carolinarollergirls.scoreboard.event.ScoreBoardEventProvider;
 import com.carolinarollergirls.scoreboard.event.Value;
@@ -14,13 +15,18 @@ public interface Official extends ScoreBoardEventProvider {
     public Child<Official> getType();
 
     public static Collection<Property<?>> props = new ArrayList<>();
+    public static Collection<Property<?>> preparedProps = new ArrayList<>(); // also present on PreparedOfficial
 
     public static final Value<String> ROLE = new Value<>(String.class, "Role", "", props);
-    public static final Value<String> NAME = new Value<>(String.class, "Name", "", props);
-    public static final Value<String> LEAGUE = new Value<>(String.class, "League", "", props);
-    public static final Value<String> CERT = new Value<>(String.class, "Cert", "", props);
+    public static final Value<String> NAME = new Value<>(String.class, "Name", "", preparedProps);
+    public static final Value<String> LEAGUE = new Value<>(String.class, "League", "", preparedProps);
+    public static final Value<String> CERT = new Value<>(String.class, "Cert", "", preparedProps);
     public static final Value<Team> P1_TEAM = new Value<>(Team.class, "P1Team", null, props);
     public static final Value<Boolean> SWAP = new Value<>(Boolean.class, "Swap", false, props);
+    public static final Value<PreparedOfficial> PREPARED_OFFICIAL =
+        new Value<>(PreparedOfficial.class, "PreparedOfficial", null, props);
+
+    public static final Command STORE = new Command("Store", props);
 
     public static final String ROLE_HNSO = "Head Non-Skating Official";
     public static final String ROLE_PLT = "Penalty Lineup Tracker";

--- a/src/com/carolinarollergirls/scoreboard/core/interfaces/PreparedOfficial.java
+++ b/src/com/carolinarollergirls/scoreboard/core/interfaces/PreparedOfficial.java
@@ -1,0 +1,16 @@
+package com.carolinarollergirls.scoreboard.core.interfaces;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import com.carolinarollergirls.scoreboard.event.Property;
+import com.carolinarollergirls.scoreboard.event.ScoreBoardEventProvider;
+import com.carolinarollergirls.scoreboard.event.Value;
+
+public interface PreparedOfficial extends ScoreBoardEventProvider {
+    public boolean matches(String name, String league);
+
+    public static Collection<Property<?>> props = new ArrayList<>();
+
+    public static final Value<String> FULL_INFO = new Value<>(String.class, "FullInfo", "", props);
+}

--- a/src/com/carolinarollergirls/scoreboard/core/interfaces/ScoreBoard.java
+++ b/src/com/carolinarollergirls/scoreboard/core/interfaces/ScoreBoard.java
@@ -49,6 +49,8 @@ public interface ScoreBoard extends ScoreBoardEventProvider {
     public static final Child<Rulesets> RULESETS = new Child<>(Rulesets.class, "Rulesets", props);
     public static final Child<Game> GAME = new Child<>(Game.class, "Game", props);
     public static final Child<PreparedTeam> PREPARED_TEAM = new Child<>(PreparedTeam.class, "PreparedTeam", props);
+    public static final Child<PreparedOfficial> PREPARED_OFFICIAL =
+        new Child<>(PreparedOfficial.class, "PreparedOfficial", props);
     public static final Child<CurrentGame> CURRENT_GAME = new Child<>(CurrentGame.class, "CurrentGame", props);
 
     public static final String SETTING_CLOCK_AFTER_TIMEOUT = "ScoreBoard.ClockAfterTimeout";

--- a/src/com/carolinarollergirls/scoreboard/core/prepared/PreparedOfficialImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/prepared/PreparedOfficialImpl.java
@@ -1,0 +1,27 @@
+package com.carolinarollergirls.scoreboard.core.prepared;
+
+import com.carolinarollergirls.scoreboard.core.interfaces.Official;
+import com.carolinarollergirls.scoreboard.core.interfaces.PreparedOfficial;
+import com.carolinarollergirls.scoreboard.core.interfaces.ScoreBoard;
+import com.carolinarollergirls.scoreboard.event.ScoreBoardEventProviderImpl;
+import com.carolinarollergirls.scoreboard.event.Value;
+
+public class PreparedOfficialImpl extends ScoreBoardEventProviderImpl<PreparedOfficial> implements PreparedOfficial {
+    public PreparedOfficialImpl(ScoreBoard parent, String id) {
+        super(parent, id, ScoreBoard.PREPARED_OFFICIAL);
+        addProperties(Official.preparedProps);
+        addProperties(props);
+        setRecalculated(FULL_INFO).addSource(this, Official.NAME).addSource(this, Official.LEAGUE);
+    }
+
+    @Override
+    protected Object computeValue(Value<?> prop, Object value, Object last, Source source, Flag flag) {
+        if (prop == FULL_INFO) { return get(Official.NAME) + " (" + get(Official.LEAGUE) + ")"; }
+        return value;
+    }
+
+    @Override
+    public boolean matches(String name, String league) {
+        return get(Official.NAME).equals(name) && ("".equals(league) || get(Official.LEAGUE).equals(league));
+    }
+}

--- a/src/com/carolinarollergirls/scoreboard/json/ScoreBoardJSONSetter.java
+++ b/src/com/carolinarollergirls/scoreboard/json/ScoreBoardJSONSetter.java
@@ -186,7 +186,7 @@ public class ScoreBoardJSONSetter {
             (key.contains("Timeout(") && key.endsWith("OrRequest")) ||
             (key.contains("Timeout(") && key.endsWith("OrResult")) ||
             (key.contains("Team(") && key.endsWith("AllBlockersSet")) || key.contains("(Timeout.JamDuring)") ||
-            key.endsWith("ExtraPenaltyTime")) {
+            key.contains("PreparedOfficial") || key.endsWith("ExtraPenaltyTime")) {
             return "v2025";
         }
         if (priorLimit.equals("v2023") || key.endsWith("ExportBlockedBy") || key.contains("ScoreAdjustment") ||


### PR DESCRIPTION
- Allow storing Officials (closes #517)
- When entering/pasting Officials add in League and/or Cert Level if they are recorded in stored officials
- When pasting Crews, match positions with different capitalization and/or white space.
  - Also match position abbreviations from CVs (PLT, SBO, HR, ...).