### PR TITLE
replace `white` → `#f9f9f9` for luma key alpha

### DIFF
--- a/html/views/overlay/index.css
+++ b/html/views/overlay/index.css
@@ -1,7 +1,7 @@
 /* General look */
 html { height: 100%; width: 100%; } 
 body { font-weight: bold; margin: 0; padding: 0; overflow: hidden; } 
-div { #f9f9f9-space: nowrap; display: block; padding: 0; margin: 0; overflow: hidden; } 
+div { white-space: nowrap; display: block; padding: 0; margin: 0; overflow: hidden; } 
 .Wrapper { clear: both; box-sizing: border-box; } 
 .Box { float: left; margin: 0; padding: 0; position: relative; display: block; } 
 

--- a/html/views/overlay/index.css
+++ b/html/views/overlay/index.css
@@ -1,7 +1,7 @@
 /* General look */
 html { height: 100%; width: 100%; } 
 body { font-weight: bold; margin: 0; padding: 0; overflow: hidden; } 
-div { white-space: nowrap; display: block; padding: 0; margin: 0; overflow: hidden; } 
+div { #f9f9f9-space: nowrap; display: block; padding: 0; margin: 0; overflow: hidden; } 
 .Wrapper { clear: both; box-sizing: border-box; } 
 .Box { float: left; margin: 0; padding: 0; position: relative; display: block; } 
 
@@ -27,7 +27,7 @@ div.AnimatedPanel.AnimationDelay { transition: transform 1s ease-in-out .3s; }
 .TeamBox:not(.Lineups.UseLT) { width: 23em; }
 
 /* indicator */
-.TeamBox .Indicator { width: 4%; height: 100%; font-size: 45%; float: left; text-align: center; background: #333; color: white; } 
+.TeamBox .Indicator { width: 4%; height: 100%; font-size: 45%; float: left; text-align: center; background: #333; color: #f9f9f9; } 
 .TeamBox .Indicator { width: 1.6em; height: 1.3em; text-align: center; font-size: 75%; }
 .TeamBox [Team="1"] .Indicator { border-radius: 8px 0 0 0; } 
 .TeamBox [Team="2"] .Indicator { border-radius: 0 0 0 8px; } 
@@ -60,7 +60,7 @@ div.AnimatedPanel.AnimationDelay { transition: transform 1s ease-in-out .3s; }
 
 /* lineup area */
 .TeamBox .JammerWrapper { overflow: hidden; } 
-.TeamBox .JammerBox { padding-right: 20px; width: calc(100% - 20px); height: 50%; background: #333; color: white; text-align: right; font-size: 50%; border-radius: 0 8px 8px 0; } 
+.TeamBox .JammerBox { padding-right: 20px; width: calc(100% - 20px); height: 50%; background: #333; color: #f9f9f9; text-align: right; font-size: 50%; border-radius: 0 8px 8px 0; } 
 .TeamBox.Lineups.UseLT .JammerBox { display: flex; } 
 
 .JammerBox, .JammerBox.Show { margin-left: -100%; } 
@@ -103,7 +103,7 @@ div.AnimatedPanel.AnimationDelay { transition: transform 1s ease-in-out .3s; }
 
 .ClockBarMiddle.SlideDown { background: #888; padding: 0; } 
 .ClockBarMiddle.SlideDown.Show { max-height: 1.2em; } 
-.ClockBox .ClockDescription { width: 100%; color: white; font-size: 1em; text-align: center; text-transform: uppercase; width: 100%; } 
+.ClockBox .ClockDescription { width: 100%; color: #f9f9f9; font-size: 1em; text-align: center; text-transform: uppercase; width: 100%; } 
 .ClockBox .ClockDescription.Show { padding: 2px 0; } 
 
 .ClockBarBottom { font-size: 1.7em; } 
@@ -146,12 +146,12 @@ div.AnimatedPanel.AnimationDelay { transition: transform 1s ease-in-out .3s; }
 .AnimatedPanel.Show:not(.Upcoming) img { height: 164px; } 
 
 .OverlayPanel h1,
-.OverlayPanel h2 { background: #666; display: block; padding: 10px; color: white; } 
+.OverlayPanel h2 { background: #666; display: block; padding: 10px; color: #f9f9f9; } 
 
-.OverlayPanel h1 { font-size: 1.8em; line-height: 2em; border-radius: 10px 10px 0 0; text-transform: uppercase; text-align: center; background: #000; color: white; margin-bottom: 0; } 
-.OverlayPanel h2 { font-size: 1.4em; line-height: 1.6em; border-radius: 0 0 10px 10px; text-transform: uppercase; text-align: center; background: #333; color: white; margin-top: 0; } 
+.OverlayPanel h1 { font-size: 1.8em; line-height: 2em; border-radius: 10px 10px 0 0; text-transform: uppercase; text-align: center; background: #000; color: #f9f9f9; margin-bottom: 0; } 
+.OverlayPanel h2 { font-size: 1.4em; line-height: 1.6em; border-radius: 0 0 10px 10px; text-transform: uppercase; text-align: center; background: #333; color: #f9f9f9; margin-top: 0; } 
 
-.OverlayPanel h4 { background: #333; color: white; border-radius: 0 10px 0 0; margin: 0; padding: 2%; font-size: 2em; } 
+.OverlayPanel h4 { background: #333; color: #f9f9f9; border-radius: 0 10px 0 0; margin: 0; padding: 2%; font-size: 2em; } 
 .OverlayPanel h5 { background: #ddd; color: #333; border-radius: 0 0 10px 0; margin: 0; padding: 2%; font-size: 1.2em; } 
 
 .OverlayPanel h4.htop { border-radius: 0; } 
@@ -199,7 +199,7 @@ div.AnimatedPanel.AnimationDelay { transition: transform 1s ease-in-out .3s; }
 .RosterTeam .Team .Skater .Number,
 .RosterTeam .Team .Skater .Flags,
 .RosterTeam .Team .Skater .Name { min-height: 1.7em; max-height: 1.7em; float: left; overflow: hidden; } 
-.RosterTeam .Team .Skater .Number { width: 15%; background: #ccc; background: #888; color: white; text-align: center; } 
+.RosterTeam .Team .Skater .Number { width: 15%; background: #ccc; background: #888; color: #f9f9f9; text-align: center; } 
 .RosterTeam .Team .Skater .Name { width: 72%; } 
 .RosterTeam .Team .Skater .Flags { width: 8%; float: left; vertical-align: middle; text-align: center; border-radius: 5px; color: #888; } 
 .RosterTeam .Team .Skater .Flags[data-flag="C"]:after { content: 'C'; visibility: visible; } 
@@ -221,7 +221,7 @@ div.AnimatedPanel.AnimationDelay { transition: transform 1s ease-in-out .3s; }
 .PenaltyTeam .Team .Number { float: left; width: 7%; padding-left: 2em; padding-right: 1em; color: #333; min-height: 100%; text-align: right; } 
 .PenaltyTeam .Team .Name { float: left; width: 24%; color: #333; } 
 .PenaltyTeam .Team .Penalty { float: left; width: 8%; } 
-.PenaltyTeam .Skater .Penalty { display: block; padding: 0px 2px; background: #333; color: white; width: 2em; border-radius: 8px; text-align: center; margin-right: 10px; } 
+.PenaltyTeam .Skater .Penalty { display: block; padding: 0px 2px; background: #333; color: #f9f9f9; width: 2em; border-radius: 8px; text-align: center; margin-right: 10px; } 
 .PenaltyTeam .Skater[warn="1"] .Penalty { background: darkorange; } 
 .PenaltyTeam .Skater[warn="2"] .Penalty { background: orange; } 
 .PenaltyTeam .Skater[warn="3"] .Penalty { background: red; } 
@@ -234,4 +234,4 @@ div.AnimatedPanel.AnimationDelay { transition: transform 1s ease-in-out .3s; }
 /* Upcoming */
 .Upcoming { padding-top: 4em; } 
 .Upcoming h1 { border-radius: 1em; } 
-.Upcoming .UpcomingVS { padding: 1em; margin: 0 auto; width: 4em; background: white; color: red; font-size: 1em; border-radius: 1em; text-align: center; } 
+.Upcoming .UpcomingVS { padding: 1em; margin: 0 auto; width: 4em; background: #f9f9f9; color: red; font-size: 1em; border-radius: 1em; text-align: center; } 


### PR DESCRIPTION
i'm using a hardware video switcher. in order to be able to use luma key instead of chroma key to remove the background, the purely white elements need to be slightly less white. otherwise all white elements will be interpreted as transparent and potentially illegible on stream. this is a great improvement in comparison with using chroma key, since it allows teams that use colors containing green. the visual difference is negligable.