### PR TITLE
Make after timeout behaviour compliant with procedures without brekaing rules compliance

### DIFF
--- a/html/javascript/conversions.js
+++ b/html/javascript/conversions.js
@@ -52,11 +52,8 @@ function sbToClockInitialNumber(k) {
 function sbToTimeoutType(k) {
   const to = WS.state[k.upTo('Game') + '.TimeoutOwner'];
   const or = isTrue(WS.state[k.upTo('Game') + '.OfficialReview']);
-  const lu = isTrue(WS.state[k.upTo('Game') + '.Clock(Lineup).Running']);
 
-  if (lu) {
-    return 'Lineup';
-  } else if (!to) {
+  if (!to) {
     return 'Timeout';
   } else if (to === 'O') {
     return 'Official Timeout';

--- a/html/javascript/utils.js
+++ b/html/javascript/utils.js
@@ -20,11 +20,14 @@ function sbClockSelect(k) {
   var jam = isTrue(WS.state[k.upTo('Game') + '.InJam']);
   var timeout = isTrue(WS.state[k.upTo('Game') + '.Clock(Timeout).Running']);
   var lineup = isTrue(WS.state[k.upTo('Game') + '.Clock(Lineup).Running']);
+  var secondLineup = lineup && timeout;
   var intermission = isTrue(WS.state[k.upTo('Game') + '.Clock(Intermission).Running']);
 
   var clock = 'NoClock';
   if (jam) {
     clock = 'Jam';
+  } else if (secondLineup) {
+    clock = "SecondLineup"
   } else if (lineup) {
     clock = 'Lineup';
   } else if (timeout) {

--- a/html/views/standard/index.css
+++ b/html/views/standard/index.css
@@ -114,7 +114,8 @@ body.box_flat .Clock.Period.Large>.Name { left: 0%; width: 100%; height: 40% }
 .Clock.Jam.Large>.Time { position: absolute; top: 40%; left: 0%; width: 100%; height: 60%; } 
 body.box_flat .Clock.Jam.Large>.Name { left: 0%; width: 100%; height: 40% } 
 
-.Clock.Small { position: absolute; top: 62%; height: 12%; opacity: 0; } 
+.Clock.Small { position: absolute; top: 62%; height: 12%; opacity: 0; }
+.Clock.Small.Below { top: 75%; } 
 .Clock.Small.Show { opacity: 1; } 
 .Clock.Period.Time.Small { left: 1%; width: 27%; line-height: 0.8; } 
 .Clock.Period.NameNumber.Small { left: 29%; width: 12%; } 

--- a/html/views/standard/index.html
+++ b/html/views/standard/index.html
@@ -9,7 +9,9 @@
     sbPrefix="&: ScoreBoard.Settings.Setting(ScoreBoard.View : )"
     sbClass="box_flat: &_BoxStyle: dspIsFlat | bright: &_BoxStyle: dspIsBright | PenaltyClocks: &_HidePenaltyClocks: !"
   >
-    <div class="DisplayPane" id="image"><img class="object" sbAttr="src: &_Image" sbCss="object-fit: &_ImageScaling" /></div>
+    <div class="DisplayPane" id="image">
+      <img class="object" sbAttr="src: &_Image" sbCss="object-fit: &_ImageScaling" />
+    </div>
     <div class="DisplayPane" id="video">
       <video class="object" onended="this.play();" sbAttr="src: &_Video" sbCss="object-fit: &_VideoScaling"></video>
     </div>
@@ -44,11 +46,7 @@
             sbClass="InBox:PenaltyTime: > 0 | sbHide: ^StarPass: dspIsJamming"
           ></div>
         </div>
-        <div
-          class="JamScore Box AutoFit"
-          sbDisplay="JamScore"
-          sbClass="NoInitial: NoInitial | Overtime: /ScoreBoard.CurrentGame.InOvertime"
-        ></div>
+        <div class="JamScore Box AutoFit" sbDisplay="JamScore" sbClass="NoInitial: NoInitial | Overtime: /ScoreBoard.CurrentGame.InOvertime"></div>
         <div class="ShowInJam Clock StarPass AutoFit" sbDisplay="StarPass: sbToSP"></div>
         <div class="DotTimeouts Box" sbCss="background: Color(scoreboard_dots.bg)">
           <div class="Dot Timeout1" sbClass="Used: Timeouts: <1" sbCss="background: Color(scoreboard_dots.fg)"></div>
@@ -99,37 +97,42 @@
 
       <!-- Lineup / Timeout / No Clocks Running -->
       <div
-        class="ShowInLineup ShowInTimeout Clock Period Small Time Box AutoFit"
+        class="ShowInLineup ShowInTimeout ShowInSecondLineup Clock Period Small Time Box AutoFit"
         sbContext="Clock(Period)"
         sbDisplay="Time, Direction: sbToTime"
       ></div>
       <div class="ShowInNoClock Clock Period Small Time Box AutoFit"></div>
       <div
-        class="ShowInLineup ShowInTimeout ShowInNoClock Clock Period Small NameNumber Box AutoFit"
+        class="ShowInLineup ShowInTimeout ShowInSecondLineup ShowInNoClock Clock Period Small NameNumber Box AutoFit"
         sbDisplay="Clock(Period).Name,Clock(Period).Number,Rule(Period.Number): sbToClockInitialNumber"
       ></div>
       <div
-        class="ShowInLineup ShowInTimeout Clock Jam Small NameNumber Box AutoFit"
+        class="ShowInLineup ShowInTimeout ShowInSecondLineup Clock Jam Small NameNumber Box AutoFit"
         sbContext="Clock(Jam)"
         sbDisplay="Name,Number: sbToClockInitialNumber"
       ></div>
       <div class="ShowInLineup Clock Description Small Box AutoFit">Lineup</div>
       <div
-        class="ShowInTimeout Clock Description Small Box AutoFit"
-        sbDisplay="TimeoutOwner, OfficialReview, Clock(Lineup).Running: sbToTimeoutType"
-        sbClass="Red: Clock(Lineup).Running: !"
+        class="ShowInTimeout ShowInSecondLineup Clock Description Small Box AutoFit Red"
+        sbDisplay="TimeoutOwner, OfficialReview: sbToTimeoutType"
       ></div>
       <div
-        class="ShowInLineup Clock Lineup Small Box AutoFit"
+        class="ShowInLineup ShowInSecondLineup Clock Lineup Small Box AutoFit"
         sbDisplay="Clock(Lineup).Time, Clock(Lineup).Direction: sbToTime"
         sbClass="Red: NoMoreJam"
       ></div>
       <div
-        class="ShowInTimeout Clock Timeout Small Box AutoFit"
+        class="ShowInTimeout ShowInSecondLineup Clock Timeout Small Box AutoFit"
         sbDisplay="Clock(Timeout).Time, Clock(Timeout).Direction: sbToTime"
         sbClass="Red: NoMoreJam"
       ></div>
       <div class="ShowInNoClock Clock None Small Box AutoFit">Coming Up</div>
+      <div class="ShowInSecondLineup Clock Description Small Below Box AutoFit">Lineup</div>
+      <div
+        class="ShowInSecondLineup Clock Lineup Small Below Box AutoFit"
+        sbDisplay="Clock(Lineup).Time, Clock(Lineup).Direction: sbToTime"
+        sbClass="Red: NoMoreJam"
+      ></div>
 
       <!-- Sponsor Banners -->
       <div class="ShowInTimeout ShowInLineup ShowInNoClock Clock" sbClass="sbHide: &_HideBanners" id="SponsorBox">

--- a/src/com/carolinarollergirls/scoreboard/core/interfaces/Game.java
+++ b/src/com/carolinarollergirls/scoreboard/core/interfaces/Game.java
@@ -184,6 +184,6 @@ public interface Game extends ScoreBoardEventProvider {
     public static final String ACTION_LINEUP = "Lineup";
     public static final String ACTION_TIMEOUT = "Timeout";
     public static final String ACTION_RE_TIMEOUT = "New Timeout";
-    public static final String ACTION_OVERTIME = "Overtime";
+    public static final String ACTION_OVERTIME = "Overtime Lineup";
     public static final String UNDO_PREFIX = "Un-";
 }

--- a/src/com/carolinarollergirls/scoreboard/rules/Rule.java
+++ b/src/com/carolinarollergirls/scoreboard/rules/Rule.java
@@ -35,10 +35,10 @@ public enum Rule {
     TTO_DURATION(new TimeRule("Timeout.TeamTODuration", "Duration of a team timeout", "1:00")),
     TIMEOUT_DIRECTION(new BooleanRule("Timeout.ClockDirection", "Which way should the timeout clock count?", false,
                                       "Count Down", "Count Up")),
-    STOP_PC_ON_TO(new BooleanRule(
-        "Timeout.StopPeriodClockAlways",
-        "Stop the period clock on every timeout? If false, the options below control the behaviour per type of timeout.",
-        true, "True", "False")),
+    STOP_PC_ON_TO(new BooleanRule("Timeout.StopPeriodClockAlways",
+                                  "Stop the period clock on every timeout? If false, the options below control the " +
+                                  "behaviour per type of timeout.",
+                                  true, "True", "False")),
     STOP_PC_ON_OTO(new BooleanRule("Timeout.StopPeriodClockOnOTO", "Stop the period clock on official timeouts?", false,
                                    "True", "False")),
     STOP_PC_ON_TTO(new BooleanRule("Timeout.StopPeriodClockOnTTO", "Stop the period clock on team timeouts?", false,
@@ -53,6 +53,9 @@ public enum Rule {
         false, "True", "False")),
     TO_JAM(new BooleanRule("Timeout.JamDuring", "Allow a jam to happen with stopped period clock?", false, "True",
                            "False")),
+    NO_TO_CLOCK_STOP(new BooleanRule("Timeout.NoClockStop",
+                                     "Should the timeout clock continue to run after the end of a timeout?", true,
+                                     "True", "False")),
 
     INTERMISSION_DURATIONS(new StringRule(
         "Intermission.Durations",
@@ -70,22 +73,23 @@ public enum Rule {
                                        "Are official reviews granted per period or per game?", true, "Period", "Game")),
     NUMBER_RETAINS(new IntegerRule("Team.MaxRetains",
                                    "How many times per game or period a team can retain an official review", 1)),
-    RDCL_PER_HALF_RULES(new BooleanRule(
-        "Team.RDCLPerHalfRules",
-        "Restrict one TTO to the first two periods and one to the rest of the game. Stretch per period ORs to first two resp. all other periods.",
-        false, "Enabled", "Disabled")),
-    WFTDA_LATE_SCORE_RULE(new BooleanRule(
-        "Score.WftdaLateChangeRule",
-        "Score changes after the end of the following jam don't affect the game score. With less than 2 minutes left in the game this applies to changes after the next jam starts.",
-        true, "Enabled", "Disabled")),
+    RDCL_PER_HALF_RULES(new BooleanRule("Team.RDCLPerHalfRules",
+                                        "Restrict one TTO to the first two periods and one to the rest of the game. " +
+                                        "Stretch per period ORs to first two resp. all other periods.",
+                                        false, "Enabled", "Disabled")),
+    WFTDA_LATE_SCORE_RULE(
+        new BooleanRule("Score.WftdaLateChangeRule",
+                        "Score changes after the end of the following jam don't affect the game score. With less " +
+                        "than 2 minutes left in the game this applies to changes after the next jam starts.",
+                        true, "Enabled", "Disabled")),
 
     PENALTIES_FILE(new StringRule("Penalties.DefinitionFile",
                                   "File that contains the penalty code definitions to be used",
                                   "/config/penalties/wftda2018.json")),
-    FO_LIMIT(new IntegerRule(
-        "Penalties.NumberToFoulout",
-        "After how many penalties a skater has fouled out of the game. Note that the software currently does not support more than 9 penalties per skater.",
-        7)),
+    FO_LIMIT(new IntegerRule("Penalties.NumberToFoulout",
+                             "After how many penalties a skater has fouled out of the game. Note that the software " +
+                             "currently does not support more than 9 penalties per skater.",
+                             7)),
     PENALTY_DURATION(new TimeRule("Penalties.Duration", "How long does a penalty last.", "0:30"));
 
     private Rule(RuleDefinition r) { rule = r; }

--- a/tests/com/carolinarollergirls/scoreboard/core/game/GameImplTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/core/game/GameImplTests.java
@@ -526,7 +526,7 @@ public class GameImplTests {
         jc.setTime(45000);
         assertEquals(22, jc.getNumber());
         assertTrue(lc.isRunning());
-        assertFalse(tc.isRunning());
+        assertTrue(tc.isRunning());
         assertFalse(ic.isRunning());
 
         g.startJam();
@@ -752,13 +752,18 @@ public class GameImplTests {
         assertFalse(jc.isRunning());
         assertTrue(lc.isRunning());
         assertTrue(lc.isTimeAtStart());
-        assertFalse(tc.isRunning());
+        assertTrue(tc.isRunning());
         assertEquals(4, tc.getNumber());
         assertFalse(ic.isRunning());
-        assertEquals(Timeout.Owners.NONE, g.getTimeoutOwner());
-        assertFalse(g.isOfficialReview());
+        assertEquals(Timeout.Owners.OTO, g.getTimeoutOwner());
+        assertTrue(g.isOfficialReview());
         checkLabels(Game.ACTION_START_JAM, Game.ACTION_NONE, Game.ACTION_TIMEOUT,
                     Game.UNDO_PREFIX + Game.ACTION_STOP_TO);
+
+        g.startJam();
+
+        assertEquals(Timeout.Owners.NONE, g.getTimeoutOwner());
+        assertFalse(g.isOfficialReview());
     }
 
     @Test
@@ -966,14 +971,14 @@ public class GameImplTests {
 
     @Test
     public void testTimeout_fromTimeout() {
+        g.setTimeoutType(Timeout.Owners.OTO, false);
+        tc.setTime(24000);
+        tc.setNumber(7);
         assertFalse(pc.isRunning());
         assertFalse(jc.isRunning());
         assertFalse(lc.isRunning());
-        tc.start();
-        tc.setTime(24000);
-        tc.setNumber(7);
+        assertTrue(tc.isRunning());
         assertFalse(ic.isRunning());
-        g.setTimeoutOwner(Timeout.Owners.OTO);
 
         g.timeout();
 
@@ -1688,7 +1693,7 @@ public class GameImplTests {
         assertFalse(pc.isRunning());
         assertFalse(jc.isRunning());
         assertTrue(lc.isRunning());
-        assertFalse(tc.isRunning());
+        assertFalse(g.getCurrentTimeout().isRunning());
         assertFalse(ic.isRunning());
         checkLabels(Game.ACTION_START_JAM, Game.ACTION_NONE, Game.ACTION_TIMEOUT,
                     Game.UNDO_PREFIX + Game.ACTION_STOP_TO);


### PR DESCRIPTION
Add ruleset option that lets the timeout clock continue at the end of a timeout until start of the jam; enable it by default for compliance with officiating procedures.
While timeout and lineup clock run in parallel show both on the main display for compliance with rules.

closes #812
closes #810