### PR TITLE
Make ant vscode play together

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,8 @@ android/build/
 /game-data/
 /node_modules/
 /package-lock.json
+/jdoc/
+spotbugs-report.xml
+html/images/old-sponsor_banner
+build-ant/
+build-vscode/

--- a/build.xml
+++ b/build.xml
@@ -82,7 +82,15 @@
 			<isfalse value="${isRelease}"/>
 		</condition>
 		<mkdir dir="${version.dest.dir}"/>
+		<mkdir dir="${version.vscode.dest.dir}"/>
 		<propertyfile file="${version.dest.dir}/${version.release.file}">
+			<entry key="release" value="${version}"/>
+			<entry key="release.commit" value="${version.commit}"/>
+			<entry key="release.user" value="${user.name}"/>
+			<entry key="release.time" value="${version.time}"/>
+			<entry key="release.host" value="${host.NAME}"/>
+		</propertyfile>
+		<propertyfile file="${version.vscode.dest.dir}/${version.release.file}">
 			<entry key="release" value="${version}"/>
 			<entry key="release.commit" value="${version.commit}"/>
 			<entry key="release.user" value="${user.name}"/>

--- a/build.xml
+++ b/build.xml
@@ -11,17 +11,17 @@
 	<property name="test.build.dir" value="test-bin" />
 	<property name="jdoc.dir" value="jdoc"/>
 	<property name="version.dest.dir" value="${dest.dir}/com/carolinarollergirls/scoreboard/version"/>
-        <!--
-            VSCode has it's own build system that doesn't play nice
-            with ant.  So we'll let VSCode do its thing, building in
-            bin, and we'll have ant use a different build directory.
+	<!--
+	    VSCode has it's own build system that doesn't play nice
+	    with ant.  So we'll let VSCode do its thing, building in
+	    bin, and we'll have ant use a different build directory.
 
-            In this paradigm, the only thing ant needs to do is create
-            a release.properties on behalf of VSCode.
+	    In this paradigm, the only thing ant needs to do is create
+	    a release.properties on behalf of VSCode.
 
-            TODO- If somebody knows of a way to get VSCode to build
-            the release.properties file, be my guest.
-        -->
+	    TODO- If somebody knows of a way to get VSCode to build
+	    the release.properties file, be my guest.
+	-->
 	<property name="version.vscode.dest.dir" value="bin/com/carolinarollergirls/scoreboard/version"/>
 	<property name="version.release.file" value="release.properties"/>
 
@@ -123,7 +123,7 @@
 			nowarn="${compile.nowarn}"
 			includeAntRuntime="false"
 			includes="**/*.java">
-			
+
 			<compilerarg value="-Xlint:all"/>
 			<compilerarg value="-Xlint:-serial"/>
 			<compilerarg value="-Xlint:-options"/>
@@ -197,9 +197,9 @@
 		<javadoc
 			packagenames="com.carolinarollergirls.scoreboard.*"
 			sourcepath="${src.dir}"
-                        classpath="${jar.dir}/deps/*"
+			classpath="${jar.dir}/deps/*"
 			destdir="${jdoc.dir}"
-                        overview="${src.dir}/overview.html"
+			overview="${src.dir}/overview.html"
 		/>
 		<echo message="Java Documentation placed in ${jdoc.dir}"/>
 	</target>

--- a/build.xml
+++ b/build.xml
@@ -17,7 +17,7 @@
 	<property name="compile.deprecation" value="true"/>
 	<property name="compile.debug" value="true"/>
 	<property name="compile.nowarn" value="false"/>
-	<property name="compile.verbose" value="false"/>
+	<property name="compile.verbose" value="true"/>
 
 	<property name="jar.dir" value="lib"/>
 	<property name="jar.file" value="crg-scoreboard.jar"/>

--- a/build.xml
+++ b/build.xml
@@ -5,7 +5,7 @@
 	<property name="ant.build.javac.target" value="1.8"/>
 
 	<property name="src.dir" value="src"/>
-	<property name="dest.dir" value="build-ant"/>
+	<property name="dest.dir" value="bin"/>
 	<property name="test.run" value="*" />
 	<property name="test.src.dir" value="tests" />
 	<property name="test.build.dir" value="test-bin" />
@@ -82,15 +82,7 @@
 			<isfalse value="${isRelease}"/>
 		</condition>
 		<mkdir dir="${version.dest.dir}"/>
-		<mkdir dir="${version.vscode.dest.dir}"/>
 		<propertyfile file="${version.dest.dir}/${version.release.file}">
