### PR TITLE
Make unstopped timeouts less impactful by showing the lineup clock when both are running

### DIFF
--- a/html/components/settings-tab/index.html
+++ b/html/components/settings-tab/index.html
@@ -3,13 +3,6 @@
     <div class="sbGroup sbHeader"><span>General Settings</span></div>
     <div class="sbGroup ScoreBoardOptions">
       <button sbToggle="$.Clock.Sync">Sync Clocks</button>
-      <span>
-        <label>Clock shown after Timeout: </label>
-        <select sbControl="$.ClockAfterTimeout">
-          <option value="Lineup">Lineup</option>
-          <option value="Timeout">Timeout</option>
-        </select>
-      </span>
       <button sbToggle="$.Penalties.UseLT">CRG Tracks Lineups</button>
       <button sbToggle="$.Penalties.UsePBT">CRG Times Penalties</button>
     </div>

--- a/html/javascript/utils.js
+++ b/html/javascript/utils.js
@@ -25,10 +25,10 @@ function sbClockSelect(k) {
   var clock = 'NoClock';
   if (jam) {
     clock = 'Jam';
-  } else if (timeout) {
-    clock = 'Timeout';
   } else if (lineup) {
     clock = 'Lineup';
+  } else if (timeout) {
+    clock = 'Timeout';
   } else if (intermission) {
     clock = 'Intermission';
   }

--- a/src/com/carolinarollergirls/scoreboard/core/admin/SettingsImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/admin/SettingsImpl.java
@@ -57,7 +57,6 @@ public class SettingsImpl extends ScoreBoardEventProviderImpl<Settings> implemen
         set(ScoreBoard.SETTING_AUTO_START_BUFFER, "0:02");
         set(ScoreBoard.SETTING_AUTO_END_JAM, "false");
         set(ScoreBoard.SETTING_AUTO_END_TTO, "false");
-        set(ScoreBoard.SETTING_CLOCK_AFTER_TIMEOUT, Clock.ID_LINEUP);
         set(Clock.SETTING_SYNC, "true");
         set(Team.SETTING_DISPLAY_NAME, Team.OPTION_LEAGUE_NAME);
         set(Game.SETTING_DEFAULT_NAME_FORMAT, "%d %G %1 vs. %2 (%s: %S)");

--- a/src/com/carolinarollergirls/scoreboard/core/game/GameImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/game/GameImpl.java
@@ -758,9 +758,7 @@ public class GameImpl extends ScoreBoardEventProviderImpl<Game> implements Game 
     private void _startJam() {
         Clock pc = getClock(Clock.ID_PERIOD);
         Clock jc = getClock(Clock.ID_JAM);
-        Clock tc = getClock(Clock.ID_TIMEOUT);
 
-        if (!getCurrentTimeout().isRunning()) { tc.stop(); }
         _endIntermission(false);
         _endLineup();
         if (!getBoolean(Rule.TO_JAM) || !getCurrentTimeout().isRunning()) { pc.start(); }
@@ -837,7 +835,7 @@ public class GameImpl extends ScoreBoardEventProviderImpl<Game> implements Game 
         if (!getCurrentTimeout().isRunning()) { return; }
 
         getCurrentTimeout().stop();
-        if (!getSetting(ScoreBoard.SETTING_CLOCK_AFTER_TIMEOUT).equals(Clock.ID_TIMEOUT)) { tc.stop(); }
+        tc.stop();
         if (!timeoutFollows) {
             set(CURRENT_TIMEOUT, noTimeoutDummy);
             if (pc.isTimeAtEnd()) {

--- a/src/com/carolinarollergirls/scoreboard/core/game/TimeoutImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/game/TimeoutImpl.java
@@ -109,10 +109,13 @@ public class TimeoutImpl extends ScoreBoardEventProviderImpl<Timeout> implements
     public void stop() {
         set(RUNNING, false);
         if (getOwner() == Owners.NONE) { set(OWNER, Owners.OTO); }
-        set(DURATION, game.getClock(Clock.ID_TIMEOUT).getTimeElapsed());
         set(WALLTIME_END, ScoreBoardClock.getInstance().getCurrentWalltime());
-        set(PERIOD_CLOCK_ELAPSED_END, game.getClock(Clock.ID_PERIOD).getTimeElapsed());
-        set(PERIOD_CLOCK_END, game.getClock(Clock.ID_PERIOD).getTime());
+        if (!game.getClock(Clock.ID_PERIOD).isRunning()) {
+            // don't record duration when ended late
+            set(DURATION, game.getClock(Clock.ID_TIMEOUT).getTimeElapsed());
+            set(PERIOD_CLOCK_ELAPSED_END, game.getClock(Clock.ID_PERIOD).getTimeElapsed());
+            set(PERIOD_CLOCK_END, game.getClock(Clock.ID_PERIOD).getTime());
+        }
     }
 
     @Override

--- a/src/com/carolinarollergirls/scoreboard/core/interfaces/ScoreBoard.java
+++ b/src/com/carolinarollergirls/scoreboard/core/interfaces/ScoreBoard.java
@@ -53,7 +53,6 @@ public interface ScoreBoard extends ScoreBoardEventProvider {
         new Child<>(PreparedOfficial.class, "PreparedOfficial", props);
     public static final Child<CurrentGame> CURRENT_GAME = new Child<>(CurrentGame.class, "CurrentGame", props);
 
-    public static final String SETTING_CLOCK_AFTER_TIMEOUT = "ScoreBoard.ClockAfterTimeout";
     public static final String SETTING_AUTO_START = "ScoreBoard.AutoStart";
     public static final String SETTING_AUTO_START_BUFFER = "ScoreBoard.AutoStartBuffer";
     public static final String SETTING_AUTO_END_JAM = "ScoreBoard.AutoEndJam";

--- a/src/com/carolinarollergirls/scoreboard/json/ScoreBoardJSONSetter.java
+++ b/src/com/carolinarollergirls/scoreboard/json/ScoreBoardJSONSetter.java
@@ -108,6 +108,7 @@ public class ScoreBoardJSONSetter {
                 if (newKey.startsWith("ScoreBoard.Clients.Client") ||
                     (newKey.startsWith("ScoreBoard.Settings.Setting(ScoreBoard.Operator") &&
                      newKey.endsWith("StartStopButtons)")) ||
+                    newKey.equals("ScoreBoard.Settings.Setting(ScoreBoard.ClockAfterTimeout)") ||
                     newKey.endsWith("FirstJam") || newKey.endsWith("FirstJamNumber")) {
                     newKey = "";
                 }
@@ -229,8 +230,9 @@ public class ScoreBoardJSONSetter {
         if (priorLimit.equals("v5") || key.startsWith("ScoreBoard.Twitter")) { return "v5"; }
         if (priorLimit.equals("v2023") || key.equals("ScoreBoard.Settings.Setting(Overlay.Interactive.ShowAllNames)") ||
             (key.startsWith("ScoreBoard.Settings.Setting(ScoreBoard.Operator") && key.endsWith("StartStopButtons")) ||
-            key.contains("Jam.SuddenScoringMaxTrainingPoints") || key.startsWith("ScoreBoard.Clients.Client(") ||
-            key.endsWith("FirstJam") || key.endsWith("FirstJamNumber")) {
+            key.contains("Jam.SuddenScoringMaxTrainingPoints") || key.contains("ScoreBoard.ClockAfterTimeout") ||
+            key.startsWith("ScoreBoard.Clients.Client(") || key.endsWith("FirstJam") ||
+            key.endsWith("FirstJamNumber")) {
             return "v2023";
         }
 

--- a/tests/com/carolinarollergirls/scoreboard/core/game/GameImplTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/core/game/GameImplTests.java
@@ -98,7 +98,6 @@ public class GameImplTests {
         sb.addScoreBoardListener(batchCounter);
         // Clock Sync can cause clocks to be changed when started, breaking tests.
         sb.getSettings().set(Clock.SETTING_SYNC, "False");
-        sb.getSettings().set(ScoreBoard.SETTING_CLOCK_AFTER_TIMEOUT, "Lineup");
         checkPeriodJamInvariants();
     }
 
@@ -783,37 +782,6 @@ public class GameImplTests {
         assertTrue(ic.isRunning());
         assertTrue(ic.isTimeAtStart());
         checkLabels(Game.ACTION_START_JAM, Game.ACTION_LINEUP, Game.ACTION_TIMEOUT,
-                    Game.UNDO_PREFIX + Game.ACTION_STOP_TO);
-    }
-
-    @Test
-    public void testStopJam_endTimeoutKeepTimeoutClock() {
-        sb.getSettings().set(ScoreBoard.SETTING_CLOCK_AFTER_TIMEOUT, "Timeout");
-
-        g.startJam();
-        g.timeout();
-        assertFalse(pc.isRunning());
-        assertFalse(pc.isTimeAtEnd());
-        assertFalse(jc.isRunning());
-        assertFalse(lc.isRunning());
-        tc.setTime(32000);
-        tc.setNumber(8);
-        assertFalse(ic.isRunning());
-        assertEquals(Timeout.Owners.NONE, g.getTimeoutOwner());
-        assertFalse(g.isOfficialReview());
-
-        g.stopJamTO();
-
-        assertFalse(pc.isRunning());
-        assertFalse(jc.isRunning());
-        assertTrue(lc.isRunning());
-        assertTrue(tc.isRunning());
-        assertEquals(32000, tc.getTimeElapsed());
-        assertEquals(8, tc.getNumber());
-        assertFalse(ic.isRunning());
-        assertEquals(Timeout.Owners.NONE, g.getTimeoutOwner());
-        assertFalse(g.isOfficialReview());
-        checkLabels(Game.ACTION_START_JAM, Game.ACTION_NONE, Game.ACTION_TIMEOUT,
                     Game.UNDO_PREFIX + Game.ACTION_STOP_TO);
     }
 
@@ -1565,29 +1533,6 @@ public class GameImplTests {
         assertFalse(g.get(Game.NO_MORE_JAM));
         assertFalse(pc.isRunning());
         assertEquals(22000, pc.getTimeRemaining());
-    }
-
-    @Test
-    public void testPeriodEndWithTimeoutClock() {
-        sb.getSettings().set(ScoreBoard.SETTING_CLOCK_AFTER_TIMEOUT, Clock.ID_TIMEOUT);
-
-        assertTrue(pc.isCountDirectionDown());
-        g.startJam();
-        pc.setTime(25000);
-        g.stopJamTO();
-        assertTrue(g.get(Game.NO_MORE_JAM));
-        g.timeout();
-        advance(35000);
-        assertTrue(g.get(Game.NO_MORE_JAM));
-        g.setTimeoutType(Timeout.Owners.OTO, false);
-        assertTrue(g.get(Game.NO_MORE_JAM));
-        g.stopJamTO();
-        assertTrue(g.get(Game.NO_MORE_JAM));
-        assertTrue(pc.isRunning());
-        advance(26000);
-        assertTrue(ic.isRunning());
-        assertFalse(tc.isRunning());
-        assertFalse(pc.isRunning());
     }
 
     @Test

--- a/tests/com/carolinarollergirls/scoreboard/core/game/TeamImplTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/core/game/TeamImplTests.java
@@ -12,7 +12,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.carolinarollergirls.scoreboard.core.ScoreBoardImpl;
-import com.carolinarollergirls.scoreboard.core.interfaces.Clock;
 import com.carolinarollergirls.scoreboard.core.interfaces.CurrentGame;
 import com.carolinarollergirls.scoreboard.core.interfaces.Fielding;
 import com.carolinarollergirls.scoreboard.core.interfaces.FloorPosition;
@@ -123,7 +122,6 @@ public class TeamImplTests {
 
     @Test
     public void testSetRetainedOfficialReview() {
-        sb.getSettings().set(ScoreBoard.SETTING_CLOCK_AFTER_TIMEOUT, Clock.ID_LINEUP);
         assertFalse(team.retainedOfficialReview());
         assertEquals(1, team.getOfficialReviews());
         sb.addScoreBoardListener(new ConditionalScoreBoardListener<>(team, Team.RETAINED_OFFICIAL_REVIEW, listener));
@@ -162,7 +160,6 @@ public class TeamImplTests {
 
     @Test
     public void testTimeoutsResetAtHalf() {
-        sb.getSettings().set(ScoreBoard.SETTING_CLOCK_AFTER_TIMEOUT, Clock.ID_LINEUP);
         team.timeout();
         advance(60000);
         g.timeout();

--- a/tests/com/carolinarollergirls/scoreboard/core/prepared/RulesetsImplTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/core/prepared/RulesetsImplTests.java
@@ -27,7 +27,6 @@ public class RulesetsImplTests {
     public void setUp() throws Exception {
         sb = new ScoreBoardImpl(false);
         sb.postAutosaveUpdate();
-        sb.getSettings().set(ScoreBoard.SETTING_CLOCK_AFTER_TIMEOUT, "Lineup");
         rulesets = sb.getRulesets();
         root = rulesets.getRuleset(RulesetsImpl.ROOT_ID);
     }

--- a/tests/com/carolinarollergirls/scoreboard/json/ScoreBoardJSONListenerTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/json/ScoreBoardJSONListenerTests.java
@@ -21,7 +21,6 @@ import com.carolinarollergirls.scoreboard.core.interfaces.Period;
 import com.carolinarollergirls.scoreboard.core.interfaces.Role;
 import com.carolinarollergirls.scoreboard.core.interfaces.Rulesets;
 import com.carolinarollergirls.scoreboard.core.interfaces.Rulesets.Ruleset;
-import com.carolinarollergirls.scoreboard.core.interfaces.ScoreBoard;
 import com.carolinarollergirls.scoreboard.core.interfaces.Skater;
 import com.carolinarollergirls.scoreboard.core.interfaces.Team;
 import com.carolinarollergirls.scoreboard.core.prepared.RulesetsImpl;
@@ -66,7 +65,6 @@ public class ScoreBoardJSONListenerTests {
         sb.postAutosaveUpdate();
         g = sb.getCurrentGame().get(CurrentGame.GAME);
         gameId = g.getId();
-        sb.getSettings().set(ScoreBoard.SETTING_CLOCK_AFTER_TIMEOUT, Clock.ID_LINEUP);
         sb.getSettings().set(Clock.SETTING_SYNC, String.valueOf(false));
 
         jsm = new JSONStateManager(false);


### PR DESCRIPTION
This breaks showing a timeout clock after the timeout ended, so remove that option and simplify the code.

Closes #757