### PR TITLE
various timeout related enhancements

### DIFF
--- a/html/components/settings-tab/index.html
+++ b/html/components/settings-tab/index.html
@@ -65,7 +65,14 @@
     </div>
     <div class="sbGroup View DisplayOptions" sbPrefix="$:ScoreBoard.Settings.Setting(ScoreBoard.View:)">
       <span></span>
-      <span></span>
+      <span>
+        <label>Clock After Timeout: </label>
+        <select sbControl="$_ClockAfterTimeout" ApplyPreview="ClockAfterTimeout">
+          <option value="Both">Both</option>
+          <option value="Timeout">Timeout</option>
+          <option value="Lineup">Lineup</option>
+        </select>
+      </span>
       <span>
         <label>Current View: </label>
         <select sbControl="$_CurrentView" ApplyPreview="CurrentView">

--- a/html/components/sk-input/index.css
+++ b/html/components/sk-input/index.css
@@ -1,6 +1,7 @@
 /* mirror team 2 */
 body:not([showTeam="2"]) [Team] ~ [Team]>.SkInput>.sbGroup:not(.sbStack)  { flex-direction: row-reverse; }
 body:not([showTeam="2"]) [Team] ~ [Team]>.SkInput .ScoreRow  { flex-direction: row-reverse; }
+body:not([showTeam="2"]) [Team] ~ [Team]>.SkInput .Timeouts > span  { flex-direction: row-reverse; }
 
 /* name/logo row */
 .SkInput img.Logo { height: 50px; max-width: 200px; }
