### PR TITLE
Allow for easier font customisation in custom themes

### DIFF
--- a/html/external/jquery-ui/jquery-ui.theme.css
+++ b/html/external/jquery-ui/jquery-ui.theme.css
@@ -15,14 +15,14 @@
 /* Component containers
 ----------------------------------*/
 .ui-widget {
-	font-family: 'LiberationSans',sans-serif;
+	font-family: var(--font-family);
 	font-size: 1em;
 }
 .ui-widget input,
 .ui-widget select,
 .ui-widget textarea,
 .ui-widget button {
-	font-family: 'LiberationSans',sans-serif;
+	font-family: var(--font-family);
 	font-size: 1em;
 }
 .ui-widget.ui-widget-content {

--- a/html/styles/fonts.css
+++ b/html/styles/fonts.css
@@ -1,4 +1,10 @@
 @font-face {font-family: 'LiberationSans'; src: url("/fonts/LiberationSans-Regular.ttf") format("truetype");} 
 @font-face {font-family: 'LiberationSans'; src: url("/fonts/LiberationSans-Bold.ttf") format("truetype"); font-weight: bold;} 
 
-body { font-family: 'LiberationSans', sans-serif; } 
+:root {
+    --font-family: 'LiberationSans', 'system-ui', sans-serif;
+}
+
+body {
+    font-family: var(--font-family);
+}


### PR DESCRIPTION
This PR adds a css variable for `--font-family` which allows easier overriding in a single place.

Usage in example theme: 

```css
@import url('https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap');

:root {
    --font-family: Inter, sans-serif;
    font-feature-settings: 'liga' 1, 'calt' 1; /* fix for Chrome */
    font-variant-numeric: tabular-nums;
}

@supports (font-variation-settings: normal) {
    :root {
        --font-family: InterVariable, sans-serif;
    }
}
```