### PR TITLE
teams/scores should be visible by default on overlay

### DIFF
--- a/src/com/carolinarollergirls/scoreboard/core/admin/SettingsImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/admin/SettingsImpl.java
@@ -42,7 +42,7 @@ public class SettingsImpl extends ScoreBoardEventProviderImpl<Settings> implemen
     private void setDefaults() {
         set("Overlay.Interactive.Clock", "true");
         set("Overlay.Interactive.Scaling", "100");
-        set("Overlay.Interactive.Score", "On");
+        set("Overlay.Interactive.Score", "true");
         set("Overlay.Interactive.ShowJammers", "true");
         set("Overlay.Interactive.ShowLineups", "true");
         set("Overlay.Interactive.ShowNames", "true");


### PR DESCRIPTION
closes #796 