### PR TITLE
Add a --help option.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,6 +13,72 @@
     },
     {
       "type": "java",
+      "name": "scoreboard --help",
+      "request": "launch",
+      "mainClass": "com.carolinarollergirls.scoreboard.Main",
+      "args": 
+      [
+         "--help"
+      ],  
+      "projectName": "crg-scoreboard"
+    },
+    {
+      "type": "java",
+      "name": "scoreboard --bogus",
+      "request": "launch",
+      "mainClass": "com.carolinarollergirls.scoreboard.Main",
+      "args": 
+      [
+         "--bogus"
+      ],  
+      "projectName": "crg-scoreboard"
+    },
+    {
+      "type": "java",
+      "name": "scoreboard --metrics",
+      "request": "launch",
+      "mainClass": "com.carolinarollergirls.scoreboard.Main",
+      "args": 
+      [
+         "--metrics"
+      ],  
+      "projectName": "crg-scoreboard"
+    },
+    {
+      "type": "java",
+      "name": "scoreboard --host=nomad.local",
+      "request": "launch",
+      "mainClass": "com.carolinarollergirls.scoreboard.Main",
+      "args": 
+      [
+         "--host=nomad.local"
+      ],  
+      "projectName": "crg-scoreboard"
+    },
+    {
+      "type": "java",
+      "name": "scoreboard --host=172.21.21.130",
+      "request": "launch",
+      "mainClass": "com.carolinarollergirls.scoreboard.Main",
+      "args": 
+      [
+         "--host=172.21.21.130"
+      ],  
+      "projectName": "crg-scoreboard"
+    },
+    {
+      "type": "java",
+      "name": "scoreboard --host=bogus",
+      "request": "launch",
+      "mainClass": "com.carolinarollergirls.scoreboard.Main",
+      "args": 
+      [
+         "--host=bogus"
+      ],  
+      "projectName": "crg-scoreboard"
+    },
+    {
+      "type": "java",
       "name": "Launch Current File",
       "request": "launch",
       "mainClass": "${file}"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -68,12 +68,12 @@
     },
     {
       "type": "java",
-      "name": "scoreboard --host=bogus",
+      "name": "scoreboard --host=bogus.example.com",
       "request": "launch",
       "mainClass": "com.carolinarollergirls.scoreboard.Main",
       "args": 
       [
-         "--host=bogus"
+         "--host=bogus.example.com"
       ],  
       "projectName": "crg-scoreboard"
     },

--- a/src/com/carolinarollergirls/scoreboard/Main.java
+++ b/src/com/carolinarollergirls/scoreboard/Main.java
@@ -140,8 +140,8 @@ public class Main extends Logger {
                 useMetrics = true;
             } else if (arg.equals("--help") || arg.equals("-h")) {
                 System.out.println("Options:");
-                System.out.println("  --gui, -g                  (default) Create GUI window to show program messages.");
-                System.out.println("  --nogui, -G                Do not create GUI window.");
+                System.out.println("  --gui, -g                  Create GUI window to show program messages.");
+                System.out.println("  --nogui, -G                (default) Do not create GUI window.");
                 System.out.println("  --port=<port>, -p=<port>   Port to listen on (default 8000)");
                 System.out.println("  --host=<host>, -h=<host>   Host to bind to (default all interfaces)");
                 System.out.println("  --import=<path>, -i=<path> Import data from non-standard location");

--- a/src/com/carolinarollergirls/scoreboard/Main.java
+++ b/src/com/carolinarollergirls/scoreboard/Main.java
@@ -138,7 +138,22 @@ public class Main extends Logger {
                 importPath = arg.split("=", 2)[1];
             } else if (arg.equals("--metrics") || arg.equals("-m")) {
                 useMetrics = true;
-            }
+            } else if (arg.equals("--help") || arg.equals("-h")) {
+                System.out.println("Options:");
+                System.out.println("  --gui, -g                  (default) Create GUI window to show program messages.");
+                System.out.println("  --nogui, -G                Do not create GUI window.");
+                System.out.println("  --port=<port>, -p=<port>   Port to listen on (default 8000)");
+                System.out.println("  --host=<host>, -h=<host>   Host to bind to (default all interfaces)");
+                System.out.println("  --import=<path>, -i=<path> Import data from non-standard location");
+                System.out.println("                             Use --import= to disable import");
+                System.out.println("  --metrics, -m              Log metrics for developers");
+                System.out.println("  --help, -h                 Show this help message");
+                System.exit(0);
+            } else {
+                System.err.println("Unknown argument: " + arg);
+                System.err.println("Use --help or -h for usage information.");
+                System.exit(1);
+            }            
         }
 
         if (gui) { createGui(); }


### PR DESCRIPTION
Small change to the command line argument parser.  If given a bogus
option the program will print an error message and exit with exit code 
of 1.  If given "--help" or "-h" it will print a short description of the 
allowed command line arguments and exit with exit code 0. 

Add VS Code launch configurations to test different command line arguments.