### PR TITLE
Handle arguments implicitly added to args by the JVM

### DIFF
--- a/src/com/carolinarollergirls/scoreboard/Main.java
+++ b/src/com/carolinarollergirls/scoreboard/Main.java
@@ -149,6 +149,9 @@ public class Main extends Logger {
                 System.out.println("  --metrics, -m              Log metrics for developers");
                 System.out.println("  --help, -h                 Show this help message");
                 System.exit(0);
+            } else if (arg.equals("") || arg.startsWith("one-jar.")) {
+                // JVM can in some cases add a one-jar.silent=, not
+                // sure why it was designed this way, just ignore it.
             } else {
                 System.err.println("Unknown argument: " + arg);
                 System.err.println("Use --help or -h for usage information.");


### PR DESCRIPTION
When run using the scoreboard.sh and scoreboard-mac.command with no command line 
arguments, the JVM will implicitly add a "one-jar.verbose=false" if no command line arguments 
are passed.

This is hidden by the "$GUI" argument which, instead of adding the "one-jar" argument, 
it will add an empty string argument.

I've modified the command line argument processing to allow either of those situations 
to occur and be handled sanely. 