### PR TITLE
Less pessimistic recompiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *~
 
+.DS_Store
 bin
 test-bin
 release

--- a/build.xml
+++ b/build.xml
@@ -95,14 +95,14 @@
 		<mkdir dir="${dest.dir}"/>
 		<mkdir dir="html/images/teamlogo" />
 		<mkdir dir="html/images/sponsor_banner" />
-		<javac srcdir="."
+		<javac srcdir="${src.dir}"
 			destdir="${dest.dir}"
 			deprecation="${compile.deprecation}"
 			debug="${compile.debug}"
 			verbose="${compile.verbose}"
 			nowarn="${compile.nowarn}"
 			includeAntRuntime="false"
-			includes="${src.dir}/com/carolinarollergirls/scoreboard/**" >
+			includes="com/carolinarollergirls/scoreboard/**" >
 
 			<compilerarg value="-Xlint:all"/>
 			<compilerarg value="-Xlint:-serial"/>


### PR DESCRIPTION
Don't compile .class files that are already up to date.
    
Setting srcdir to ${src.dir} and using a relative path to the includes
seems to solve the overly pessimistic dependency checks.