### PR TITLE
Add tooltips to buttons with dynamic visibility support

### DIFF
--- a/html/components/sk-input/index.html
+++ b/html/components/sk-input/index.html
@@ -29,14 +29,17 @@
   <div class="sbGroup sbStack">
     <div class="ScoreRow">
       <div class="sbStack">
-        <button
-          class="sbKeyControl sbImportant"
-          sbAttr="id:-: 'Team[Team]ScoreDown'"
-          sbProp="disabled: TripScore: == 0"
-          sbSet="TripScore: -1: change"
-        >
-          Trip Pts -1
-        </button>
+        <span class="tooltip">
+          <button
+            class="sbKeyControl sbImportant"
+            sbAttr="id:-: 'Team[Team]ScoreDown'"
+            sbProp="disabled: TripScore: == 0"
+            sbSet="TripScore: -1: change"
+          >
+            Trip Pts -1
+          </button>
+          <span class="tooltiptext">Remove 1 point from current trip. Use numbered buttons below to override current points for this trip.</span>
+        </span>
         <button class="sbKeyControl" sbAttr="id:-: 'Team[Team]RemoveTrip'" sbProp="disabled: NoInitial" sbSet="RemoveTrip">
           Remove Trip
         </button>
@@ -47,17 +50,48 @@
       </div>
       <span class="sbVeryVeryImportant" sbDisplay="Score"></span>
       <div class="sbStack">
-        <button class="sbKeyControl sbImportant" sbAttr="id:-: 'Team[Team]ScoreUp'" sbSet="TripScore: +1: change">Trip Pts +1</button>
-        <button class="sbKeyControl" sbAttr="id:-: 'Team[Team]AddTrip'" sbSet="AddTrip">Add Trip</button>
+        <span class="tooltip">
+          <button class="sbKeyControl sbImportant" sbAttr="id:-: 'Team[Team]ScoreUp'" sbSet="TripScore: +1: change">Trip Pts +1</button>
+          <span class="tooltiptext">Add 1 to current trip points. Use numbered buttons below to override existing points instead of appending.</span>
+        </span>
+        <span class="tooltip">
+          <button class="sbKeyControl" sbAttr="id:-: 'Team[Team]AddTrip'" sbSet="AddTrip">Add Trip</button>
+          <span class="tooltiptext">Log current jammer having passed the pack.</span>
+        </span>
       </div>
     </div>
     <div class="ScoreRow">
       <span>Set Trip Pts</span>
-      <button class="sbKeyControl" sbAttr="id:-:'Team[Team]TripScore0'" sbSet="TripScore: 0">0</button>
-      <button class="sbKeyControl" sbAttr="id:-:'Team[Team]TripScore1'" sbSet="TripScore: 1">1</button>
-      <button class="sbKeyControl" sbAttr="id:-:'Team[Team]TripScore2'" sbSet="TripScore: 2">2</button>
-      <button class="sbKeyControl" sbAttr="id:-:'Team[Team]TripScore3'" sbSet="TripScore: 3">3</button>
-      <button class="sbKeyControl" sbAttr="id:-:'Team[Team]TripScore4'" sbSet="TripScore: 4">4</button>
+      <span class="tooltip">
+        <button class="sbKeyControl" sbAttr="id:-:'Team[Team]TripScore0'" sbSet="TripScore: 0">0</button>
+        <span class="tooltiptext">
+          Set Trip Pts to 0 (overrides any existing value).
+        </span>
+      </span>
+      <span class="tooltip">
+        <button class="sbKeyControl" sbAttr="id:-:'Team[Team]TripScore1'" sbSet="TripScore: 1">1</button>
+        <span class="tooltiptext">
+          Set Trip Pts to 1 (overrides any existing value).
+        </span>
+      </span>
+      <span class="tooltip">
+        <button class="sbKeyControl" sbAttr="id:-:'Team[Team]TripScore2'" sbSet="TripScore: 2">2</button>
+        <span class="tooltiptext">
+          Set Trip Pts to 2 (overrides any existing value).
+        </span>
+      </span>
+      <span class="tooltip">
+        <button class="sbKeyControl" sbAttr="id:-:'Team[Team]TripScore3'" sbSet="TripScore: 3">3</button>
+        <span class="tooltiptext">
+          Set Trip Pts to 3 (overrides any existing value).
+        </span>
+      </span>
+      <span class="tooltip">
+        <button class="sbKeyControl" sbAttr="id:-:'Team[Team]TripScore4'" sbSet="TripScore: 4">4</button>
+        <span class="tooltiptext">
+          Set Trip Pts to 4 (overrides any existing value).
+        </span>
+      </span>
     </div>
   </div>
   <div class="sbGroup sbShowOnOperator Timeouts">

--- a/html/json/core.js
+++ b/html/json/core.js
@@ -68,3 +68,15 @@ const theme = new URL(window.location).searchParams.get('theme');
 if (theme) {
   _include(theme);
 }
+
+$(document).keydown(function (event) {
+  if (event.key === 'Control') {
+    $(".tooltiptext").addClass('modifierPressed');
+  }
+})
+
+$(document).keyup(function (event) {
+  if (event.key === 'Control') {
+    $(".tooltiptext").removeClass('modifierPressed')
+  }
+})

--- a/html/styles/common.css
+++ b/html/styles/common.css
@@ -164,3 +164,30 @@ body:not(.sbNoConnectionStatus) #sbConnectionStatus:not([status="ready"]) { disp
     transform: translate3d(-50%, -50%, 0);
     will-change: transform;
 }
+
+.tooltip {
+    position: relative;
+    display: inline-block;
+    border-bottom: 1px dotted black;
+}
+
+.tooltip .tooltiptext {
+    visibility: hidden;
+    opacity: 0;
+    transition: visibility 0.2s, opacity 0.5s;
+    width: 160px;
+    background-color: black;
+    color: #fff;
+    text-align: center;
+    border-radius: 6px;
+    padding: 5px 0;
+
+    /* Position the tooltip */
+    position: absolute;
+    z-index: 1000;
+}
+
+.tooltip:hover .tooltiptext.modifierPressed {
+    visibility: visible;
+    opacity: 1;
+}


### PR DESCRIPTION
I was taking a look at https://github.com/rollerderby/scoreboard/issues/405 and thought that a decent middle ground on solving this is instead of adding a new button to hold a variable that will dictate whether to show tooltips, we could instead use hovering while holding a modifier key on the keyboard to control that display logic.

This PR adds integrated tooltips across score control buttons to provide contextual guidance to users, but only when the `Control` key is being held & the user is actively hovering over an element with the class `tooltip` that has a child element with the class `tooltiptext`. I couldn't add the `tooltiptext` span directly as a child of the `button` or the button's display rules interfere with getting the tooltip to show up on top of the other elements on the page.

Notes: 

Because of the way browsers detect key presses, the user will have had to interact with the page in some format before the control + hover functionality will work. This could be pressing a button or even just clicking anywhere on the page.

I am in zero way tied to _where_ this javascript code should live nor what the styling should be, so please feel free to adjust that or make suggestions on what changes I should make!

And finally, I only added a few tooltip texts because I'm still learning how to use this program and am the prime audience for _needing_ these help bubbles!

![image](https://github.com/user-attachments/assets/f853d567-28d8-4163-a751-629b0693e766)

