### PR TITLE
Fix score going to 0 when deleting the most recent jam

### DIFF
--- a/src/com/carolinarollergirls/scoreboard/core/game/JamImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/game/JamImpl.java
@@ -95,6 +95,10 @@ public class JamImpl extends NumberedScoreBoardEventProviderImpl<Jam> implements
                 }
 
                 delete(source);
+
+                if (parent instanceof Period && this == ((Period) parent).getCurrentJam()) {
+                    ((Period) parent).set(Period.CURRENT_JAM, getPrevious());
+                }
             } else if (prop == INSERT_BEFORE) {
                 if (parent instanceof Period) {
                     parent.add(ownType, new JamImpl(parent, getNumber()));

--- a/tests/com/carolinarollergirls/scoreboard/core/game/GameImplTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/core/game/GameImplTests.java
@@ -1928,6 +1928,12 @@ public class GameImplTests {
         g.startJam();
         assertEquals(4, g.getCurrentPeriod().numberOf(Period.JAM));
         assertEquals(4, g.getCurrentPeriod().getCurrentJam().getNumber());
+
+        g.stopJamTO();
+        g.getCurrentPeriod().getCurrentJam().execute(Jam.DELETE);
+        checkPeriodJamInvariants();
+        assertEquals(3, g.getCurrentPeriod().numberOf(Period.JAM));
+        assertEquals(3, g.getCurrentPeriod().getCurrentJam().getNumber());
     }
 
     @Test


### PR DESCRIPTION
This is only a temporary display problem - the data is still there and the points come back to the display when a jam is started. But it's quite unsettling if you're caught off guard and chances are people do not start a jam when it happens.