### PR TITLE
Lock bottom part of PBT screen in place

### DIFF
--- a/html/nso/pbt/index.css
+++ b/html/nso/pbt/index.css
@@ -1,5 +1,5 @@
 body { display: flex; flex-direction: column; height: calc(100dvh - 16px); }
-#List { flex: 1; }
+#List { flex: 1; overflow: scroll; }
 
 #Unassigned { 
     display: grid; 


### PR DESCRIPTION
Now the penalty list scrolls behind it instead of the buttons disappearing when there are many penalties in a Jam.

closes #808 