### PR TITLE
Scale sponsor banner image to fit, not to fill.

### DIFF
--- a/html/views/standard/index.css
+++ b/html/views/standard/index.css
@@ -132,13 +132,21 @@ body.box_flat .Clock.Jam.Large>.Name { left: 0%; width: 100%; height: 40% }
 .Clock.Intermission .Time { position: absolute; top: 40%; height: 60%; left: 0%; width: 100%; font-size: 21vh; line-height: 0.8; } 
 .Clock.Intermission .Time.Hidden { opacity: 0; } 
 
-
 #SponsorBox { position: absolute; left: 0%; top: 100%; width: 100%; height: 25%; transition: top 500ms; }
 #SponsorBox.Show { top: 75%; }
 #SponsorBox>div { position: absolute; top: 0%; right: 0%; width: 100%; height: 100%; font-size: 0px; transition: right 1s; } 
 #SponsorBox>div.NextImg { right: 100%; } 
 #SponsorBox>div.NextImg>img { display: none; }
 #SponsorBox>div.CurrentImg { right: 0%; transition-delay: 20ms; }
-#SponsorBox>div.FinishedImg { right: -100%; } 
-#SponsorBox>div>img { width: 100%; height: 100%; } 
+#SponsorBox>div.CurrentImg>img{ 
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+}
+#SponsorBox>div.FinishedImg { right: -100%; }
+#SponsorBox>div>img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+} 
 #SponsorBox>div>[src=""] { display: none; }


### PR DESCRIPTION
Adding
    object-fit: contain;
to the sponsor image elements.