-			<entry key="release" value="${version}"/>
-			<entry key="release.commit" value="${version.commit}"/>
-			<entry key="release.user" value="${user.name}"/>
-			<entry key="release.time" value="${version.time}"/>
-			<entry key="release.host" value="${host.NAME}"/>
-		</propertyfile>
-		<propertyfile file="${version.vscode.dest.dir}/${version.release.file}">
 			<entry key="release" value="${version}"/>
 			<entry key="release.commit" value="${version.commit}"/>
 			<entry key="release.user" value="${user.name}"/>
@@ -105,22 +97,20 @@
 		<mkdir dir="html/images/teamlogo" />
 		<mkdir dir="html/images/sponsor_banner" />
 		<javac srcdir="${src.dir}"
-		       destdir="${dest.dir}"
-                       failonerror="true"
-		       fork="true"
-                       deprecation="${compile.deprecation}"
-		       debug="${compile.debug}"
-		       verbose="${compile.verbose}"
-		       nowarn="${compile.nowarn}"
-		       includeAntRuntime="false"
-		       includes="**/*.java">
-                  
-		  <compilerarg value="-Xlint:all"/>
-		  <compilerarg value="-Xlint:-serial"/>
-		  <compilerarg value="-Xlint:-options"/>
-		  <classpath>
-		    <fileset dir="${jar.dir}" includes="deps/*.jar" />
-		  </classpath>
+			destdir="${dest.dir}"
+			deprecation="${compile.deprecation}"
+			debug="${compile.debug}"
+			verbose="${compile.verbose}"
+			nowarn="${compile.nowarn}"
+			includeAntRuntime="false"
+			includes="com/carolinarollergirls/scoreboard/**" >
+
+			<compilerarg value="-Xlint:all"/>
+			<compilerarg value="-Xlint:-serial"/>
+			<compilerarg value="-Xlint:-options"/>
+			<classpath>
+				<fileset dir="${jar.dir}" includes="deps/*.jar" />
+			</classpath>
 		</javac>
 
 		<copy todir="${dest.dir}">

--- a/build.xml
+++ b/build.xml
@@ -5,7 +5,7 @@
 	<property name="ant.build.javac.target" value="1.8"/>
 
 	<property name="src.dir" value="src"/>
-	<property name="dest.dir" value="bin"/>
+	<property name="dest.dir" value="build-ant"/>
 	<property name="test.run" value="*" />
 	<property name="test.src.dir" value="tests" />
 	<property name="test.build.dir" value="test-bin" />
@@ -106,13 +106,14 @@
 		<mkdir dir="html/images/sponsor_banner" />
 		<javac srcdir="${src.dir}"
 			destdir="${dest.dir}"
-			deprecation="${compile.deprecation}"
+
+                        deprecation="${compile.deprecation}"
 			debug="${compile.debug}"
 			verbose="${compile.verbose}"
 			nowarn="${compile.nowarn}"
 			includeAntRuntime="false"
-			includes="com/carolinarollergirls/scoreboard/**" >
-
+			includes="**/*.java">
+                        
 			<compilerarg value="-Xlint:all"/>
 			<compilerarg value="-Xlint:-serial"/>
 			<compilerarg value="-Xlint:-options"/>
@@ -186,7 +187,9 @@
 		<javadoc
 			packagenames="com.carolinarollergirls.scoreboard.*"
 			sourcepath="${src.dir}"
+                        classpath="${jar.dir}/deps/*"
 			destdir="${jdoc.dir}"
+                        overview="${src.dir}/overview.html"
 		/>
 		<echo message="Java Documentation placed in ${jdoc.dir}"/>
 	</target>

--- a/build.xml
+++ b/build.xml
@@ -106,7 +106,6 @@
 		<mkdir dir="html/images/sponsor_banner" />
 		<javac srcdir="${src.dir}"
 			destdir="${dest.dir}"
-
                         deprecation="${compile.deprecation}"
 			debug="${compile.debug}"
 			verbose="${compile.verbose}"

--- a/build.xml
+++ b/build.xml
@@ -5,12 +5,13 @@
 	<property name="ant.build.javac.target" value="1.8"/>
 
 	<property name="src.dir" value="src"/>
-	<property name="dest.dir" value="bin"/>
+	<property name="dest.dir" value="build-ant"/>
 	<property name="test.run" value="*" />
 	<property name="test.src.dir" value="tests" />
 	<property name="test.build.dir" value="test-bin" />
 	<property name="jdoc.dir" value="jdoc"/>
 	<property name="version.dest.dir" value="${dest.dir}/com/carolinarollergirls/scoreboard/version"/>
