### PR TITLE
fix: for All operator buttons (Start Jam / Stop / Timeout) become unresponsive after Undo

### DIFF
--- a/src/com/carolinarollergirls/scoreboard/core/game/GameImpl.java
+++ b/src/com/carolinarollergirls/scoreboard/core/game/GameImpl.java
@@ -953,27 +953,30 @@ public final class GameImpl extends ScoreBoardEventProviderImpl<Game> implements
     }
     protected void restoreSnapshot() {
         restoreRunning = true;
-        ScoreBoardClock.getInstance().rewindTo(snapshot.getSnapshotTime());
-        for (Clock clock : getAll(CLOCK)) { clock.restoreSnapshot(snapshot.getClockSnapshot(clock.getProviderId())); }
-        set(IN_JAM, snapshot.inJam());
-        set(IN_PERIOD, snapshot.inPeriod());
-        set(CURRENT_PERIOD, snapshot.getCurrentPeriod());
-        getCurrentPeriod().restoreSnapshot(snapshot.getPeriodSnapshot());
-        if (getCurrentTimeout() != snapshot.getCurrentTimeout() && getCurrentTimeout() != noTimeoutDummy) {
-            getCurrentTimeout().delete();
-        }
-        set(CURRENT_TIMEOUT, snapshot.getCurrentTimeout());
-        getCurrentTimeout().set(Timeout.RUNNING, snapshot.inTimeout());
-        set(OR_IS_TO, snapshot.orIsTo());
-        set(IN_OVERTIME, snapshot.inOvertime());
-        for (Team team : getAll(TEAM)) { team.restoreSnapshot(snapshot.getTeamSnapshot(team.getProviderId())); }
-        for (BoxTrip bt : getAll(Team.BOX_TRIP)) { bt.restoreSnapshot(snapshot.getBoxTripSnapshot(bt.getId())); };
-        for (Team team : getAll(TEAM)) {
-            for (BoxTrip bt : team.getAll(Team.BOX_TRIP)) {
-                bt.restoreSnapshot(snapshot.getBoxTripSnapshot(bt.getId()));
+        try {
+            ScoreBoardClock.getInstance().rewindTo(snapshot.getSnapshotTime());
+            for (Clock clock : getAll(CLOCK)) { clock.restoreSnapshot(snapshot.getClockSnapshot(clock.getProviderId())); }
+            set(IN_JAM, snapshot.inJam());
+            set(IN_PERIOD, snapshot.inPeriod());
+            set(CURRENT_PERIOD, snapshot.getCurrentPeriod());
+            getCurrentPeriod().restoreSnapshot(snapshot.getPeriodSnapshot());
+            if (getCurrentTimeout() != snapshot.getCurrentTimeout() && getCurrentTimeout() != noTimeoutDummy) {
+                getCurrentTimeout().delete();
             }
+            set(CURRENT_TIMEOUT, snapshot.getCurrentTimeout());
+            getCurrentTimeout().set(Timeout.RUNNING, snapshot.inTimeout());
+            set(OR_IS_TO, snapshot.orIsTo());
+            set(IN_OVERTIME, snapshot.inOvertime());
+            for (Team team : getAll(TEAM)) { team.restoreSnapshot(snapshot.getTeamSnapshot(team.getProviderId())); }
+            for (BoxTrip bt : getAll(Team.BOX_TRIP)) { bt.restoreSnapshot(snapshot.getBoxTripSnapshot(bt.getId())); }
+            for (Team team : getAll(TEAM)) {
+                for (BoxTrip bt : team.getAll(Team.BOX_TRIP)) {
+                    bt.restoreSnapshot(snapshot.getBoxTripSnapshot(bt.getId()));
+                }
+            }
+        } finally {
+            restoreRunning = false;
         }
-        restoreRunning = false;
     }
     protected void finishReplace() {
         if (replacePending != null) {


### PR DESCRIPTION
Created this bug in the scoreboard repo.  [here](https://github.com/rollerderby/scoreboard/issues/929)

fix: wrap restoreSnapshot in try/finally to guarantee restoreRunning is cleared

If restoreSnapshot throws after setting restoreRunning=true, the flag
was never cleared, permanently blocking startJam, stopJamTO, and timeout
for the rest of the session. All three check restoreRunning as a guard,
requiring a full app restart to recover.

try/finally guarantees the flag is reset regardless of success or failure.

Affects v2025.8 and v2025.9. Not present in v2025.7.
Root cause: commit 58904866, widened by ebb90645.