### PR TITLE
Fix macos unittest probs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *~
 
+.DS_Store
 bin
 test-bin
 release

--- a/build.xml
+++ b/build.xml
@@ -95,14 +95,14 @@
 		<mkdir dir="${dest.dir}"/>
 		<mkdir dir="html/images/teamlogo" />
 		<mkdir dir="html/images/sponsor_banner" />
-		<javac srcdir="."
+		<javac srcdir="${src.dir}"
 			destdir="${dest.dir}"
 			deprecation="${compile.deprecation}"
 			debug="${compile.debug}"
 			verbose="${compile.verbose}"
 			nowarn="${compile.nowarn}"
 			includeAntRuntime="false"
-			includes="${src.dir}/com/carolinarollergirls/scoreboard/**" >
+			includes="com/carolinarollergirls/scoreboard/**" >
 
 			<compilerarg value="-Xlint:all"/>
 			<compilerarg value="-Xlint:-serial"/>

--- a/tests/com/carolinarollergirls/scoreboard/core/admin/MediaImplTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/core/admin/MediaImplTests.java
@@ -28,6 +28,11 @@ import com.carolinarollergirls.scoreboard.utils.BasePath;
 
 public class MediaImplTests {
 
+    // In general Java's macOS implementation takes longer for file system notifications.
+    private static final int secondsToWait = (System.getProperty("os.name").toLowerCase().matches("^mac.*os.*$")
+                                              ? 10 
+                                              : 1);
+
     private Media media;
     private File init;
 
@@ -75,8 +80,8 @@ public class MediaImplTests {
     @Test
     public void testFileDeletionManual() throws Exception {
         init.delete();
-        ScoreBoardEvent<?> e = collectedEvents.poll(1, TimeUnit.SECONDS); // batch start
-        e = collectedEvents.poll(1, TimeUnit.SECONDS);
+        ScoreBoardEvent<?> e = collectedEvents.poll(secondsToWait, TimeUnit.SECONDS); // batch start
+        e = collectedEvents.poll(secondsToWait, TimeUnit.SECONDS);
         assertNotNull(e);
         assertEquals(MediaType.FILE, e.getProperty());
         assertTrue(e.isRemove());
@@ -86,8 +91,8 @@ public class MediaImplTests {
     @Test
     public void testFileDeletion() throws Exception {
         assertTrue(media.removeMediaFile("images", "teamlogo", "init.png"));
-        ScoreBoardEvent<?> e = collectedEvents.poll(1, TimeUnit.SECONDS); // batch start
-        e = collectedEvents.poll(1, TimeUnit.SECONDS);
+        ScoreBoardEvent<?> e = collectedEvents.poll(secondsToWait, TimeUnit.SECONDS); // batch start
+        e = collectedEvents.poll(secondsToWait, TimeUnit.SECONDS);
         assertNotNull(e);
         assertEquals(MediaType.FILE, e.getProperty());
         assertTrue(e.isRemove());
@@ -97,7 +102,7 @@ public class MediaImplTests {
     @Test
     public void testFileCreation() throws Exception {
         dir.newFile("html/images/teamlogo/new.png");
-        ScoreBoardEvent<?> e = collectedEvents.poll(1, TimeUnit.SECONDS);
+        ScoreBoardEvent<?> e = collectedEvents.poll(secondsToWait, TimeUnit.SECONDS);
         assertNotNull(e);
         assertEquals(ScoreBoardEventProviderImpl.BATCH_START, e.getProperty());
         e = collectedEvents.poll(1, TimeUnit.SECONDS);


### PR DESCRIPTION
The system failed unit tests on macOS.  This was traced to the fact 
that Java's macOS implementation uses polling, not the Mac equivalent 
of Linux's inotify.  To make matters worse, the macOS implementation 
only checks every 10 seconds for file system changes. 

The timeouts when on macOS have been bumped up to 10 seconds. 