@@ -9,7 +10,11 @@ body:not([showTeam="2"]) [Team] ~ [Team]>.SkInput .ScoreRow  { flex-direction: r
 .SkInput .sbGroup.Name>div.Name { flex: 3 0 content; }
 
 /* timeout row */
-.SkInput .Timeouts > * { flex: 1; }
+.SkInput .Timeouts > div { flex: 1; }
+.SkInput .Timeouts > span { flex: 5; display: flex; height: fit-content; }
+.SkInput .Timeouts > span.OR { border-right: var(--group-border-top); border-left: var(--group-border-top); padding-left: .5em; padding-right: .5em; }
+.SkInput .Timeouts > span > .ToNumber { flex: 1; align-self: center; height: fit-content; }
+.SkInput .Timeouts > span > .ToButton { flex: 2; align-self: center; height: fit-content; z-index: 1 }
 .SkInput .Timeouts { position: relative; }
 .SkInput .OfficialTimeout>div { position: absolute; right: calc(50% + (0.5 * var(--segment-gap))); width: 100%; }
 .SkInput .OfficialTimeout button { transform: translateY(-50%) var(--button-transform); }

--- a/html/components/sk-input/index.html
+++ b/html/components/sk-input/index.html
@@ -37,9 +37,7 @@
         >
           Trip Pts -1
         </button>
-        <button class="sbKeyControl" sbAttr="id:-: 'Team[Team]RemoveTrip'" sbProp="disabled: NoInitial" sbSet="RemoveTrip">
-          Remove Trip
-        </button>
+        <button class="sbKeyControl" sbAttr="id:-: 'Team[Team]RemoveTrip'" sbProp="disabled: NoInitial" sbSet="RemoveTrip">Remove Trip</button>
       </div>
       <div class="sbStack">
         <span>Jam Pts: <span class="sbImportant" sbDisplay="JamScore"></span></span>
@@ -61,30 +59,44 @@
     </div>
   </div>
   <div class="sbGroup sbShowOnOperator Timeouts">
-    <button
-      class="sbKeyControl"
-      sbAttr="id:-:'Team[Team]Timeout'"
-      sbClass="sbActive: Id,^TimeoutOwner, ^OfficialReview: sbIsToThisTeam"
-      sbSet="Timeout"
-    >
-      Team TO
-    </button>
-    <span class="sbVeryImportant" sbDisplay="Timeouts" sbCall="opOpenTimeoutDialog"></span>
-    <button
-      class="sbKeyControl"
-      sbAttr="id:-:'Team[Team]OfficialReview'"
-      sbClass="sbActive: Id,^TimeoutOwner, ^OfficialReview: sbIsOrThisTeam"
-      sbSet="OfficialReview"
-    >
-      Off Review
-    </button>
-    <span class="sbVeryImportant" sbDisplay="OfficialReviews" sbCall="opOpenTimeoutDialog"></span>
-    <button class="sbKeyControl" sbAttr="id:-:'Team[Team]RetainedOfficialReview'" sbToggle="RetainedOfficialReview">Retained</button>
+    <span>
+      <button
+        class="sbKeyControl ToButton"
+        sbAttr="id:-:'Team[Team]Timeout'"
+        sbClass="sbActive: Id,^TimeoutOwner, ^OfficialReview: sbIsToThisTeam"
+        sbSet="Timeout"
+      >
+        Team TO
+      </button>
+      <span class="sbVeryImportant ToNumber" sbDisplay="Timeouts" sbCall="opOpenTimeoutDialog"></span>
+    </span>
+    <span class="OR">
+      <span class="sbStack ToButton">
+        <button
+          class="sbKeyControl"
+          sbAttr="id:-:'Team[Team]OfficialReview'"
+          sbClass="sbActive: Id,^TimeoutOwner, ^OfficialReview: sbIsOrThisTeam"
+          sbSet="OfficialReview"
+        >
+          Off Review
+        </button>
+        <span>
+          <button
+            class="sbKeyControl"
+            sbAttr="id:-:'Team[Team]OrAsTo'"
+            sbClass="sbHide: Id,^TimeoutOwner, ^OfficialReview: sbIsNotOrThisTeam"
+            sbToggle="^ReviewIsTo"
+          >
+            As TO
+          </button>
+          <button class="sbKeyControl" sbAttr="id:-:'Team[Team]RetainedOfficialReview'" sbToggle="RetainedOfficialReview">Retained</button>
+        </span>
+      </span>
+      <span class="sbVeryImportant ToNumber OR" sbDisplay="OfficialReviews" sbCall="opOpenTimeoutDialog"></span>
+    </span>
     <div class="OfficialTimeout">
       <div>
-        <button class="sbKeyControl" id="OfficialTimeout" sbClass="sbActive: ^TimeoutOwner: ==='O'" sbSet="^OfficialTimeout">
-          Official Timeout
-        </button>
+        <button class="sbKeyControl" id="OfficialTimeout" sbClass="sbActive: ^TimeoutOwner: ==='O'" sbSet="^OfficialTimeout">Official Timeout</button>
       </div>
     </div>
   </div>
@@ -105,9 +117,7 @@
     <span
       >Jammer:
       <span sbButtonGroup>
-        <button class="sbKeyControl" sbAttr="Id:-: 'Team[Team]JammerNone'" sbClass="sbActive: p.Skater: sbIsEmpty" sbSet="p.Skater: ''">
-          ?
-        </button>
+        <button class="sbKeyControl" sbAttr="Id:-: 'Team[Team]JammerNone'" sbClass="sbActive: p.Skater: sbIsEmpty" sbSet="p.Skater: ''">?</button>
         <button
           class="sbKeyControl"
           sbForeach="Skater:: rosterNumber: resort=RosterNumber,onInsert=skiSetupKey"
@@ -131,9 +141,7 @@
     <span
       >Piv/4th Bl:
       <span sbButtonGroup>
-        <button class="sbKeyControl" sbAttr="Id:-: 'Team[Team]PivotNone'" sbClass="sbActive: p.Skater: sbIsEmpty" sbSet="p.Skater: ''">
-          ?
-        </button>
+        <button class="sbKeyControl" sbAttr="Id:-: 'Team[Team]PivotNone'" sbClass="sbActive: p.Skater: sbIsEmpty" sbSet="p.Skater: ''">?</button>
         <button
           class="sbKeyControl"
           sbForeach="Skater:: rosterNumber: resort=RosterNumber,onInsert=skiSetupKey"

--- a/html/javascript/boolconversions.js
+++ b/html/javascript/boolconversions.js
@@ -51,6 +51,14 @@ function sbIsOrThisTeam(k, v) {
   return v === WS.state[prefix + '.TimeoutOwner'] && isTrue(WS.state[prefix + '.OfficialReview']);
 }
 
+function sbIsNotToThisTeam(k, v) {
+  return !sbIsToThisTeam(k, v);
+}
+
+function sbIsNotOrThisTeam(k, v) {
+  return !sbIsOrThisTeam(k, v);
+}
+
 function sbIsOnTrackRole(k, v) {
   return v === 'Jammer' || v === 'Pivot' || v === 'Blocker';
 }

--- a/html/javascript/utils.js
+++ b/html/javascript/utils.js
@@ -16,28 +16,40 @@ function sbCloseDialogIfNull(k, v, elem) {
   }
 }
 
