### PR TITLE
Fix issue #938.  Handle spaces in install path.

### DIFF
--- a/scoreboard-mac.command
+++ b/scoreboard-mac.command
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-cd "$(dirname $0)"
+loc="$(dirname "${0}")"
+cd "${loc}" || exit 1
+
 
 GUI="--gui"
 
@@ -13,4 +15,4 @@ if [ -x /usr/libexec/java_home ]; then
   JAVA="/usr/libexec/java_home -exec java"
 fi
 
-exec $JAVA -Done-jar.silent=true -Dorg.eclipse.jetty.server.LEVEL=WARN -jar lib/crg-scoreboard.jar "$GUI" "$@"
+exec $JAVA -Done-jar.silent=true -Dorg.eclipse.jetty.server.LEVEL=WARN -jar "${loc}/lib/crg-scoreboard.jar" ${GUI} "$@"

--- a/scoreboard-mac.command
+++ b/scoreboard-mac.command
@@ -15,4 +15,4 @@ if [ -x /usr/libexec/java_home ]; then
   JAVA="/usr/libexec/java_home -exec java"
 fi
 
-exec $JAVA -Done-jar.silent=true -Dorg.eclipse.jetty.server.LEVEL=WARN -jar "${loc}/lib/crg-scoreboard.jar" ${GUI} "$@"
+exec $JAVA -Done-jar.silent=true -Dorg.eclipse.jetty.server.LEVEL=WARN -jar lib/crg-scoreboard.jar ${GUI} "$@"

--- a/scoreboard.sh
+++ b/scoreboard.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-cd "$(dirname $0)"
+loc="$(dirname "${0}")"
+cd "${loc}" || exit 1
+
 
 GUI="--gui"
 
@@ -13,4 +15,4 @@ if [ -x /usr/libexec/java_home ]; then
   JAVA="/usr/libexec/java_home -exec java"
 fi
 
-exec $JAVA -Done-jar.silent=true -Dorg.eclipse.jetty.server.LEVEL=WARN -jar lib/crg-scoreboard.jar "$GUI" "$@"
+exec $JAVA -Done-jar.silent=true -Dorg.eclipse.jetty.server.LEVEL=WARN -jar "${loc}/lib/crg-scoreboard.jar" ${GUI} "$@"

--- a/scoreboard.sh
+++ b/scoreboard.sh
@@ -15,4 +15,4 @@ if [ -x /usr/libexec/java_home ]; then
   JAVA="/usr/libexec/java_home -exec java"
 fi
 
-exec $JAVA -Done-jar.silent=true -Dorg.eclipse.jetty.server.LEVEL=WARN -jar "${loc}/lib/crg-scoreboard.jar" ${GUI} "$@"
+exec $JAVA -Done-jar.silent=true -Dorg.eclipse.jetty.server.LEVEL=WARN -jar lib/crg-scoreboard.jar ${GUI} "$@"


### PR DESCRIPTION
The quoting of the output from dirname was incorrect.  If there were any spaces in the path to scoreboard.sh/scoreboard-mac.command, the script wouldn't set it's working directory correctly and would fail to find the .jar file.

In addition, the ${GUI} was quoted, even when empty and could result in an empty parameter being passed into the java program.