### PR TITLE
Selecting Role for a Stored Official for a game doesn't enable 'Add' Button

### DIFF
--- a/html/components/igrf-tab/index.html
+++ b/html/components/igrf-tab/index.html
@@ -191,7 +191,7 @@
       </tr>
       <tr class="AddPreparedOfficial sbSubHeader">
         <th colspan="2">
-          <select class="Prepared">
+          <select class="Prepared" sbOn="change: igrfUpdateAddButton">
             <option value="">Select Stored Official</option>
             <option
               sbContext="/ScoreBoard"


### PR DESCRIPTION
Fixes #858

I haven't mad any changes to the 'Role' select or the igrfUpdateAddButton as I wanted to confirm exactly what the intended behaviour was first.

At the moment (no changes) the function checks the Name field and Prepared Official select for changes, if changes are found then the Add button will enable.

Although no bug occurs, logically it feels more correct to have either of those two (as current) **AND** a Role entered before the 'Add' button is enabled.

This would require some changes to the JavaScript file which I am happy to make however wanted to confirm if this was desired functionality before making the change.

I fly out to the RDWC tomorrow (1st) so will review any comments when I'm back