-function sbClockSelect(k) {
-  var jam = isTrue(WS.state[k.upTo('Game') + '.InJam']);
-  var timeout = isTrue(WS.state[k.upTo('Game') + '.Clock(Timeout).Running']);
-  var lineup = isTrue(WS.state[k.upTo('Game') + '.Clock(Lineup).Running']);
-  var secondLineup = lineup && timeout;
-  var intermission = isTrue(WS.state[k.upTo('Game') + '.Clock(Intermission).Running']);
+function _sbClockSelect(game, setting) {
+  var jam = isTrue(WS.state[game + '.InJam']);
+  var timeout = isTrue(WS.state[game + '.Clock(Timeout).Running']);
+  var lineup = isTrue(WS.state[game + '.Clock(Lineup).Running']);
+  var postTimeout = lineup && timeout;
+  var postTimeoutClock = WS.state['ScoreBoard.Settings.Setting(' + setting + ')'];
+  var intermission = isTrue(WS.state[game + '.Clock(Intermission).Running']);
+  var final = isTrue(WS.state[game + '.OfficialScore']);
+  var clockDuringFinal = isTrue(WS.state[game + '.ClockDuringFinalScore']);
 
   var clock = 'NoClock';
+  var betweenJams = false;
   if (jam) {
     clock = 'Jam';
-  } else if (secondLineup) {
-    clock = "SecondLineup"
+  } else if (postTimeout) {
+    clock = "PostTimeout" + postTimeoutClock;
+    betweenJams = true;
   } else if (lineup) {
     clock = 'Lineup';
+    betweenJams = true;
   } else if (timeout) {
     clock = 'Timeout';
+    betweenJams = true;
   } else if (intermission) {
-    clock = 'Intermission';
+    if (final && !clockDuringFinal) {
+      clock = 'Final';
+    } else {
+      clock = 'Intermission';
+    }
   }
 
   $('.Clock,.SlideDown').removeClass('Show');
   $('.ShowIn' + clock).addClass('Show');
+  if (betweenJams) { $('.ShowInBetweenJams').addClass('Show'); }
 }
 
 function sbSetActiveTimeout(k) {

--- a/html/views/overlay/admin/index.html
+++ b/html/views/overlay/admin/index.html
@@ -15,8 +15,7 @@
         <h2>Elements</h2>
         <button data-key="C" sbToggle="$.Clock" class="ToggleSwitch">Clock [C]</button>
         <button data-key="S" sbToggle="$.Score" class="ToggleSwitch">Score [S]</button>
-        <button data-key="J" sbToggle="$.ShowJammers" sbClass="disabled: l,$.ShowLineups: ovaLineups" class="ToggleSwitch">
-          Show Jammers [J]</button
+        <button data-key="J" sbToggle="$.ShowJammers" sbClass="disabled: l,$.ShowLineups: ovaLineups" class="ToggleSwitch">Show Jammers [J]</button
         ><br />
         <button data-key="L" sbToggle="$.ShowLineups" sbClass="disabled: l: !" class="ToggleSwitch">Full Lineups [L]</button><br />
         <button data-key="N" sbToggle="$.ShowNames" sbClass="disabled: l,$.ShowLineups,$.ShowJammers: ovaNobody" class="ToggleSwitch">
@@ -72,6 +71,16 @@
           </div>
         </div>
       </div>
+      <div id="TeamOptions" class="Panel" sbContext="ScoreBoard.CurrentGame">
+        <h2>Team Display</h2>
+        <div sbForeach="Team: 1,2: only">
+          <input sbControl="AlternateName(overlay),Name:: sbToNullIfEmpty" type="text" />
+          <input sbControl="Color(overlay.fg): ovaDefaultFgIfNull" type="color" sbClass="Cleared: Color(overlay.fg): ==null" />
+          <button class="ClearPrev" sbSet="Color(overlay.fg): null">X</button>
+          <input sbControl="Color(overlay.bg): ovaDefaultBgIfNull" type="color" sbClass="Cleared: Color(overlay.bg): ==null" />
+          <button class="ClearPrev" sbSet="Color(overlay.bg): null">X</button>
+        </div>
+      </div>
       <div id="Scaling" class="Panel">
         <h2>Scaling</h2>
         <input sbControl="$.Scaling" type="range" min="50" max="200" /><br />
@@ -84,15 +93,12 @@
           <option value="#00ff00">Green</option>
         </select>
       </div>
-      <div id="TeamOptions" class="Panel" sbContext="ScoreBoard.CurrentGame">
-        <h2>Team Display</h2>
-        <div sbForeach="Team: 1,2: only">
-          <input sbControl="AlternateName(overlay),Name:: sbToNullIfEmpty" type="text" />
-          <input sbControl="Color(overlay.fg): ovaDefaultFgIfNull" type="color" sbClass="Cleared: Color(overlay.fg): ==null" />
-          <button class="ClearPrev" sbSet="Color(overlay.fg): null">X</button>
-          <input sbControl="Color(overlay.bg): ovaDefaultBgIfNull" type="color" sbClass="Cleared: Color(overlay.bg): ==null" />
-          <button class="ClearPrev" sbSet="Color(overlay.bg): null">X</button>
-        </div>
+      <div id="PostTimeoutClock" class="Panel">
+        <h2>Clock After Timeout</h2>
+        <select sbControl="$.ClockAfterTimeout">
+          <option value="Lineup">Lineup</option>
+          <option value="Timeout">Timeout</option>
+        </select>
       </div>
       <div id="PreviewSize" class="Panel">
         <h2>Preview Size</h2>

--- a/html/views/overlay/index.css
+++ b/html/views/overlay/index.css
@@ -96,8 +96,7 @@ div.AnimatedPanel.AnimationDelay { transition: transform 1s ease-in-out .3s; }
 
 .SlideDown { transition: max-height 1s ease; width: 100%; overflow: hidden; padding: 0;  max-height: 0; } 
 
-.ClockBarTop { padding: 0; font-size: 1.4em; }
-.ClockBarTop.SlideDown.Show { width: 100%; padding: 2% 5%; max-height: 2em; } 
+.ClockBarTop { padding: 0; font-size: 1.4em; width: 100%; padding: 2% 5%; max-height: 2em; } 
 .ClockNames { width: 100%; font-size: 1.7em; } 
 .ClockNames > .Box { float: left; text-align: center; } 
 .ClockBox .Name { width: 49%; } 
@@ -108,8 +107,10 @@ div.AnimatedPanel.AnimationDelay { transition: transform 1s ease-in-out .3s; }
 .ClockBox .ClockDescription.Show { padding: 2px 0; } 
 
 .ClockBarBottom { font-size: 1.7em; } 
+.ClockBarBottom.SlideDown.Show { max-height: 2em; }
 .BottomRow { border-radius: 0 0 10px 10px; width: 100%; padding: 2% 5%; }
-.ClockBox .Time { width: 49%; } 
+.ClockBox .Time.TextLeft { width: 55%; } 
+.ClockBox .Time.TextRight { width: 45%; } 
 .ClockBox .Time.ShowInIntermission { width: 100%; } 
 .ClockBox .Time.Hidden { display: none; }
 

--- a/html/views/overlay/index.html
+++ b/html/views/overlay/index.html
@@ -50,24 +50,22 @@
         </div>
 
         <div class="ClockBox TopClock AnimatedPanel PanelHideTop Wrapper" sbClass="Show: $.Clock">
-          <div
-            class="ClockBarTop Wrapper Row SlideDown ClockNames ShowInJam ShowInLineup ShowInTimeout ShowInSecondLineup ShowInIntermission ShowInNoClock barBackgroundTop"
-          >
+          <div class="ClockBarTop Wrapper Row SlideDown ClockNames ShowInJam ShowInBetweenJams ShowInNoClock barBackgroundTop">
             <div class="Box TextLeft Name" sbDisplay="Clock(Period).Name,Clock(Period).Number,Rule(Period.Number): sbToClockInitialNumber"></div>
             <div
-              class="Box TextRight Clock ShowInJam ShowInIntermission ShowInLineup ShowInTimeout Name"
+              class="Box TextRight Clock ShowInJam ShowInBetweenJams Name"
               sbContext="Clock(Jam)"
               sbDisplay="Name,Number: sbToClockInitialNumber"
             ></div>
           </div>
 
           <div
-            class="ClockBarMiddle Wrapper SlideDown ShowInIntermission ShowInLineup ShowInTimeout ShowInSecondLineup ShowInNoClock Box BigName ClockDescription"
+            class="ClockBarMiddle Wrapper SlideDown ShowInIntermission ShowInFinal ShowInBetweenJams ShowInNoClock Box BigName ClockDescription"
             sbDisplay="Clock(Intermission).Number, Clock(*).Running, TimeoutOwner, OfficialReviews, ^Settings.Setting(ScoreBoard.Intermission.*), OfficialScore, ClockDuringFinalScore, Rule(Period.Number): ovlToClockType"
           ></div>
-          <div class="ClockBarBottom Wrapper Row BottomRow barBackgroundBottom">
+          <div class="ClockBarBottom Wrapper SlideDown ShowInIntermission ShowInJam ShowInBetweenJams Row BottomRow barBackgroundBottom">
             <div
-              class="Box TextLeft Time Clock Show ShowInJam ShowInLineup ShowInTimeout ShowInSecondLineup sbClock"
+              class="Box TextLeft Time Clock Show ShowInJam ShowInBetweenJams sbClock"
               sbContext="Clock(Period)"
               sbDisplay="Time, Direction: sbToTime"
             ></div>
@@ -78,11 +76,15 @@
             ></div>
             <div class="Box TextRight Time Clock Show ShowInJam sbClock" sbContext="Clock(Jam)" sbDisplay="Time, Direction: sbToTime"></div>
             <div
-              class="Box TextRight Time Clock ShowInLineup ShowInSecondLineup sbClock"
+              class="Box TextRight Time Clock ShowInLineup ShowInPostTimeoutLineup sbClock"
               sbContext="Clock(Lineup)"
               sbDisplay="Time, Direction: sbToTime"
             ></div>
-            <div class="Box TextRight Time Clock ShowInTimeout sbClock" sbContext="Clock(Timeout)" sbDisplay="Time, Direction: sbToTime"></div>
+            <div
+              class="Box TextRight Time Clock ShowInTimeout ShowInPostTimeoutTimeout sbClock"
+              sbContext="Clock(Timeout)"
+              sbDisplay="Time, Direction: sbToTime"
+            ></div>
           </div>
         </div>
       </div>

--- a/html/views/overlay/index.js
+++ b/html/views/overlay/index.js
@@ -5,11 +5,13 @@ WS.Register(
     'ScoreBoard.CurrentGame.TimeoutOwner',
     'ScoreBoard.CurrentGame.OfficialReview',
     'ScoreBoard.CurrentGame.Team(*).Timeouts',
+    'ScoreBoard.CurrentGame.ClockDuringFinalScore'
   ],
   sbSetActiveTimeout
 );
 
-WS.Register(['ScoreBoard.CurrentGame.Clock(*).Running', 'ScoreBoard.CurrentGame.InJam'], sbClockSelect);
+WS.Register(['ScoreBoard.Settings.Setting(Overlay.Interactive.ClockAfterTimeout)', 'ScoreBoard.CurrentGame.Clock(*).Running', 'ScoreBoard.CurrentGame.InJam'],
+  function (k) { _sbClockSelect('ScoreBoard.CurrentGame', 'Overlay.Interactive.ClockAfterTimeout') });
 
 WS.Register('ScoreBoard.CurrentGame.Rule(Penalties.NumberToFoulout)');
 
@@ -87,10 +89,10 @@ function ovlToIndicator(k, v) {
   return isTrue(WS.state[prefix + '.StarPass'])
     ? 'SP'
     : isTrue(WS.state[prefix + '.Lost'])
-    ? ''
-    : isTrue(WS.state[prefix + '.Lead'])
-    ? '★'
-    : '';
+      ? ''
+      : isTrue(WS.state[prefix + '.Lead'])
+        ? '★'
+        : '';
 }
 
 function ovlIsJamming(k, v, elem) {

--- a/html/views/standard/index.css
+++ b/html/views/standard/index.css
@@ -27,7 +27,7 @@ body.box_flat .Box.FlatDark, .Team>.JamScore.NoInitial:not(.Overtime) { color: #
   0% { color: #FF0000; } 50% { color: #FFFFFF; } 100% { color: #FF0000; } 
 } 
 
-body.HideLineups .Team>.Jammer.ShowInLineup:not(.HasClock)>.Name, body.HideLineups:not(.PenaltyClocks) .Team>.Jammer.ShowInLineup>.Name { visibility: hidden; }
+body.HideLineups .Team>.Jammer.ShowInBetweenJams:not(.HasClock)>.Name, body.HideLineups:not(.PenaltyClocks) .Team>.Jammer.ShowInBetweenJams>.Name { visibility: hidden; }
 
 .Dot { border-radius: 100%; background: #000000; } 
 .Dot.Current { background: #000000; opacity: 0; animation: DotActive 0.75s infinite steps(6); } 
@@ -101,7 +101,7 @@ body.HideLineups .Team>.Jammer.ShowInLineup:not(.HasClock)>.Name, body.HideLineu
 .Team.Right>.Jammer>.Name { right: 0%; }
 .Team.Right>.Jammer>.PenaltyTime { right: -100%; }
 .PenaltyClocks .Team.Right>.Jammer.HasClock>.PenaltyTime { right: 70%; }
-.Team>.Jammer.ShowInLineup { height: 10%; }
+.Team>.Jammer.ShowInBetweenJams { height: 10%; }
 
 
 .Clock.Period.Large { position: absolute; top: 65%; left: -40%; right: auto; width: 40%; height: 28%;  } 

--- a/html/views/standard/index.html
+++ b/html/views/standard/index.html
@@ -72,7 +72,7 @@
           <span class="Name AutoFit" sbAutoFitOn="PenaltyTime, &_HidePenaltyClocks" sbDisplay="Name, ^DisplayLead: dspToJammerName"></span>
           <span class="PenaltyTime Box Red AutoFit sbClock" sbDisplay="PenaltyTime: sbToSeconds"></span>
         </div>
-        <div class="ShowInLineup ShowInTimeout ShowInSecondLineup Clock Jammer" sbContext="Position(Jammer)" sbClass="HasClock: PenaltyTime: > 0">
+        <div class="ShowInBetweenJams Clock Jammer" sbContext="Position(Jammer)" sbClass="HasClock: PenaltyTime: > 0">
           <span class="Name AutoFit" sbAutoFitOn="PenaltyTime, &_HidePenaltyClocks" sbDisplay="Name"></span>
           <span class="PenaltyTime Box Red AutoFit sbClock" sbDisplay="PenaltyTime: sbToSeconds"></span>
         </div>
@@ -96,42 +96,52 @@
 
       <!-- Lineup / Timeout / No Clocks Running -->
       <div
-        class="ShowInLineup ShowInTimeout ShowInSecondLineup Clock Period Small Time Box AutoFit sbClock"
+        class="ShowInBetweenJams Clock Period Small Time Box AutoFit sbClock"
         sbContext="Clock(Period)"
         sbDisplay="Time, Direction: sbToTime"
       ></div>
       <div class="ShowInNoClock Clock Period Small Time Box AutoFit"></div>
       <div
-        class="ShowInLineup ShowInTimeout ShowInSecondLineup ShowInNoClock Clock Period Small NameNumber Box AutoFit"
+        class="ShowInBetweenJams ShowInNoClock Clock Period Small NameNumber Box AutoFit"
         sbDisplay="Clock(Period).Name,Clock(Period).Number,Rule(Period.Number): sbToClockInitialNumber"
       ></div>
       <div
-        class="ShowInLineup ShowInTimeout ShowInSecondLineup Clock Jam Small NameNumber Box AutoFit"
+        class="ShowInBetweenJams Clock Jam Small NameNumber Box AutoFit"
         sbContext="Clock(Jam)"
         sbDisplay="Name,Number: sbToClockInitialNumber"
       ></div>
-      <div class="ShowInLineup Clock Description Small Box AutoFit">Lineup</div>
+      <div class="ShowInLineup ShowInPostTimeoutLineup Clock Description Small Box AutoFit">Lineup</div>
       <div
-        class="ShowInTimeout ShowInSecondLineup Clock Description Small Box AutoFit Red"
+        class="ShowInTimeout ShowInPostTimeoutTimeout ShowInPostTimeoutBoth Clock Description Small Box AutoFit Red"
         sbDisplay="TimeoutOwner, OfficialReview: sbToTimeoutType"
       ></div>
       <div
-        class="ShowInLineup ShowInSecondLineup Clock Lineup Small Box AutoFit sbClock"
+        class="ShowInLineup ShowInPostTimeoutLineup Clock Lineup Small Box AutoFit sbClock"
         sbDisplay="Clock(Lineup).Time, Clock(Lineup).Direction: sbToTime"
         sbClass="Red: NoMoreJam"
       ></div>
       <div
-        class="ShowInTimeout ShowInSecondLineup Clock Timeout Small Box AutoFit sbClock"
+        class="ShowInTimeout ShowInPostTimeoutTimeout ShowInPostTimeoutBoth Clock Timeout Small Box AutoFit sbClock"
         sbDisplay="Clock(Timeout).Time, Clock(Timeout).Direction: sbToTime"
         sbClass="Red: NoMoreJam"
       ></div>
       <div class="ShowInNoClock Clock None Small Box AutoFit">Coming Up</div>
-      <div class="ShowInSecondLineup Clock Description Small Below Box AutoFit" sbDisplay="Clock(Lineup).Name"></div>
+      <div class="ShowInPostTimeoutBoth Clock Description Small Below Box AutoFit" sbDisplay="Clock(Lineup).Name"></div>
       <div
-        class="ShowInSecondLineup Clock Lineup Small Below Box AutoFit sbClock"
+        class="ShowInPostTimeoutBoth Clock Lineup Small Below Box AutoFit sbClock"
         sbDisplay="Clock(Lineup).Time, Clock(Lineup).Direction: sbToTime"
         sbClass="Red: NoMoreJam"
       ></div>
+
+      <!-- Intermission -->
+      <div class="ShowInIntermission ShowInFinal Clock Intermission">
+        <div
+          class="Message Box AutoFit"
+          sbPrefix="#: ScoreBoard.Settings.Setting(ScoreBoard.Intermission : )"
+          sbDisplay="#.*, OfficialScore, ClockDuringFinalScore, Clock(Intermission).Number, Rule(Period.Number): sbToIntermissionDisplay"
+        ></div>
+        <div class="Time Box AutoFit sbClock" sbContext="Clock(Intermission)" sbDisplay="Time, Direction: sbToTime"></div>
+      </div>
 
       <!-- Sponsor Banners -->
       <div class="ShowInTimeout ShowInLineup ShowInNoClock Clock" sbClass="sbHide: &_HideBanners" id="SponsorBox">
@@ -148,16 +158,6 @@
 
       <div id="Banners" class="sbHide" sbContext="/ScoreBoard.Media.Format(images).Type(sponsor_banner)">
         <div sbForeach="File:: name: resort=Name" sbAttr="src: Src"></div>
-      </div>
-
-      <!-- Intermission -->
-      <div class="ShowInIntermission Clock Intermission">
-        <div
-          class="Message Box AutoFit"
-          sbPrefix="#: ScoreBoard.Settings.Setting(ScoreBoard.Intermission : )"
-          sbDisplay="#.*, OfficialScore, ClockDuringFinalScore, Clock(Intermission).Number, Rule(Period.Number): sbToIntermissionDisplay"
-        ></div>
-        <div class="Time Box AutoFit sbClock" sbContext="Clock(Intermission)" sbDisplay="Time, Direction: sbToTime"></div>
       </div>
     </div>
     <div class="DisplayPane Show" id="cover"></div>

--- a/html/views/standard/index.js
+++ b/html/views/standard/index.js
@@ -34,7 +34,8 @@
   );
 
   // Show Clocks
-  WS.Register(['ScoreBoard.CurrentGame.Clock(*).Running', 'ScoreBoard.CurrentGame.InJam'], sbClockSelect);
+  WS.Register(['ScoreBoard.Settings.Setting(ScoreBoard.' + view + '_ClockAfterTimeout)', 'ScoreBoard.CurrentGame.Clock(*).Running', 'ScoreBoard.CurrentGame.InJam'],
+    function (k) { _sbClockSelect('ScoreBoard.CurrentGame', 'ScoreBoard.' + view + '_ClockAfterTimeout') });
 })();
 
 WS.AfterLoad(function () {

--- a/src/com/carolinarollergirls/scoreboard/core/admin/SettingsImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/admin/SettingsImpl.java
@@ -41,6 +41,7 @@ public class SettingsImpl extends ScoreBoardEventProviderImpl<Settings> implemen
 
     private void setDefaults() {
         set("Overlay.Interactive.Clock", "true");
+        set("Overlay.Interactive.ClockAfterTimeout", "Lineup");
         set("Overlay.Interactive.Scaling", "100");
         set("Overlay.Interactive.Score", "true");
         set("Overlay.Interactive.ShowJammers", "true");
@@ -57,7 +58,7 @@ public class SettingsImpl extends ScoreBoardEventProviderImpl<Settings> implemen
         set(ScoreBoard.SETTING_AUTO_START, "");
         set(ScoreBoard.SETTING_AUTO_START_BUFFER, "0:02");
         set(ScoreBoard.SETTING_AUTO_END_JAM, "false");
-        set(ScoreBoard.SETTING_AUTO_END_TTO, "false");
+        set(ScoreBoard.SETTING_AUTO_END_TTO, "true");
         set(Clock.SETTING_SYNC, "true");
         set(Team.SETTING_DISPLAY_NAME, Team.OPTION_LEAGUE_NAME);
         set(Game.SETTING_DEFAULT_NAME_FORMAT, "%d %G %1 vs. %2 (%s: %S)");
@@ -68,6 +69,7 @@ public class SettingsImpl extends ScoreBoardEventProviderImpl<Settings> implemen
         set("ScoreBoard.Intermission.OfficialWithClock", "Final Score");
 
         setBothViews("BoxStyle", "box_flat_bright");
+        setBothViews("ClockAfterTimeout", "Both");
         setBothViews("CurrentView", "scoreboard");
         setBothViews("CustomHtml", "/customhtml/fullscreen/example.html");
         setBothViews("Image", "/images/fullscreen/test-image.png");

--- a/src/com/carolinarollergirls/scoreboard/core/game/ClockImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/game/ClockImpl.java
@@ -151,6 +151,7 @@ public class ClockImpl extends ScoreBoardEventProviderImpl<Clock> implements Clo
     public void restoreSnapshot(ClockSnapshot s) {
         synchronized (coreLock) {
             if (s.getId() != getId()) { return; }
+            setName(s.getName());
             setNumber(s.getNumber());
             stop();
             set(TIME, isCountDirectionDown() ? getMaximumTime() - s.getTime() : s.getTime(), Flag.SPECIAL_CASE);
@@ -343,6 +344,7 @@ public class ClockImpl extends ScoreBoardEventProviderImpl<Clock> implements Clo
     public static class ClockSnapshotImpl implements ClockSnapshot {
         private ClockSnapshotImpl(Clock clock) {
             id = clock.getId();
+            name = clock.getName();
             number = clock.getNumber();
             time = clock.getTimeElapsed();
             isRunning = clock.isRunning();
@@ -351,6 +353,10 @@ public class ClockImpl extends ScoreBoardEventProviderImpl<Clock> implements Clo
         @Override
         public String getId() {
             return id;
+        }
+        @Override
+        public String getName() {
+            return name;
         }
         @Override
         public int getNumber() {
@@ -366,6 +372,7 @@ public class ClockImpl extends ScoreBoardEventProviderImpl<Clock> implements Clo
         }
 
         protected String id;
+        protected String name;
         protected int number;
         protected long time;
         protected boolean isRunning;

--- a/src/com/carolinarollergirls/scoreboard/core/interfaces/Clock.java
+++ b/src/com/carolinarollergirls/scoreboard/core/interfaces/Clock.java
@@ -77,6 +77,7 @@ public interface Clock extends ScoreBoardEventProvider {
 
     public static interface ClockSnapshot {
         public String getId();
+        public String getName();
         public int getNumber();
         public long getTime();
         public boolean isRunning();

--- a/src/com/carolinarollergirls/scoreboard/core/interfaces/Game.java
+++ b/src/com/carolinarollergirls/scoreboard/core/interfaces/Game.java
@@ -124,6 +124,7 @@ public interface Game extends ScoreBoardEventProvider {
     public static final Value<TimeoutOwner> TIMEOUT_OWNER =
         new Value<>(TimeoutOwner.class, "TimeoutOwner", null, props);
     public static final Value<Boolean> OFFICIAL_REVIEW = new Value<>(Boolean.class, "OfficialReview", false, props);
+    public static final Value<Boolean> OR_IS_TO = new Value<>(Boolean.class, "ReviewIsTo", false, props);
     public static final Value<Boolean> NO_MORE_JAM = new Value<>(Boolean.class, "NoMoreJam", false, props);
     public static final Value<Ruleset> RULESET = new Value<>(Ruleset.class, "Ruleset", null, props);
     public static final Value<String> RULESET_NAME = new Value<>(String.class, "RulesetName", "Custom", props);

--- a/src/com/carolinarollergirls/scoreboard/core/interfaces/Timeout.java
+++ b/src/com/carolinarollergirls/scoreboard/core/interfaces/Timeout.java
@@ -41,6 +41,8 @@ public interface Timeout extends ScoreBoardEventProvider {
     public static final Command DELETE = new Command("Delete", props);
     public static final Command INSERT_AFTER = new Command("InsertAfter", props);
 
+    public static final String OR_AS_TO_TEXT = "Taken as Team Timeout";
+
     public enum Owners implements TimeoutOwner {
         NONE(""),
         OTO("O");

--- a/src/com/carolinarollergirls/scoreboard/utils/ScoreBoardClock.java
+++ b/src/com/carolinarollergirls/scoreboard/utils/ScoreBoardClock.java
@@ -65,6 +65,10 @@ public class ScoreBoardClock extends TimerTask {
         }
     }
 
+    public boolean isRunning() {
+        synchronized (coreLock) { return stopCounter == 0; }
+    }
+
     public void registerClient(ScoreBoardClockClient client) {
         synchronized (coreLock) { clients.add(client); }
     }

--- a/tests/com/carolinarollergirls/scoreboard/core/game/GameImplTests.java
+++ b/tests/com/carolinarollergirls/scoreboard/core/game/GameImplTests.java
@@ -479,6 +479,7 @@ public class GameImplTests {
 
     @Test
     public void testStartJam_fromTimeout() {
+        g.set(Rule.TO_JAM, "true");
         fastForwardJams(17);
         g.timeout();
         assertFalse(pc.isRunning());
@@ -498,7 +499,7 @@ public class GameImplTests {
         g.startJam();
 
         assertEquals(Game.ACTION_START_JAM, g.snapshot.getType());
-        assertTrue(pc.isRunning());
+        assertFalse(pc.isRunning());
         assertEquals(1, pc.getNumber());
         assertTrue(jc.isRunning());
         assertTrue(jc.isTimeAtStart());


### PR DESCRIPTION
- enable AutoEndTeamTimeout by default - TTOs always end after exactly 60s as per Rules Theory
- allow marking ORs taken as timeout, so AutoEndTeamTimeout can catch them
- add option to select clock(s) displayed after timeout for main display and stream overlay (separately)
- fix unending auto-ended timeout
- tweak layout of timeout buttons