### PR TITLE
make sponsor banner scaling configurable

### DIFF
--- a/html/components/settings-tab/index.html
+++ b/html/components/settings-tab/index.html
@@ -144,6 +144,14 @@
           <option sbForeach="File:: name: resort=Name" sbAttr="name: Name | value: Src" sbDisplay="Name"></option>
         </select>
       </span>
+      <span>
+        <label>Sponsor Banner Scaling: </label>
+        <select sbControl="$_SponsorScaling" ApplyPreview="SponsorScaling">
+          <option value="contain">Scale to fit</option>
+          <option value="cover">Scale to fill</option>
+          <option value="fill">Stretch</option>
+        </select>
+      </span>
     </div>
     <div class="sbGroup sbSubHeader ViewFrameLabels">
       <span>Current</span>

--- a/html/views/standard/index.html
+++ b/html/views/standard/index.html
@@ -153,13 +153,13 @@
       <!-- Sponsor Banners -->
       <div class="ShowInTimeout ShowInLineup ShowInNoClock Clock" sbClass="sbHide: &_HideBanners" id="SponsorBox">
         <div class="NextImg">
-          <img src="" />
+          <img src="" sbCss="object-fit: &_SponsorScaling" />
         </div>
         <div class="CurrentImg">
-          <img src="" />
+          <img src="" sbCss="object-fit: &_SponsorScaling" />
         </div>
         <div class="FinishedImg">
-          <img src="" />
+          <img src="" sbCss="object-fit: &_SponsorScaling" />
         </div>
       </div>
 

--- a/src/com/carolinarollergirls/scoreboard/core/admin/SettingsImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/admin/SettingsImpl.java
@@ -78,6 +78,7 @@ public final class SettingsImpl extends ScoreBoardEventProviderImpl<Settings> im
         setBothViews("HideLogos", "false");
         setBothViews("HidePenaltyClocks", "false");
         setBothViews("SidePadding", "");
+        setBothViews("SponsorScaling", "fill");
         setBothViews("SwapTeams", "false");
         setBothViews("Video", "/videos/fullscreen/test-video.webm");
         setBothViews("VideoScaling", "contain");


### PR DESCRIPTION
supersedes #886
closes #885

Note: Default for v2025.x is the current behavior. It is scheduled to be changed to "Scale to fit" for v2027.x (see #919)