### PR TITLE
Delete leading and trailing spaces on enter login name.

### DIFF
--- a/html/nso/sbo/index.js
+++ b/html/nso/sbo/index.js
@@ -42,7 +42,7 @@ function _setOperatorSettings(op) {
 }
 
 function _login(name) {
-  name = name || '';
+  name = (name && name.trim()) || '';
   $('#operatorId').text(name);
   _sbUpdateUrl('operator', name);
   _crgKeyControls.setupKeyControls(name);


### PR DESCRIPTION
The name passed into html/nso/sbo/index.js:_login() is now stripped of all leading and trailing spaces before operating on that name.  This way we'll never use names that differ only in trailing whitespace.

This should fix bug #883 