+	<property name="version.vscode.dest.dir" value="bin/com/carolinarollergirls/scoreboard/version"/>
 	<property name="version.release.file" value="release.properties"/>
 
 	<property name="compile.deprecation" value="true"/>
@@ -81,7 +82,15 @@
 			<isfalse value="${isRelease}"/>
 		</condition>
 		<mkdir dir="${version.dest.dir}"/>
+		<mkdir dir="${version.vscode.dest.dir}"/>
 		<propertyfile file="${version.dest.dir}/${version.release.file}">
+			<entry key="release" value="${version}"/>
+			<entry key="release.commit" value="${version.commit}"/>
+			<entry key="release.user" value="${user.name}"/>
+			<entry key="release.time" value="${version.time}"/>
+			<entry key="release.host" value="${host.NAME}"/>
+		</propertyfile>
+		<propertyfile file="${version.vscode.dest.dir}/${version.release.file}">
 			<entry key="release" value="${version}"/>
 			<entry key="release.commit" value="${version.commit}"/>
 			<entry key="release.user" value="${user.name}"/>
@@ -96,20 +105,22 @@
 		<mkdir dir="html/images/teamlogo" />
 		<mkdir dir="html/images/sponsor_banner" />
 		<javac srcdir="${src.dir}"
-			destdir="${dest.dir}"
-			deprecation="${compile.deprecation}"
-			debug="${compile.debug}"
-			verbose="${compile.verbose}"
-			nowarn="${compile.nowarn}"
-			includeAntRuntime="false"
-			includes="com/carolinarollergirls/scoreboard/**" >
-
-			<compilerarg value="-Xlint:all"/>
-			<compilerarg value="-Xlint:-serial"/>
-			<compilerarg value="-Xlint:-options"/>
-			<classpath>
-				<fileset dir="${jar.dir}" includes="deps/*.jar" />
-			</classpath>
+		       destdir="${dest.dir}"
+                       failonerror="true"
+		       fork="true"
+                       deprecation="${compile.deprecation}"
+		       debug="${compile.debug}"
+		       verbose="${compile.verbose}"
+		       nowarn="${compile.nowarn}"
+		       includeAntRuntime="false"
+		       includes="**/*.java">
+                  
+		  <compilerarg value="-Xlint:all"/>
+		  <compilerarg value="-Xlint:-serial"/>
+		  <compilerarg value="-Xlint:-options"/>
+		  <classpath>
+		    <fileset dir="${jar.dir}" includes="deps/*.jar" />
+		  </classpath>
 		</javac>
 
 		<copy todir="${dest.dir}">

--- a/build.xml
+++ b/build.xml
@@ -11,6 +11,17 @@
 	<property name="test.build.dir" value="test-bin" />
 	<property name="jdoc.dir" value="jdoc"/>
 	<property name="version.dest.dir" value="${dest.dir}/com/carolinarollergirls/scoreboard/version"/>
+        <!--
+            VSCode has it's own build system that doesn't play nice
+            with ant.  So we'll let VSCode do its thing, building in
+            bin, and we'll have ant use a different build directory.
+
+            In this paradigm, the only thing ant needs to do is create
+            a release.properties on behalf of VSCode.
+
+            TODO- If somebody knows of a way to get VSCode to build
+            the release.properties file, be my guest.
+        -->
 	<property name="version.vscode.dest.dir" value="bin/com/carolinarollergirls/scoreboard/version"/>
 	<property name="version.release.file" value="release.properties"/>
 

--- a/build.xml
+++ b/build.xml
@@ -117,13 +117,13 @@
 		<mkdir dir="html/images/sponsor_banner" />
 		<javac srcdir="${src.dir}"
 			destdir="${dest.dir}"
-                        deprecation="${compile.deprecation}"
+			deprecation="${compile.deprecation}"
 			debug="${compile.debug}"
 			verbose="${compile.verbose}"
 			nowarn="${compile.nowarn}"
 			includeAntRuntime="false"
 			includes="**/*.java">
-                        
+			
 			<compilerarg value="-Xlint:all"/>
 			<compilerarg value="-Xlint:-serial"/>
 			<compilerarg value="-Xlint:-options"/>


### PR DESCRIPTION
The interaction between VS Code's build system and ant's build as defined in build.xml 
is less than ideal.  For details see issue #877.

This change solves the issue by using separate outputPath directories 
for Ant and VS Code.  I've kept the same path for VS Code (i.e. "bin") 
and told Ant to place the output in "build-ant".
